### PR TITLE
Drop the minecraftlike tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-Buildat - A minecraftlike with vast extendability.
-==================================================
+Buildat
+=======
+A small engine for networked 3D games.
 
-Buildat doesn't actually even implement a minecraftlike by default. It just
-provides a lot of useful machinery for doing just that, with immense modding
-capabilities.
+The server runs C++ modules compiled at runtime. The client runs a
+whitelisted subset of Urho3D's Lua API in a sandbox; scripts and data
+come from the server.
 
-It wraps a safe subset of Urho3D's Lua API in a whitelisting Lua sandbox on
-the client side and runs runtime-compiled C++ modules on the server side.
-
-Go ahead and write some modules and extensions, maybe the minecraftlike will
-exist in the near future!
+Voxel worlds, replication, and worldgen are builtin modules. Nothing
+requires a block game. Digger is one example.
 
 Further reading:
 

--- a/doc/design.txt
+++ b/doc/design.txt
@@ -1,6 +1,6 @@
 Buildat
 =======
-A minecraftlike with vast extendability.
+A small engine for networked 3D games.
 
 License: Apache 2.0
 


### PR DESCRIPTION
Keep the name Buildat. Stop calling it a minecraftlike.

The interesting part for developers is the split: runtime-compiled C++ modules on the server, a sandboxed Urho3D Lua client that gets its scripts from the server. Voxelworld is a builtin, not the product.

README and `doc/design.txt` now use: **a small engine for networked 3D games.**

GitHub repo description is still `The minecraftlike that isn't a minecraftlike.` Change it on merge to something like:

`A small engine for networked 3D games. Runtime-compiled C++ server, sandboxed Lua client.`