### PR TITLE
Add buildat launcher for local play and connect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,9 @@ if(BUILD_CLIENT)
 	#		${LUA_LIBRARY}
 	#	)
 	#endif()
+
+	add_executable(buildat src/launcher/main.cpp)
+	add_dependencies(buildat ${CLIENT_EXE_NAME})
 endif(BUILD_CLIENT)
 
 #
@@ -343,7 +346,7 @@ if(WIN32)
 	install(FILES "${COMPILER_USR_PATH}/bin/libstdc++-6.dll" DESTINATION "${DST_BIN}")
 
 	if(BUILD_CLIENT)
-		install(TARGETS ${CLIENT_EXE_NAME} DESTINATION "${DST_BIN}")
+		install(TARGETS ${CLIENT_EXE_NAME} buildat DESTINATION "${DST_BIN}")
 		install(DIRECTORY "${CMAKE_SOURCE_DIR}/client" DESTINATION "${DST_SHARE}")
 		install(DIRECTORY "${CMAKE_SOURCE_DIR}/extensions" DESTINATION "${DST_SHARE}")
 	endif()

--- a/README.md
+++ b/README.md
@@ -45,8 +45,17 @@ server or the client, respectively.
 Optional: `-DURHO3D_LUAJIT=TRUE` builds the bundled LuaJIT instead of Lua.
 `URHO3D_HOME` still overrides the bundled tree if you need an external build.
 
-Run Buildat
--------------
+Play
+----
+
+    $ $wherever_buildat_is/Build/bin/buildat
+
+Local game or connect to a server.
+
+Server and client
+-----------------
+
+For development or hosting, run the two binaries separately:
 
 Terminal 1:
 

--- a/client/api.lua
+++ b/client/api.lua
@@ -4,6 +4,11 @@
 local log = buildat.Logger("__client/api")
 
 buildat.connect_server    = __buildat_connect_server
+buildat.list_games        = __buildat_list_games
+buildat.start_local_server = __buildat_start_local_server
+buildat.stop_local_server = __buildat_stop_local_server
+buildat.local_server_ready = __buildat_local_server_ready
+buildat.local_server_running = __buildat_local_server_running
 buildat.extension_path    = __buildat_extension_path
 buildat.get_time_us       = __buildat_get_time_us
 buildat.SpatialUpdateQueue = __buildat_SpatialUpdateQueue

