### PR TITLE
Scale UI from a 1080 short-side reference

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -13,9 +13,13 @@ buildat.local_server_ready = __buildat_local_server_ready
 buildat.local_server_running = __buildat_local_server_running
 buildat.extension_path    = __buildat_extension_path
 buildat.get_time_us       = __buildat_get_time_us
+buildat.set_ui_scale      = __buildat_set_ui_scale
+buildat.get_ui_scale      = __buildat_get_ui_scale
 buildat.SpatialUpdateQueue = __buildat_SpatialUpdateQueue
 
 buildat.safe.disconnect    = __buildat_disconnect
+buildat.safe.set_ui_scale  = __buildat_set_ui_scale
+buildat.safe.get_ui_scale  = __buildat_get_ui_scale
 buildat.safe.get_time_us   = __buildat_get_time_us
 buildat.safe.profiler_block_begin = __buildat_profiler_block_begin
 buildat.safe.profiler_block_end   = __buildat_profiler_block_end

--- a/extensions/urho3d/safe_classes.lua
+++ b/extensions/urho3d/safe_classes.lua
@@ -829,10 +829,28 @@ function M.define(dst, util)
 					end
 				end
 			),
+			SetScale = util.wrap_function({"UI", "number"},
+				function(self, scale)
+					__buildat_set_ui_scale(scale)
+				end),
+			GetScale = util.self_function(
+					"GetScale", {"number"}, {"UI"}),
 		},
 		properties = {
 			root = util.simple_property(dst.UIElement),
 			focusElement = util.simple_property({dst.UIElement, "__nil"}),
+			scale = {
+				get = function(current_value)
+					return current_value
+				end,
+				set = function(new_value)
+					if type(new_value) ~= "number" then
+						error("UI.scale must be a number")
+					end
+					__buildat_set_ui_scale(new_value)
+					return new_value
+				end,
+			},
 		},
 	})
 

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -39,6 +39,7 @@
 #include <PhysicsWorld.h>
 #include <DebugRenderer.h>
 #include <Profiler.h>
+#include <UI.h>
 extern "C" {
 #include <lua.h>
 #include <lauxlib.h>
@@ -52,6 +53,9 @@ extern "C" {
 #endif
 #define MODULE "__app"
 namespace magic = Urho3D;
+
+// Auto UI scale: min(window w,h) / this. Lua/config/CLI overrides replace it.
+static const float UI_REF_SHORT = 1080.f;
 
 extern client::Config g_client_config;
 extern bool g_sigint_received;
@@ -231,6 +235,7 @@ struct CApp: public App, public magic::Application
 	magic::LuaScript *m_script;
 	lua_State *L;
 	bool m_reboot_requested = false;
+	float m_ui_scale_lua = 0.f; // 0 = not set by Lua
 	Options m_options;
 	bool m_draw_debug_geometry = false;
 	int64_t m_last_update_us;
@@ -445,9 +450,37 @@ struct CApp: public App, public magic::Application
 
 	// Non-public methods
 
+	void apply_ui_scale()
+	{
+		magic::Graphics *g = GetSubsystem<magic::Graphics>();
+		magic::UI *ui = GetSubsystem<magic::UI>();
+		if(!g || !ui)
+			return;
+		float s = 0.f;
+		if(m_ui_scale_lua > 0.f)
+			s = m_ui_scale_lua;
+		else {
+			double cfg = g_client_config.get<double>("ui_scale");
+			if(cfg > 0)
+				s = (float)cfg;
+			else {
+				int short_side = g->GetWidth();
+				if(g->GetHeight() < short_side)
+					short_side = g->GetHeight();
+				s = (float)short_side / UI_REF_SHORT;
+				if(s < 0.01f)
+					s = 0.01f;
+			}
+		}
+		ui->SetScale(s);
+		log_i(MODULE, "UI scale %g (%ix%i)", s, g->GetWidth(), g->GetHeight());
+	}
+
 	void Start()
 	{
 		log_v(MODULE, "Start()");
+
+		apply_ui_scale();
 
 		// Restore window to previous position
 		if(m_options.graphics.window_x != GraphicsOptions::UNDEFINED_INT &&
@@ -490,6 +523,8 @@ struct CApp: public App, public magic::Application
 		DEF_BUILDAT_FUNC(get_file_content)
 		DEF_BUILDAT_FUNC(get_path)
 		DEF_BUILDAT_FUNC(extension_path)
+		DEF_BUILDAT_FUNC(set_ui_scale)
+		DEF_BUILDAT_FUNC(get_ui_scale)
 
 		// Create a scene that will be synchronized from the server
 		m_scene = new magic::Scene(context_);
@@ -616,6 +651,7 @@ struct CApp: public App, public magic::Application
 			log_v(MODULE, "Window size in graphics options updated: %ix%i",
 					m_options.graphics.window_w, m_options.graphics.window_h);
 		}
+		apply_ui_scale();
 	}
 
 	void on_logmessage(magic::StringHash event_type, magic::VariantMap &event_data)
@@ -729,6 +765,29 @@ struct CApp: public App, public magic::Application
 	{
 		stop_local_server();
 		return 0;
+	}
+
+	// set_ui_scale(scale: number)  -- <=0 restores auto/config
+	static int l_set_ui_scale(lua_State *L)
+	{
+		lua_getfield(L, LUA_REGISTRYINDEX, "__buildat_app");
+		CApp *self = (CApp*)lua_touserdata(L, -1);
+		lua_pop(L, 1);
+		double s = lua_tonumber(L, 1);
+		self->m_ui_scale_lua = (s > 0) ? (float)s : 0.f;
+		self->apply_ui_scale();
+		return 0;
+	}
+
+	// get_ui_scale() -> number
+	static int l_get_ui_scale(lua_State *L)
+	{
+		lua_getfield(L, LUA_REGISTRYINDEX, "__buildat_app");
+		CApp *self = (CApp*)lua_touserdata(L, -1);
+		lua_pop(L, 1);
+		magic::UI *ui = self->GetSubsystem<magic::UI>();
+		lua_pushnumber(L, ui ? ui->GetScale() : 1.0);
+		return 1;
 	}
 
 	// request_stop_local_server()

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -56,6 +56,10 @@ namespace magic = Urho3D;
 
 // Auto UI scale: min(window w,h) / this. Lua/config/CLI overrides replace it.
 static const float UI_REF_SHORT = 1080.f;
+// Snap to 1x, 2x, ... when close, so 1px lines stay on-pixel.
+// Under: maximized window chrome (taskbar, title). Over: 16:10 like 1200p.
+static const float UI_SNAP_UNDER = 0.08f;
+static const float UI_SNAP_OVER = 0.12f;
 
 extern client::Config g_client_config;
 extern bool g_sigint_received;
@@ -470,6 +474,13 @@ struct CApp: public App, public magic::Application
 				s = (float)short_side / UI_REF_SHORT;
 				if(s < 0.01f)
 					s = 0.01f;
+				else {
+					int n = (int)(s + 0.5f);
+					if(n >= 1 &&
+							s >= (float)n * (1.f - UI_SNAP_UNDER) &&
+							s <= (float)n * (1.f + UI_SNAP_OVER))
+						s = (float)n;
+				}
 			}
 		}
 		ui->SetScale(s);

