### PR TITLE
WIP: Digger spawn, physics, and terrain

### DIFF
--- a/extensions/urho3d/safe_classes.lua
+++ b/extensions/urho3d/safe_classes.lua
@@ -321,6 +321,7 @@ function M.define(dst, util)
 			lightType = util.simple_property("number"),
 			brightness = util.simple_property("number"),
 			castShadows = util.simple_property("boolean"),
+			shadowIntensity = util.simple_property("number"),
 			shadowBias = util.simple_property("BiasParameters"),
 			shadowCascade = util.simple_property("CascadeParameters"),
 			color = util.simple_property("Color"),

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -173,8 +173,31 @@ do
 	--]]
 end
 
+-- Volume data can exist before Bullet boxes. Require a solid voxel under
+-- the feet and a RigidBody on that chunk (set_voxel_physics_boxes).
+local function floor_has_collision()
+	local p = player_node:GetWorldPosition()
+	local floor = magic.Vector3(p.x, p.y - PLAYER_HEIGHT / 2 - 0.25, p.z)
+	local v = voxelworld.get_static_voxel(floor)
+	if v.id < 2 then
+		return false
+	end
+	local chunk_p = voxelworld.get_chunk_position(floor)
+	if not chunk_p then
+		return false
+	end
+	local node = voxelworld.get_static_node(chunk_p)
+	if not node then
+		return false
+	end
+	return node:GetComponent("RigidBody") ~= nil
+end
+
 local function enable_physics()
 	if physics_enabled or not spawn_received then
+		return
+	end
+	if not floor_has_collision() then
 		return
 	end
 	local body = player_node:GetComponent("RigidBody")
@@ -417,14 +440,7 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 		log:info("p="..camera_node:GetRotation():PitchAngle())]]
 
 		local body = player_node:GetComponent("RigidBody")
-		local moving = magic.input:GetKeyDown(magic.KEY_W) or
-				magic.input:GetKeyDown(magic.KEY_S) or
-				magic.input:GetKeyDown(magic.KEY_A) or
-				magic.input:GetKeyDown(magic.KEY_D) or
-				magic.input:GetKeyDown(magic.KEY_SPACE)
-		if moving then
-			enable_physics()
-		end
+		enable_physics()
 
 		do 
 			local wanted_v = magic.Vector3(0, 0, 0) -- re. world

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -174,7 +174,7 @@ do
 end
 
 local function enable_physics()
-	if physics_enabled then
+	if physics_enabled or not spawn_received then
 		return
 	end
 	local body = player_node:GetComponent("RigidBody")
@@ -226,6 +226,7 @@ end
 local title_text = magic.ui.root:CreateChild("Text")
 local misc_text = magic.ui.root:CreateChild("Text")
 local worldgen_text = magic.ui.root:CreateChild("Text")
+local wait_text = magic.ui.root:CreateChild("Text")
 do
 	title_text:SetText("digger/init.lua")
 	title_text:SetFont(magic.cache:GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15)
@@ -239,14 +240,34 @@ do
 	misc_text.verticalAlignment = magic.VA_CENTER
 	misc_text:SetPosition(0, -magic.ui.root.height/2 + 40)
 
-	worldgen_text:SetText("Waiting for terrain")
+	worldgen_text:SetText("")
 	worldgen_text:SetFont(magic.cache:GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15)
-	--[[worldgen_text.horizontalAlignment = magic.HA_LEFT
-	worldgen_text.verticalAlignment = magic.VA_TOP
-	worldgen_text:SetPosition(0, 0)--]]
 	worldgen_text.horizontalAlignment = magic.HA_CENTER
 	worldgen_text.verticalAlignment = magic.VA_CENTER
 	worldgen_text:SetPosition(0, -magic.ui.root.height/2 + 60)