--- a/extensions/launch_menu/init.lua
+++ b/extensions/launch_menu/init.lua
@@ -1,0 +1,236 @@
+-- Buildat: extension/launch_menu/init.lua
+-- http://www.apache.org/licenses/LICENSE-2.0
+-- Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+local log = buildat.Logger("extension/launch_menu")
+local magic = require("buildat/extension/urho3d").safe
+local uistack = require("buildat/extension/uistack")
+local ui_utils = require("buildat/extension/ui_utils").safe
+local M = {safe = nil}
+
+local function show_error(message)
+	ui_utils.show_message_dialog(message)
+end
+
+local function make_button(parent, label)
+	local button = parent:CreateChild("Button")
+	button:SetStyleAuto()
+	button:SetName("Button")
+	button:SetLayout(LM_VERTICAL, 10, magic.IntRect(0, 0, 0, 0))
+	button.minHeight = 24
+	local text = button:CreateChild("Text")
+	text:SetName("ButtonText")
+	text:SetStyleAuto()
+	text.text = label
+	text:SetTextAlignment(HA_CENTER)
+	return button
+end
+
+local function make_labeled_edit(parent, label, value, width)
+	local text = parent:CreateChild("Text")
+	text:SetStyleAuto()
+	text.text = label
+	local edit = parent:CreateChild("LineEdit")
+	edit:SetStyleAuto()
+	edit.minHeight = 24
+	edit.minWidth = width or 300
+	edit:SetText(value)
+	return edit
+end
+
+local function connect_or_show_error(address)
+	local ok, err = buildat.connect_server(address)
+	if ok then
+		log:info("connect_server() ok")
+		uistack.main:push({desc="empty (game is running)"})
+		magic.ui:SetFocusElement(nil)
+	else
+		log:info("connect_server() failed")
+		show_error(err)
+	end
+end
+
+local function show_connect_to_server()
+	buildat.stop_local_server()
+	local root = uistack.main:push({desc="connect_to_server"})
+
+	local style = magic.cache:GetResource("XMLFile", "__menu/res/main_style.xml")
+	root.defaultStyle = style
+
+	local window = root:CreateChild("Window")
+	window:SetStyleAuto()
+	window:SetLayout(LM_VERTICAL, 10, magic.IntRect(10, 10, 10, 10))
+	window:SetAlignment(HA_LEFT, VA_CENTER)
+
+	local address_edit = make_labeled_edit(window, "Address", "localhost")
+	local port_edit = make_labeled_edit(window, "Port (optional)", "20000")
+	address_edit:SetFocus(true)
+
+	local function do_connect()
+		local host = address_edit:GetText()
+		local port = port_edit:GetText()
+		if host == "" then
+			show_error("Enter a server address")
+			return
+		end
+		local address = host
+		if port ~= "" then
+			address = host..":"..port
+		end
+		connect_or_show_error(address)
+	end
+
+	local connect_button = make_button(window, "Connect")
+	magic.SubscribeToEvent(connect_button, "Released",
+	function(self, event_type, event_data)
+		do_connect()
+	end)
+	magic.SubscribeToEvent(address_edit, "TextFinished",
+	function(self, event_type, event_data)
+		do_connect()
+	end)
+	magic.SubscribeToEvent(port_edit, "TextFinished",
+	function(self, event_type, event_data)
+		do_connect()
+	end)
+
+	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
+		local key = event_data:GetInt("Key")
+		if key == KEY_ESC then
+			uistack.main:pop(root)
+		end
+	end)
+end
+
+local function show_starting(game)
+	local root = uistack.main:push({desc="starting_local_server"})
+
+	local style = magic.cache:GetResource("XMLFile", "__menu/res/main_style.xml")
+	root.defaultStyle = style
+
+	local window = root:CreateChild("Window")
+	window:SetStyleAuto()
+	window:SetLayout(LM_VERTICAL, 10, magic.IntRect(10, 10, 10, 10))
+	window:SetAlignment(HA_LEFT, VA_CENTER)
+
+	local status = window:CreateChild("Text")
+	status:SetStyleAuto()
+	status.text = "Starting "..game.."..."
+
+	local t0 = buildat.get_time_us()
+	local done = false
+	root:SubscribeToStackEvent("Update", function(event_type, event_data)
+		if done then
+			return
+		end
+		if buildat.local_server_ready() then
+			done = true
+			connect_or_show_error("localhost")
+			return
+		end
+		if not buildat.local_server_running() then
+			done = true
+			show_error("Server exited")
+			uistack.main:pop(root)
+			return
+		end
+		if buildat.get_time_us() - t0 > 90 * 1000000 then
+			done = true
+			buildat.stop_local_server()
+			show_error("Server did not start")
+			uistack.main:pop(root)
+		end
+	end)
+
+	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
+		local key = event_data:GetInt("Key")
+		if key == KEY_ESC then
+			done = true
+			buildat.stop_local_server()
+			uistack.main:pop(root)
+		end
+	end)
+end
+
+local function start_local_game(game)
+	local ok, err = buildat.start_local_server(game)
+	if not ok then
+		show_error(err)
+		return
+	end
+	show_starting(game)
+end
+
+local function show_local_game()
+	local root = uistack.main:push({desc="local_game"})
+
+	local style = magic.cache:GetResource("XMLFile", "__menu/res/main_style.xml")
+	root.defaultStyle = style
+
+	local window = root:CreateChild("Window")
+	window:SetStyleAuto()
+	window:SetLayout(LM_VERTICAL, 10, magic.IntRect(10, 10, 10, 10))
+	window:SetAlignment(HA_LEFT, VA_CENTER)
+
+	local title = window:CreateChild("Text")
+	title:SetStyleAuto()
+	title.text = "Local game"
+
+	local games = buildat.list_games()
+	if #games == 0 then
+		local empty = window:CreateChild("Text")
+		empty:SetStyleAuto()
+		empty.text = "No games found"
+	else
+		for _, name in ipairs(games) do
+			local button = make_button(window, name)
+			magic.SubscribeToEvent(button, "Released",
+			function(self, event_type, event_data)
+				start_local_game(name)
+			end)
+		end
+	end
+
+	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
+		local key = event_data:GetInt("Key")
+		if key == KEY_ESC then
+			uistack.main:pop(root)
+		end
+	end)
+end
+
+function M.boot()
+	local root = uistack.main:push("boot")
+
+	local style = magic.cache:GetResource("XMLFile", "__menu/res/main_style.xml")
+	root.defaultStyle = style
+
+	local window = root:CreateChild("Window")
+	window:SetStyleAuto()
+	window:SetLayout(LM_VERTICAL, 10, magic.IntRect(10, 10, 10, 10))
+	window:SetAlignment(HA_LEFT, VA_CENTER)
+
+	local local_button = make_button(window, "Local game")
+	magic.SubscribeToEvent(local_button, "Released",
+	function(self, event_type, event_data)
+		show_local_game()
+	end)
+
+	local connect_button = make_button(window, "Connect to server")
+	magic.SubscribeToEvent(connect_button, "Released",
+	function(self, event_type, event_data)
+		show_connect_to_server()
+	end)
+
+	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
+		local key = event_data:GetInt("Key")
+		if key == KEY_ESC then
+			engine:Exit()
+		end
+		if key == KEY_RETURN then
+			show_local_game()
+		end
+	end)
+end
+
+return M
+-- vim: set noet ts=4 sw=4:

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -8,8 +8,13 @@
 #include "lua_bindings/util.h"
 #include "lua_bindings/replicate.h"
 #include "interface/fs.h"