--- a/src/client/config.cpp
+++ b/src/client/config.cpp
@@ -19,6 +19,7 @@ Config::Config()
 	set_default("server_address", "");
 	set_default("boot_to_menu", false);
 	set_default("menu_extension_name", "__menu");
+	set_default("ui_scale", 0.0); // 0 = auto from short side / 1080
 }
 
 bool Config::check_paths()

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
 
 	client::Config &config = g_client_config;
 
-	const char opts[100] = "hs:P:C:U:l:L:m:";
+	const char opts[100] = "hs:P:C:U:l:L:m:u:";
 	const char usagefmt[1000] =
 			"Usage: %s [OPTION]...\n"
 			"  -h                   Show this help\n"
@@ -52,6 +52,7 @@ int main(int argc, char *argv[])
 			"  -l [level number]    Set maximum log level (0...5)\n"
 			"  -L [log file path]   Append log to a specified file\n"
 			"  -m [name]            Choose menu extension name\n"
+			"  -u [scale]           UI scale (0 = auto from short side / 1080)\n"
 			;
 
 	int c;
@@ -87,6 +88,10 @@ int main(int argc, char *argv[])
 		case 'm':
 			log_i(MODULE, "config.menu_extension_name: %s", c55_optarg);
 			config.set("menu_extension_name", c55_optarg);
+			break;
+		case 'u':
+			log_i(MODULE, "config.ui_scale: %s", c55_optarg);
+			config.set("ui_scale", atof(c55_optarg));
 			break;
 		default:
 			fprintf(stderr, "Invalid command-line argument\n");


### PR DESCRIPTION
Auto UI scale is `min(window w, h) / 1080` via Urho `UI::SetScale`. 1 design unit is 1 device pixel at 1080p and 2 at 4K. Existing UI sizes are left as-is.

When the auto factor is close to 1x, 2x, … it snaps to that integer so 1px lines stay on-pixel: within 8% under (maximized window chrome) or 12% over (16:10 like 1200p). 1440p stays 1.333x.

Overrides, later-wins: auto → config `ui_scale` → CLI `-u` → Lua `buildat.set_ui_scale` / `UI.scale`. Values `<= 0` restore auto (or config if set). Lua and config `> 0` stick across resize; auto is recomputed. Overrides are not snapped.