+
+	wait_text:SetText("Generating terrain...")
+	wait_text:SetFont(magic.cache:GetResource("Font", "Fonts/Anonymous Pro.ttf"), 24)
+	wait_text.horizontalAlignment = magic.HA_CENTER
+	wait_text.verticalAlignment = magic.VA_CENTER
+	wait_text:SetPosition(0, 0)
+end
+
+local function set_generating_status(queue_size)
+	if spawn_received then
+		wait_text:SetText("")
+		if queue_size and queue_size > 0 then
+			worldgen_text:SetText("Worldgen queue size: "..queue_size)
+		else
+			worldgen_text:SetText("")
+		end
+		return
+	end
+	if queue_size and queue_size > 0 then
+		wait_text:SetText("Generating terrain... ("..queue_size.." sections left)")
+	else
+		wait_text:SetText("Generating terrain...")
+	end
 end
 
 -- Unfocus UI
@@ -523,21 +544,11 @@ buildat.sub_packet("main:spawn", function(data)
 	end
 	spawn_received = true
 	enable_physics()
+	set_generating_status(0)
 end)
 
 buildat.sub_packet("main:worldgen_queue_size", function(data)
-	local queue_size = tonumber(data)
-	if not spawn_received then
-		if queue_size > 0 then
-			worldgen_text:SetText("Waiting for terrain ("..queue_size..")")
-		else
-			worldgen_text:SetText("Waiting for terrain")
-		end
-	elseif queue_size > 0 then
-		worldgen_text:SetText("Worldgen queue size: "..queue_size)
-	else
-		worldgen_text:SetText("")
-	end
+	set_generating_status(tonumber(data))
 end)
 
 -- vim: set noet ts=4 sw=4:

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -95,9 +95,9 @@ do
 	local zone_node = scene:CreateChild("Zone")
 	local zone = zone_node:CreateComponent("Zone")
 	zone.boundingBox = magic.BoundingBox(-1000, 1000)
-	zone.ambientColor = magic.Color(0.1, 0.1, 0.1)
+	zone.ambientColor = magic.Color(0.42, 0.48, 0.60)
 	--zone.ambientColor = magic.Color(0, 0, 0)
-	zone.fogColor = magic.Color(0.6, 0.7, 0.8)
+	zone.fogColor = magic.Color(0.68, 0.76, 0.85)
 	--zone.fogColor = magic.Color(0, 0, 0)
 	zone.fogStart = 10
 	zone.fogEnd = FOG_END
@@ -131,18 +131,8 @@ do
 	local light = node:CreateComponent("Light")
 	light.lightType = magic.LIGHT_DIRECTIONAL
 	light.castShadows = true
-	light.brightness = 0.8
+	light.brightness = 1.2
 	light.color = magic.Color(1.0, 1.0, 0.95)