+#include "interface/os.h"
+#include "interface/process.h"
+#include "interface/tcpsocket.h"
 #include "interface/voxel.h"
 #include "interface/thread_pool.h"
+#include <cctype>
+#include <algorithm>
 #include <c55/getopt.h>
 #include <c55/os.h>
 #include <Application.h>
@@ -44,6 +49,35 @@ namespace magic = Urho3D;
 
 extern client::Config g_client_config;
 extern bool g_sigint_received;
+
+static bool valid_game_name(const ss_ &name)
+{
+	if(name.empty() || name.size() > 64)
+		return false;
+	for(char c : name){
+		if(!(isalnum((unsigned char)c) || c == '_' || c == '-'))
+			return false;
+	}
+	return true;
+}
+
+// Survives CApp reboot so disconnect can kill the server we started.
+static interface::process::Handle g_local_server;
+
+static void stop_local_server()
+{
+	if(!g_local_server.valid())
+		return;
+	log_i(MODULE, "Stopping local server");
+	interface::process::terminate(g_local_server);
+	for(int i = 0; i < 200; i++){
+		if(!interface::process::is_running(g_local_server) &&
+				!interface::probe_connect("127.0.0.1", "20000"))
+			return;
+		interface::os::sleep_us(50000);
+	}
+	log_w(MODULE, "Local server did not release port 20000");
+}
 
 namespace app {
 
@@ -190,6 +224,7 @@ struct CApp: public App, public magic::Application
 
 	~CApp()
 	{
+		stop_local_server();
 	}
 
 	void set_state(sp_<client::State> state)
@@ -337,6 +372,11 @@ struct CApp: public App, public magic::Application
 
 		DEF_BUILDAT_FUNC(connect_server)
 		DEF_BUILDAT_FUNC(disconnect)
+		DEF_BUILDAT_FUNC(list_games)
+		DEF_BUILDAT_FUNC(start_local_server)
+		DEF_BUILDAT_FUNC(stop_local_server)
+		DEF_BUILDAT_FUNC(local_server_ready)
+		DEF_BUILDAT_FUNC(local_server_running)
 		DEF_BUILDAT_FUNC(send_packet);
 		DEF_BUILDAT_FUNC(get_file_path)
 		DEF_BUILDAT_FUNC(get_file_content)
@@ -508,12 +548,99 @@ struct CApp: public App, public magic::Application
 		return 2;
 	}
 
