### PR TITLE
Use KEY_ESCAPE in games and extensions

### DIFF
--- a/extensions/__menu/init.lua
+++ b/extensions/__menu/init.lua
@@ -69,8 +69,8 @@ local function show_connect_to_server()
 
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
-			log:info("KEY_ESC pressed at connect_to_server level")
+		if key == KEY_ESCAPE then
+			log:info("KEY_ESCAPE pressed at connect_to_server level")
 			uistack.main:pop(root)
 		end
 	end)
@@ -135,8 +135,8 @@ function M.boot()
 
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
-			log:info("KEY_ESC pressed at top level")
+		if key == KEY_ESCAPE then
+			log:info("KEY_ESCAPE pressed at top level")
 			engine:Exit()
 		end
 		if key == KEY_RETURN then

--- a/extensions/launch_menu/init.lua
+++ b/extensions/launch_menu/init.lua
@@ -95,7 +95,7 @@ local function show_connect_to_server()
 
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
+		if key == KEY_ESCAPE then
 			uistack.main:pop(root)
 		end
 	end)
@@ -143,7 +143,7 @@ local function show_starting(game)
 
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
+		if key == KEY_ESCAPE then
 			done = true
 			buildat.request_stop_local_server()
 			uistack.main:pop(root)
@@ -204,7 +204,7 @@ local function show_waiting_for_old_server(game)
 
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
+		if key == KEY_ESCAPE then
 			done = true
 			uistack.main:pop(root)
 		end
@@ -252,7 +252,7 @@ local function show_local_game()
 
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
+		if key == KEY_ESCAPE then
 			uistack.main:pop(root)
 		end
 	end)
@@ -293,7 +293,7 @@ function M.boot()
 
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
+		if key == KEY_ESCAPE then
 			engine:Exit()
 		end
 		if key == KEY_RETURN then

--- a/extensions/ui_utils/init.lua
+++ b/extensions/ui_utils/init.lua
@@ -65,8 +65,8 @@ function M.safe.show_message_dialog(message)
 
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
-			log:info("show_message_dialog: KEY_ESC pressed")
+		if key == KEY_ESCAPE then
+			log:info("show_message_dialog: KEY_ESCAPE pressed")
 			uistack.main:pop(root)
 			message_handle = nil
 		end
@@ -126,7 +126,7 @@ function M.safe.show_confirm_dialog(message, on_yes, on_no)
 	end)
 	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
 		local key = event_data:GetInt("Key")
-		if key == KEY_ESC then
+		if key == KEY_ESCAPE then
 			finish(false)
 		end
 	end)

--- a/extensions/urho3d/init.lua
+++ b/extensions/urho3d/init.lua
@@ -118,8 +118,6 @@ for _, name in ipairs(safe_globals) do
 		Safe[name] = v
 	end
 end
--- 1.6 renamed KEY_ESC to KEY_ESCAPE. Keep the old name for existing games.
-Safe.KEY_ESC = Safe.KEY_ESCAPE
 
 local mouse = { hide_wanted = false }
 

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -300,8 +300,8 @@ magic.ui:SetFocusElement(nil)
 
 magic.SubscribeToEvent("KeyDown", function(event_type, event_data)
 	local key = event_data:GetInt("Key")
-	if key == magic.KEY_ESC then
-		log:info("KEY_ESC pressed")
+	if key == magic.KEY_ESCAPE then
+		log:info("KEY_ESCAPE pressed")
 		buildat.disconnect()
 	end
 end)

--- a/games/entitytest/main/client_lua/init.lua
+++ b/games/entitytest/main/client_lua/init.lua
@@ -32,8 +32,8 @@ magic.ui:SetFocusElement(nil)
 
 function handle_keydown(event_type, event_data)
 	local key = event_data:GetInt("Key")
-	if key == magic.KEY_ESC then
-		log:info("KEY_ESC pressed")
+	if key == magic.KEY_ESCAPE then
+		log:info("KEY_ESCAPE pressed")
 		buildat.disconnect()
 	end
 end

--- a/games/geometry/main/client_lua/init.lua
+++ b/games/geometry/main/client_lua/init.lua
@@ -32,8 +32,8 @@ magic.ui:SetFocusElement(nil)
 
 function handle_keydown(event_type, event_data)
 	local key = event_data:GetInt("Key")
-	if key == magic.KEY_ESC then
-		log:info("KEY_ESC pressed")
+	if key == magic.KEY_ESCAPE then
+		log:info("KEY_ESCAPE pressed")
 		buildat.disconnect()
 	end
 end

--- a/games/geometry2/main/client_lua/init.lua
+++ b/games/geometry2/main/client_lua/init.lua
@@ -32,8 +32,8 @@ magic.ui:SetFocusElement(nil)
 
 function handle_keydown(event_type, event_data)
 	local key = event_data:GetInt("Key")
-	if key == magic.KEY_ESC then
-		log:info("KEY_ESC pressed")
+	if key == magic.KEY_ESCAPE then
+		log:info("KEY_ESCAPE pressed")
 		buildat.disconnect()
 	end
 end

--- a/games/minigame/main/client_lua/init.lua
+++ b/games/minigame/main/client_lua/init.lua
@@ -201,8 +201,8 @@ end)
 
 function handle_keydown(event_type, event_data)
 	local key = event_data:GetInt("Key")
-	if key == magic.KEY_ESC then
-		log:info("KEY_ESC pressed")
+	if key == magic.KEY_ESCAPE then
+		log:info("KEY_ESCAPE pressed")
 		buildat.disconnect()
 	end
 

--- a/games/test/test1/client_lua/init.lua
+++ b/games/test/test1/client_lua/init.lua
@@ -194,8 +194,8 @@ magic.SubscribeToEvent("Update", "handle_update")
 
 function handle_keydown(event_type, event_data)
 	local key = event_data:GetInt("Key")
-	if key == magic.KEY_ESC then
-		log:info("KEY_ESC pressed")
+	if key == magic.KEY_ESCAPE then
+		log:info("KEY_ESCAPE pressed")
 		buildat.disconnect()
 	end
 end

--- a/games/uitest/main/client_lua/init.lua
+++ b/games/uitest/main/client_lua/init.lua
@@ -29,8 +29,8 @@ show_stuff()
 
 function handle_keydown(event_type, event_data)
 	local key = event_data:GetInt("Key")
-	if key == magic.KEY_ESC then
-		log:info("KEY_ESC pressed")
+	if key == magic.KEY_ESCAPE then
+		log:info("KEY_ESCAPE pressed")
 		buildat.disconnect()
 	end
 end


### PR DESCRIPTION
Urho 1.6 renamed `KEY_ESC` to `KEY_ESCAPE`. Games and extensions now use the new name. The sandbox alias is gone.

Escape on the launcher boot screen exits. On a submenu it pops back.