-
-	---[[
-	local node = scene:CreateChild("DirectionalLight")
-	node.direction = magic.Vector3(0.3, -1.0, -0.4)
-	local light = node:CreateComponent("Light")
-	light.lightType = magic.LIGHT_DIRECTIONAL
-	light.castShadows = true
-	light.brightness = 0.2
-	light.color = magic.Color(0.7, 0.7, 1.0)
-	--]]
 
 	--[[
 	local node = scene:CreateChild("DirectionalLight")

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -29,6 +29,8 @@ local scene = replicate.main_scene
 
 local player_touches_ground = false
 local player_crouched = false
+local physics_enabled = false
+local spawn_received = false
 
 local pointed_voxel_p = nil
 local pointed_voxel_p_above = nil
@@ -162,7 +164,6 @@ do
 	player_node.direction = magic.Vector3(-1, 0, 0.4)
 	---[[
 	local body = player_node:CreateComponent("RigidBody")
-	--body.mass = 70.0
 	body.friction = 0
 	--body.linearVelocity = magic.Vector3(0, -10, 0)
 	body.angularFactor = magic.Vector3(0, 0, 0)
@@ -170,6 +171,19 @@ do
 	--player_shape:SetBox(magic.Vector3(1, 1.7*PLAYER_SCALE, 1))
 	player_shape:SetCapsule(PLAYER_WIDTH, PLAYER_HEIGHT)
 	--]]
+end
+
+local function enable_physics()
+	if physics_enabled then
+		return
+	end
+	local body = player_node:GetComponent("RigidBody")
+	if not body then
+		return
+	end
+	body.mass = PLAYER_MASS
+	physics_enabled = true
+	log:info("player physics enabled")
 end
 
 -- Add a camera so we can look at the scene
@@ -225,7 +239,7 @@ do
 	misc_text.verticalAlignment = magic.VA_CENTER
 	misc_text:SetPosition(0, -magic.ui.root.height/2 + 40)
 
-	worldgen_text:SetText("")
+	worldgen_text:SetText("Waiting for terrain")
 	worldgen_text:SetFont(magic.cache:GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15)
 	--[[worldgen_text.horizontalAlignment = magic.HA_LEFT
 	worldgen_text.verticalAlignment = magic.VA_TOP
@@ -370,6 +384,14 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 		log:info("p="..camera_node:GetRotation():PitchAngle())]]
 
 		local body = player_node:GetComponent("RigidBody")
+		local moving = magic.input:GetKeyDown(magic.KEY_W) or
+				magic.input:GetKeyDown(magic.KEY_S) or
+				magic.input:GetKeyDown(magic.KEY_A) or
+				magic.input:GetKeyDown(magic.KEY_D) or
+				magic.input:GetKeyDown(magic.KEY_SPACE)
+		if moving then
+			enable_physics()
+		end
 
 		do 
 			local wanted_v = magic.Vector3(0, 0, 0) -- re. world
@@ -421,16 +443,7 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 			end
 		end
 		if magic.input:GetKeyDown(magic.KEY_SHIFT) then
-			--local bv = body.linearVelocity
-			--bv.y = -MOVE_SPEED
-			--body.linearVelocity = bv
-
-			-- Delay setting this to here so that it's possible to wait for the
-			-- world to load first
-			if body.mass == 0 then
-				body.mass = PLAYER_MASS
-			end
-
+			enable_physics()
 			if not player_crouched then
 				player_shape:SetCapsule(PLAYER_WIDTH, PLAYER_HEIGHT/2)
 				camera_node.position = magic.Vector3(0, 0.411*PLAYER_HEIGHT/2, 0)
@@ -508,11 +521,19 @@ buildat.sub_packet("main:spawn", function(data)
 	if body then
 		body.linearVelocity = magic.Vector3(0, 0, 0)
 	end
+	spawn_received = true
+	enable_physics()
 end)
 
 buildat.sub_packet("main:worldgen_queue_size", function(data)
 	local queue_size = tonumber(data)
-	if queue_size > 0 then
+	if not spawn_received then
+		if queue_size > 0 then
+			worldgen_text:SetText("Waiting for terrain ("..queue_size..")")
+		else
+			worldgen_text:SetText("Waiting for terrain")
+		end
+	elseif queue_size > 0 then
 		worldgen_text:SetText("Worldgen queue size: "..queue_size)
 	else
 		worldgen_text:SetText("")

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -251,6 +251,18 @@ do
 	wait_text.horizontalAlignment = magic.HA_CENTER
 	wait_text.verticalAlignment = magic.VA_CENTER
 	wait_text:SetPosition(0, 0)
+
+	local function crosshair_bar(w, h)
+		local bar = magic.ui.root:CreateChild("BorderImage")
+		bar.width = w
+		bar.height = h
+		bar.horizontalAlignment = magic.HA_CENTER
+		bar.verticalAlignment = magic.VA_CENTER
+		bar:SetPosition(0, 0)
+		bar.color = magic.Color(1, 1, 1)
+	end
+	crosshair_bar(15, 1)
+	crosshair_bar(1, 15)
 end
 
 local function set_generating_status(queue_size)

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -157,9 +157,8 @@ end
 local player_node = scene:CreateChild("Player")
 local player_shape = player_node:CreateComponent("CollisionShape")
 do
-	--player_node.position = magic.Vector3(0, 30, 0)
-	--player_node.position = magic.Vector3(55, 30, 40)
-	player_node.position = magic.Vector3(-5, 1, 257)
+	-- Placeholder until main:spawn arrives with terrain height at this x,z
+	player_node.position = magic.Vector3(-5, 80, 257)
 	player_node.direction = magic.Vector3(-1, 0, 0.4)
 	---[[
 	local body = player_node:CreateComponent("RigidBody")
@@ -495,6 +494,20 @@ voxelworld.sub_ready(function()
 		end
 		local name = node:GetName()
 	end)
+end)
+
+buildat.sub_packet("main:spawn", function(data)
+	local v = cereal.binary_input(data, {"object",
+		{"x", "double"},
+		{"y", "double"},
+		{"z", "double"},
+	})
+	log:info("spawn ("..v.x..", "..v.y..", "..v.z..")")
+	player_node.position = magic.Vector3(v.x, v.y, v.z)
+	local body = player_node:GetComponent("RigidBody")
+	if body then
+		body.linearVelocity = magic.Vector3(0, 0, 0)
+	end
 end)
 
 buildat.sub_packet("main:worldgen_queue_size", function(data)

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -231,20 +231,20 @@ do
 	title_text:SetText("digger/init.lua")
 	title_text:SetFont(magic.cache:GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15)
 	title_text.horizontalAlignment = magic.HA_CENTER
-	title_text.verticalAlignment = magic.VA_CENTER
-	title_text:SetPosition(0, -magic.ui.root.height/2 + 20)
+	title_text.verticalAlignment = magic.VA_TOP
+	title_text:SetPosition(0, 20)
 
 	misc_text:SetText("")
 	misc_text:SetFont(magic.cache:GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15)
 	misc_text.horizontalAlignment = magic.HA_CENTER
-	misc_text.verticalAlignment = magic.VA_CENTER
-	misc_text:SetPosition(0, -magic.ui.root.height/2 + 40)
+	misc_text.verticalAlignment = magic.VA_TOP
+	misc_text:SetPosition(0, 40)
 
 	worldgen_text:SetText("")
 	worldgen_text:SetFont(magic.cache:GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15)
 	worldgen_text.horizontalAlignment = magic.HA_CENTER
-	worldgen_text.verticalAlignment = magic.VA_CENTER
-	worldgen_text:SetPosition(0, -magic.ui.root.height/2 + 60)
+	worldgen_text.verticalAlignment = magic.VA_TOP
+	worldgen_text:SetPosition(0, 60)
 
 	wait_text:SetText("Generating terrain...")
 	wait_text:SetFont(magic.cache:GetResource("Font", "Fonts/Anonymous Pro.ttf"), 24)

--- a/games/digger/main/main.cpp
+++ b/games/digger/main/main.cpp
@@ -486,6 +486,35 @@ struct Module: public interface::Module
 		}
 	}
 
+	// Standing-height air along -X (player facing). No path check; long enough
+	// that it is likely to hit a slope, pocket, or the world edge.
+	void carve_spawn_tunnel(int floor_y)
+	{
+		const int length = 96;
+		const int height = 3;
+		const int half_w = 1;
+		const int back = 2;
+		voxelworld::access(m_server, m_main_scene,
+				[&](voxelworld::Instance *world)
+		{
+			for(int dx = -back; dx < length; dx++){
+				int x = SPAWN_X - dx;
+				for(int dz = -half_w; dz <= half_w; dz++){
+					int z = SPAWN_Z + dz;
+					for(int dy = 1; dy <= height; dy++){
+						world->set_voxel(
+								pv::Vector3DInt32(x, floor_y + dy, z),
+								VoxelInstance(1), true);
+					}
+				}
+			}
+		});
+		log_i(MODULE, "Spawn tunnel: x=%i..%i y=%i..%i z=%i..%i",
+				SPAWN_X + back, SPAWN_X - (length - 1),
+				floor_y + 1, floor_y + height,
+				SPAWN_Z - half_w, SPAWN_Z + half_w);
+	}
+
 	void send_spawn(network::PeerInfo::Id peer)
 	{
 		if(!m_spawn_ready)
@@ -534,6 +563,7 @@ struct Module: public interface::Module
 					SPAWN_X, SPAWN_Z);
 			return;
 		}
+		carve_spawn_tunnel(surface_y);
 		// Voxel n is a 1x1x1 cube centered at n; stand on its top face.
 		m_spawn_y = (float)surface_y + 0.5f + PLAYER_HEIGHT / 2.0f + 0.05f;
 		m_spawn_ready = true;

--- a/games/digger/main/main.cpp
+++ b/games/digger/main/main.cpp
@@ -83,7 +83,7 @@ struct Worldgen: public worldgen::GeneratorInterface
 					uc.getX(), uc.getY(), uc.getZ());
 
 			interface::v3f spread(160, 160, 160);
-			interface::NoiseParams np(0, 40, spread, 0, 7, 0.55);
+			interface::NoiseParams np(0, 20, spread, 0, 7, 0.4);
 
 			int w = uc.getX() - lc.getX() + 1;
 			int d = uc.getZ() - lc.getZ() + 1;

--- a/games/digger/main/main.cpp
+++ b/games/digger/main/main.cpp
@@ -26,6 +26,7 @@
 #include <cereal/archives/portable_binary.hpp>
 #include <cereal/types/unordered_map.hpp>
 #include <cereal/types/vector.hpp>
+#include <sstream>
 #define MODULE "main"
 
 namespace magic = Urho3D;
@@ -179,6 +180,15 @@ struct Module: public interface::Module
 	interface::Server *m_server;
 
 	SceneReference m_main_scene;
+
+	static const int SPAWN_X = -5;
+	static const int SPAWN_Z = 257;
+	static const int SPAWN_Y_MAX = 127;
+	static const int SPAWN_Y_MIN = -64;
+	static constexpr float PLAYER_HEIGHT = 1.7f;
+
+	bool m_spawn_ready = false;
+	float m_spawn_y = 0;
 
 	Module(interface::Server *server):
 		interface::Module(MODULE),
@@ -476,6 +486,73 @@ struct Module: public interface::Module
 		}
 	}
 