+	// list_games() -> {name, ...}
+	static int l_list_games(lua_State *L)
+	{
+		ss_ games_dir = g_client_config.get<ss_>("share_path")+"/games";
+		auto nodes = interface::fs::list_directory(games_dir);
+		sv_<ss_> names;
+		for(const auto &n : nodes){
+			if(!n.is_directory || !valid_game_name(n.name))
+				continue;
+			names.push_back(n.name);
+		}
+		std::sort(names.begin(), names.end());
+		lua_newtable(L);
+		int i = 1;
+		for(const ss_ &name : names){
+			lua_pushstring(L, name.c_str());
+			lua_rawseti(L, -2, i++);
+		}
+		return 1;
+	}
+
+	// start_local_server(game: string) -> status: bool, error: string or nil
+	static int l_start_local_server(lua_State *L)
+	{
+		ss_ game = lua_bindings::lua_tocppstring(L, 1);
+		if(!valid_game_name(game)){
+			lua_pushboolean(L, false);
+			lua_pushstring(L, "Invalid game name");
+			return 2;
+		}
+
+		ss_ game_path = g_client_config.get<ss_>("share_path")+"/games/"+game;
+		if(!interface::fs::path_exists(game_path)){
+			lua_pushboolean(L, false);
+			lua_pushstring(L, "Game not found");
+			return 2;
+		}
+
+		stop_local_server();
+
+		ss_ server_path = interface::os::get_sibling_exe_path("buildat_server");
+		if(!interface::fs::path_exists(server_path)){
+			lua_pushboolean(L, false);
+			lua_pushstring(L, "buildat_server not found");
+			return 2;
+		}
+
+		game_path = interface::fs::get_absolute_path(game_path);
+		g_local_server = interface::process::start(
+				server_path, {"-m", game_path});
+		if(!g_local_server.valid()){
+			lua_pushboolean(L, false);
+			lua_pushstring(L, "Failed to start server");
+			return 2;
+		}
+		lua_pushboolean(L, true);
+		lua_pushnil(L);
+		return 2;
+	}
+
+	// stop_local_server()
+	static int l_stop_local_server(lua_State *L)
+	{
+		stop_local_server();
+		return 0;
+	}
+
+	// local_server_ready() -> bool
+	static int l_local_server_ready(lua_State *L)
+	{
+		if(!interface::process::is_running(g_local_server)){
+			lua_pushboolean(L, false);
+			return 1;
+		}
+		lua_pushboolean(L, interface::probe_connect("127.0.0.1", "20000"));
+		return 1;
+	}
+
+	// local_server_running() -> bool
+	static int l_local_server_running(lua_State *L)
+	{
+		lua_pushboolean(L, interface::process::is_running(g_local_server));
+		return 1;
+	}
+
 	// disconnect()
 	static int l_disconnect(lua_State *L)
 	{
 		lua_getfield(L, LUA_REGISTRYINDEX, "__buildat_app");
 		CApp *self = (CApp*)lua_touserdata(L, -1);
 		lua_pop(L, 1);
+
+		stop_local_server();
 
 		if(g_client_config.get<bool>("boot_to_menu")){
 			// If menu, reboot client into menu

--- a/src/impl/linux/os.cpp
+++ b/src/impl/linux/os.cpp
@@ -30,6 +30,11 @@ ss_ get_current_exe_path()
 	return buf;
 }
 
+ss_ get_sibling_exe_path(const ss_ &name)
+{
+	return interface::fs::strip_file_name(get_current_exe_path())+"/"+name;
+}
+
 }
 }
 // vim: set noet ts=4 sw=4:

--- a/src/impl/linux/process.cpp
+++ b/src/impl/linux/process.cpp
@@ -2,6 +2,10 @@
 #include "core/log.h"
 #include <unistd.h>
 #include <sys/wait.h>
+#include <signal.h>
+#include <errno.h>
+#include <cstring>
+#include <vector>
 #define MODULE "__process"
 
 namespace interface {
@@ -23,6 +27,68 @@ int shell_exec(const ss_ &command, const ExecOptions &opts)
 	int exit_status;
 	while(wait(&exit_status) > 0);
 	return exit_status;
+}
+
+bool Handle::valid() const
+{
+	return impl > 0;
+}
+
+Handle start(const ss_ &path, const sv_<ss_> &args)
+{
+	Handle h;
+	pid_t pid = fork();
+	if(pid < 0){
+		log_w(MODULE, "fork failed: %s", strerror(errno));
+		return h;
+	}
+	if(pid == 0){
+		std::vector<char*> argv;
+		argv.push_back(const_cast<char*>(path.c_str()));
+		for(const ss_ &a : args)
+			argv.push_back(const_cast<char*>(a.c_str()));
+		argv.push_back(nullptr);
+		execv(path.c_str(), argv.data());
+		log_w(MODULE, "execv(\"%s\") failed: %s", cs(path), strerror(errno));
+		_exit(127);
+	}
+	h.impl = pid;
+	log_i(MODULE, "Started pid %i: %s", (int)pid, cs(path));
+	return h;
+}
+
+void terminate(Handle &h)
+{
+	if(!h.valid())
+		return;
+	pid_t pid = (pid_t)h.impl;
+	kill(pid, SIGTERM);
+	for(int i = 0; i < 100; i++){
+		int status = 0;
+		pid_t r = waitpid(pid, &status, WNOHANG);
+		if(r == pid || (r < 0 && errno == ECHILD)){
+			h.impl = 0;
+			return;
+		}
+		usleep(50000);
+	}
+	kill(pid, SIGKILL);
+	waitpid(pid, nullptr, 0);
+	h.impl = 0;
+}
+
+bool is_running(const Handle &h)
+{
+	if(!h.valid())
+		return false;
+	pid_t pid = (pid_t)h.impl;
+	if(kill(pid, 0) == 0)
+		return true;
+	if(errno == ESRCH){
+		waitpid(pid, nullptr, WNOHANG);
+		return false;
+	}
+	return true;
 }
 
 }

