### PR TITLE
digger: jump from contact height, not collision normal

### DIFF
--- a/extensions/urho3d/safe_classes.lua
+++ b/extensions/urho3d/safe_classes.lua
@@ -434,6 +434,7 @@ function M.define(dst, util)
 			angularFactor = util.simple_property(dst.Vector3),
 			kinematic = util.simple_property("boolean"),
 			linearVelocity = util.simple_property(dst.Vector3),
+			collisionEventMode = util.simple_property("number"),
 		},
 	})
 

--- a/extensions/urho3d/safe_events.lua
+++ b/extensions/urho3d/safe_events.lua
@@ -67,6 +67,9 @@ return {
 		Scene = {variant = "Ptr", safe = "Scene"},
 		Node = {variant = "Ptr", safe = "Node"},
 	},
+	PhysicsPreStep = {
+		TimeStep = {variant = "Float", safe = "number"},
+	},
 	PhysicsCollision = {
 		NodeA = {variant = "Ptr", safe = "Node"},
 		NodeB = {variant = "Ptr", safe = "Node"},

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -158,6 +158,9 @@ do
 	--body.linearVelocity = magic.Vector3(0, -10, 0)
 	body.angularFactor = magic.Vector3(0, 0, 0)
 	body.gravityOverride = magic.Vector3(0, -15.0, 0) -- A bit more than normally
+	-- Default COLLISION_ACTIVE drops events when the body sleeps, so jump
+	-- would fail while standing still.
+	body.collisionEventMode = magic.COLLISION_ALWAYS
 	--player_shape:SetBox(magic.Vector3(1, 1.7*PLAYER_SCALE, 1))
 	player_shape:SetCapsule(PLAYER_WIDTH, PLAYER_HEIGHT)
 	--]]
@@ -501,7 +504,12 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 		misc_text:SetText("("..math.floor(p.x + 0.5)..", "..
 				math.floor(p.y + 0.5)..", "..math.floor(p.z + 0.5)..")")
 	end
+end)
 
+-- PhysicsCollision is only sent on a Bullet step. Update can run on
+-- interpolation frames with no step; keep the last step's grounded flag
+-- until the next PreStep instead of clearing it every Update.
+magic.SubscribeToEvent("PhysicsPreStep", function(event_type, event_data)
 	player_touches_ground = false
 end)
 
@@ -512,13 +520,15 @@ magic.SubscribeToEvent("PhysicsCollision", function(event_type, event_data)
 	local contacts = event_data:GetBuffer("Contacts")
 	if node_a:GetID() == player_node:GetID() or
 			node_b:GetID() == player_node:GetID() then
+		-- PhysicsCollision normals are NodeA's view and flip with pointer
+		-- order. Contact height does not: feet are below the capsule center.
+		local player_y = player_node:GetWorldPosition().y
 		while not contacts.eof do
 			local position = contacts:ReadVector3()
 			local normal = contacts:ReadVector3()
 			local distance = contacts:ReadFloat()
 			local impulse = contacts:ReadFloat()
-			--log:info("normal: ("..normal.x..", "..normal.y..", "..normal.z..")")
-			if normal.y < 0.5 then
+			if position.y < player_y then
 				player_touches_ground = true
 			end
 		end


### PR DESCRIPTION
Digger jump used `PhysicsCollision` contact normals. Those normals are NodeA's view and A/B are sorted by rigid-body pointer, so a Y threshold only matched some tiles. `Update` also cleared the grounded flag every frame, including interpolation frames that have no Bullet step.

Ground is now a contact below the capsule center. The flag is cleared in `PhysicsPreStep` instead of `Update`. The player body uses `COLLISION_ALWAYS` so sleeping still reports contacts.

`PhysicsPreStep` and `RigidBody.collisionEventMode` are whitelisted for the Lua sandbox.