+	void send_spawn(network::PeerInfo::Id peer)
+	{
+		if(!m_spawn_ready)
+			return;
+		std::ostringstream os(std::ios::binary);
+		cereal::PortableBinaryOutputArchive ar(os);
+		double x = SPAWN_X;
+		double y = m_spawn_y;
+		double z = SPAWN_Z;
+		ar(x, y, z);
+		network::access(m_server, [&](network::Interface *inetwork){
+			inetwork->send(peer, "main:spawn", os.str());
+		});
+		log_v(MODULE, "Sent spawn (%.2f, %.2f, %.2f) to peer %zu",
+				x, y, z, peer);
+	}
+
+	// Terrain ids: 2 rock, 3 dirt, 4 grass. Skip air (1), trees/leaves (5, 6).
+	void try_resolve_spawn()
+	{
+		if(m_spawn_ready)
+			return;
+		int surface_y = SPAWN_Y_MIN - 1;
+		bool column_ready = true;
+		voxelworld::access(m_server, m_main_scene,
+				[&](voxelworld::Instance *world)
+		{
+			for(int y = SPAWN_Y_MAX; y >= SPAWN_Y_MIN; y--){
+				VoxelInstance v = world->get_voxel(
+						pv::Vector3DInt32(SPAWN_X, y, SPAWN_Z), true);
+				auto id = v.get_id();
+				if(id == interface::VOXELTYPEID_UNDEFINED){
+					column_ready = false;
+					return;
+				}
+				if(id == 2 || id == 3 || id == 4){
+					surface_y = y;
+					return;
+				}
+			}
+		});
+		if(!column_ready)
+			return;
+		if(surface_y < SPAWN_Y_MIN){
+			log_w(MODULE, "Spawn column (%i, *, %i) has no terrain",
+					SPAWN_X, SPAWN_Z);
+			return;
+		}
+		// Voxel n is a 1x1x1 cube centered at n; stand on its top face.
+		m_spawn_y = (float)surface_y + 0.5f + PLAYER_HEIGHT / 2.0f + 0.05f;
+		m_spawn_ready = true;
+		log_i(MODULE, "Spawn at (%i, %.2f, %i) (terrain y=%i)",
+				SPAWN_X, m_spawn_y, SPAWN_Z, surface_y);
+
+		network::access(m_server, [&](network::Interface *inetwork){
+			std::ostringstream os(std::ios::binary);
+			cereal::PortableBinaryOutputArchive ar(os);
+			double x = SPAWN_X;
+			double y = m_spawn_y;
+			double z = SPAWN_Z;
+			ar(x, y, z);
+			ss_ data = os.str();
+			for(auto peer : inetwork->list_peers())
+				inetwork->send(peer, "main:spawn", data);
+		});
+	}
+
 	void on_files_transmitted(const client_file::FilesTransmitted &event)
 	{
 		replicate::access(m_server, [&](replicate::Interface *ireplicate){
@@ -485,6 +562,7 @@ struct Module: public interface::Module
 			inetwork->send(event.recipient, "core:run_script",
 					"buildat.run_script_file(\"main/init.lua\")");
 		});
+		send_spawn(event.recipient);
 	}
 
 	void on_place_voxel(const network::Packet &packet)