--- a/src/impl/tcpsocket.cpp
+++ b/src/impl/tcpsocket.cpp
@@ -350,5 +350,31 @@ TCPSocket* createTCPSocket(int fd)
 	return new CTCPSocket(fd);
 }
 
+bool probe_connect(const ss_ &address, const ss_ &port)
+{
+	struct addrinfo hints;
+	struct addrinfo *res0 = NULL;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+	int err = getaddrinfo(address.c_str(), port.c_str(), &hints, &res0);
+	if(err || res0 == NULL)
+		return false;
+	bool ok = false;
+	for(struct addrinfo *res = res0; res != NULL; res = res->ai_next){
+		int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+		if(fd == -1)
+			continue;
+		if(connect(fd, res->ai_addr, res->ai_addrlen) == 0)
+			ok = true;
+		closesocket(fd);
+		if(ok)
+			break;
+	}
+	freeaddrinfo(res0);
+	return ok;
+}
+
 }
 // vim: set noet ts=4 sw=4:

--- a/src/impl/windows/os.cpp
+++ b/src/impl/windows/os.cpp
@@ -1,6 +1,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 // Copyright 2014 Perttu Ahola <celeron55@gmail.com>
 #include "interface/os.h"
+#include "interface/fs.h"
 #include "core/log.h"
 #include <sys/time.h>
 #include "ports/windows_minimal.h"
@@ -55,6 +56,11 @@ ss_ get_current_exe_path()
 		}
 	}
 	throw Exception("get_current_exe_path(): .exe module not found");
+}
+
+ss_ get_sibling_exe_path(const ss_ &name)
+{
+	return interface::fs::strip_file_name(get_current_exe_path())+"/"+name+".exe";
 }
 
 }

--- a/src/impl/windows/process.cpp
+++ b/src/impl/windows/process.cpp
@@ -81,5 +81,65 @@ int shell_exec(const ss_ &command, const ExecOptions &opts)
 	return exit_code;
 }
 
+bool Handle::valid() const
+{
+	return impl != 0;
+}
+
+Handle start(const ss_ &path, const sv_<ss_> &args)
+{
+	Handle h;
+	ss_ cmd = "\"" + path + "\"";
+	for(const ss_ &a : args)
+		cmd += " \"" + a + "\"";
+
+	STARTUPINFO si;
+	PROCESS_INFORMATION pi;
+	memset(&si, 0, sizeof(si));
+	si.cb = sizeof(si);
+	memset(&pi, 0, sizeof(pi));
+
+	char command_c[50000];
+	snprintf(command_c, 50000, "%s", cs(cmd));
+
+	if(!CreateProcess(
+			path.c_str(),
+			command_c,
+			NULL, NULL, false, 0,
+			NULL, NULL, &si, &pi)){
+		log_w(MODULE, "start(\"%s\"): CreateProcess failed: %s",
+				cs(path), cs(format_last_error()));
+		return h;
+	}
+	CloseHandle(pi.hThread);
+	h.impl = (intptr_t)pi.hProcess;
+	log_i(MODULE, "Started process: %s", cs(path));
+	return h;
+}
+
+void terminate(Handle &h)
+{
+	if(!h.valid())
+		return;
+	HANDLE process = (HANDLE)h.impl;
+	TerminateProcess(process, 1);
+	WaitForSingleObject(process, 5000);
+	if(WaitForSingleObject(process, 0) != WAIT_OBJECT_0)
+		TerminateProcess(process, 1);
+	WaitForSingleObject(process, INFINITE);
+	CloseHandle(process);
+	h.impl = 0;
+}
+
+bool is_running(const Handle &h)
+{
+	if(!h.valid())
+		return false;
+	DWORD code = 0;
+	if(!GetExitCodeProcess((HANDLE)h.impl, &code))
+		return false;
+	return code == STILL_ACTIVE;
+}
+
 }
 }