@@ -533,6 +611,8 @@ struct Module: public interface::Module
 						itos(event.queue_size));
 			}
 		});
+		if(event.queue_size == 0)
+			try_resolve_spawn();
 	}
 };
 

--- a/games/digger/main/main.cpp
+++ b/games/digger/main/main.cpp
@@ -588,9 +588,17 @@ struct Module: public interface::Module
 		replicate::access(m_server, [&](replicate::Interface *ireplicate){
 			ireplicate->assign_scene_to_peer(m_main_scene, event.recipient);
 		});
+		size_t queue_size = 0;
+		worldgen::access(m_server, m_main_scene,
+				[&](worldgen::Instance *instance)
+		{
+			queue_size = instance->get_num_sections_queued();
+		});
 		network::access(m_server, [&](network::Interface *inetwork){
 			inetwork->send(event.recipient, "core:run_script",
 					"buildat.run_script_file(\"main/init.lua\")");
+			inetwork->send(event.recipient, "main:worldgen_queue_size",
+					itos(queue_size));
 		});
 		send_spawn(event.recipient);
 	}


### PR DESCRIPTION
WIP. More digger changes will land on this branch.

Spawn, movement, HUD, and lighting so the minigame is playable after connecting.

## Spawn
- Server waits until the worldgen queue is empty, scans column `(-5, *, 257)` for the top rock/dirt/grass voxel, and sends `main:spawn`. Client holds the player in the air until that packet.
- After surface Y is known, carve a 3×3×96 air tunnel along −X (player facing). No path check.
- Connecting before worldgen finishes still works. Centered `Generating terrain...` overlay (with queue size when known) until spawn.

## Physics
- Player rigidbody mass stays 0 until spawn. Shift is only crouch.
- After spawn, mass stays 0 until the voxel under the feet is solid and that chunk has a `RigidBody` (client physics boxes, not just volume data). Avoids falling into hills on reconnect.

## Terrain
- Heightmap: scale 40→20, persist 0.55→0.4.

## HUD
- Title, coordinates, and worldgen queue pinned with `VA_TOP` so they stay at the top edge on resize.
- 15px white crosshair at screen center (camera ray used for dig/place).

## Lighting
- Sun brightness 0.8→1.2. Outdoor ambient 0.1→0.42,0.48,0.60 (blue-ish shade). Extra directional fill removed.
- Caves still pick up some of that ambient; lighting model is later work.
- Lua: `Light.shadowIntensity` exposed, unused by digger for now.