--- a/src/interface/os.h
+++ b/src/interface/os.h
@@ -10,6 +10,8 @@ namespace interface
 		int64_t time_us();
 		void sleep_us(int us);
 		ss_ get_current_exe_path();
+		// name without extension; looks next to the current executable
+		ss_ get_sibling_exe_path(const ss_ &name);
 	}
 }
 

--- a/src/interface/process.h
+++ b/src/interface/process.h
@@ -15,6 +15,16 @@ namespace interface
 
 		int shell_exec(const std::string &command,
 				const ExecOptions &opts = ExecOptions());
+
+		// Long-running child. Does not wait. path is the executable.
+		struct Handle {
+			intptr_t impl = 0;
+			bool valid() const;
+		};
+
+		Handle start(const std::string &path, const sv_<ss_> &args);
+		void terminate(Handle &h);
+		bool is_running(const Handle &h);
 	}
 }
 // vim: set noet ts=4 sw=4:

--- a/src/interface/tcpsocket.h
+++ b/src/interface/tcpsocket.h
@@ -24,6 +24,9 @@ namespace interface
 	};
 
 	TCPSocket* createTCPSocket(int fd = -1);
+
+	// Quiet connect attempt; does not keep the socket.
+	bool probe_connect(const ss_ &address, const ss_ &port);
 }
 
 // vim: set noet ts=4 sw=4:

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -1,0 +1,74 @@
+// http://www.apache.org/licenses/LICENSE-2.0
+// Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+//
+// Exec buildat_client -m launch_menu. Extra argv is forwarded.
+
+#ifdef _WIN32
+	#include <windows.h>
+	#include <process.h>
+	#include <stdio.h>
+	#include <string.h>
+	#include <vector>
+#else
+	#include <unistd.h>
+	#include <stdio.h>
+	#include <string.h>
+	#include <limits.h>
+	#include <vector>
+#endif
+
+static void client_path(char *out, size_t out_size)
+{
+#ifdef _WIN32
+	char path[MAX_PATH];
+	DWORD n = GetModuleFileNameA(NULL, path, MAX_PATH);
+	if(n == 0 || n >= MAX_PATH){
+		snprintf(out, out_size, "buildat_client.exe");
+		return;
+	}
+	char *slash = strrchr(path, '\\');
+	if(!slash)
+		slash = strrchr(path, '/');
+	if(slash)
+		*(slash + 1) = 0;
+	else
+		path[0] = 0;
+	snprintf(out, out_size, "%sbuildat_client.exe", path);
+#else
+	char path[PATH_MAX];
+	memset(path, 0, sizeof(path));
+	if(readlink("/proc/self/exe", path, sizeof(path) - 1) < 0){
+		snprintf(out, out_size, "buildat_client");
+		return;
+	}
+	char *slash = strrchr(path, '/');
+	if(slash)
+		*(slash + 1) = 0;
+	else
+		path[0] = 0;
+	snprintf(out, out_size, "%sbuildat_client", path);
+#endif
+}
+
+int main(int argc, char *argv[])
+{
+	char path[8192];
+	client_path(path, sizeof(path));
+
+	std::vector<char*> nargv;
+	nargv.push_back(path);
+	nargv.push_back((char*)"-m");
+	nargv.push_back((char*)"launch_menu");
+	for(int i = 1; i < argc; i++)
+		nargv.push_back(argv[i]);
+	nargv.push_back(nullptr);
+
+#ifdef _WIN32
+	_execv(path, nargv.data());
+#else
+	execv(path, nargv.data());
+#endif
+	fprintf(stderr, "Failed to exec %s -m launch_menu\n", path);
+	return 1;
+}
+// vim: set noet ts=4 sw=4:


### PR DESCRIPTION
`bin/buildat` execs `buildat_client -m launch_menu`. That menu is for non-advanced use: pick a local game or type a server address and optional port.

- Local game lists `games/`, starts `buildat_server -m <game>`, waits until port 20000 accepts, then connects.
- Leaving the game kills that server. The menu is not shown until the process is gone and the port is free.
- `buildat_server` and `buildat_client` are unchanged for development and hosting.

README Play section documents `bin/buildat`.