### PR TITLE
Add client -c command sequence for screenshots and input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ if(BUILD_CLIENT)
 		src/client/state.cpp
 		src/client/app.cpp
 		src/client/config.cpp
+		src/client/command_seq.cpp
 		src/lua_bindings/util.cpp
 		src/lua_bindings/init.cpp
 		src/lua_bindings/misc.cpp

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Further reading:
 * [doc/design.txt](doc/design.txt)
 * [doc/conventions.txt](doc/conventions.txt)
 * [doc/client_api.txt](doc/client_api.txt)
+* [doc/client_commands.txt](doc/client_commands.txt)
 * [doc/todo.txt](doc/todo.txt)
 
 Buildat Linux How-To
@@ -68,6 +69,17 @@ Terminal 2:
 
     $ $wherever_buildat_is/Build
     $ bin/buildat_client -s localhost
+
+Client command sequence (CI / visual checks)
+--------------------------------------------
+
+The client can run a one-shot command script and exit. Screenshots, delays,
+and injected keyboard/mouse input:
+
+    $ bin/buildat_client -c $'delay 2000\nscreenshot /tmp/menu.png'
+    $ bin/buildat_client -c @commands.txt
+
+See [doc/client_commands.txt](doc/client_commands.txt).
 
 Modify something and see stuff happen
 ---------------------------------------

--- a/doc/client_commands.txt
+++ b/doc/client_commands.txt
@@ -1,0 +1,88 @@
+Client command sequence
+=======================
+The client can run a one-shot list of commands and then exit. Intended for
+CI, visual checks of UI/rendering changes, and checking that an input action
+actually registers.
+
+Pass the sequence with -c. One command per line. When -c is given, the client
+exits after the sequence finishes (exit status 1 if a command fails).
+
+    $ bin/buildat_client -c $'delay 2000\nscreenshot /tmp/menu.png'
+    $ bin/buildat_client -c @commands.txt
+    $ bin/buildat_client -s localhost -c @commands.txt
+
+@path reads the commands from a file. Empty lines and lines starting with # are
+ignored.
+
+delay is wall-clock milliseconds of game time continuing to run. Use it to wait
+for startup, network, or for a held key to have an effect. Input is queued as
+SDL events at the start of the frame (before Urho3D Input::Update). Screenshots
+are taken after the current frame has been rendered (3D + UI), before buffer
+swap.
+
+The OS mouse is never captured or grabbed in -c mode, even if the game calls
+SetMouseVisible(false). Use mouse_move for look (GetMouseMove); that is
+relative and does not use a cursor position. mouse_pos is for a visible UI
+cursor.
+
+The window is raised when the sequence starts. Injected keys go through
+Urho3D's Input path (GetKeyDown / GetKeyPress). Under Xvfb that is normally
+fine.
+
+Commands
+--------
+delay <ms>
+    Wait this many milliseconds before the next command. Game keeps running.
+
+screenshot <path>
+    Write a PNG of the current framebuffer. Parent directories are created.
+    Path may be relative to the working directory.
+
+keydown <key>
+keyup <key>
+    Hold or release a key. Key names are SDL names: W, Space, Return, Escape,
+    Left Shift, F1, Left, ... Aliases: enter, esc, shift, ctrl, alt.
+
+keypress <key>
+    Key down and up in the same frame. Use for taps (UI, GetKeyPress). Use
+    keydown / delay / keyup to hold a key across frames (movement).
+
+mouse_pos <x> <y>
+    Move the visible cursor to window pixel coordinates (backbuffer). For UI.
+
+mouse_move <dx> <dy>
+    Relative motion in pixels (GetMouseMove). Use this to look around. Does
+    not move the OS cursor.
+
+mouse_down <button>
+mouse_up <button>
+mouse_click <button>
+    Buttons: left, middle, right (or 1, 2, 3). click is down+up same frame.
+
+mouse_wheel <delta>
+    Wheel ticks. Positive is away from the user.
+
+text <string>
+    SDL text input (UI text fields). Rest of the line is the string.
+
+quit
+    Stop the sequence early. The client always exits at the end of -c anyway.
+
+Example
+-------
+Wait for the launcher, screenshot it, click a point, wait, screenshot again:
+
+    delay 2000
+    screenshot /tmp/buildat_menu.png
+    mouse_pos 400 300
+    mouse_click left
+    delay 1000
+    screenshot /tmp/buildat_after_click.png
+
+Hold W for half a second while connected to a local server:
+
+    delay 3000
+    keydown W
+    delay 500
+    keyup W
+    screenshot /tmp/buildat_moved.png

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -4,6 +4,7 @@
 #include "core/log.h"
 #include "client/config.h"
 #include "client/state.h"
+#include "client/command_seq.h"
 #include "lua_bindings/init.h"
 #include "lua_bindings/util.h"
 #include "lua_bindings/replicate.h"
@@ -266,6 +267,14 @@ struct CApp: public App, public magic::Application
 	bool m_draw_debug_geometry = false;
 	int64_t m_last_update_us;
 
+	sv_<client::command_seq::Command> m_commands;
+	size_t m_command_index = 0;
+	int64_t m_command_wait_until_us = 0;
+	ss_ m_pending_screenshot;
+	bool m_command_seq_active = false;
+	bool m_command_seq_failed = false;
+	bool m_command_seq_extra_frame = false;
+
 	magic::SharedPtr<magic::Scene> m_scene;
 	magic::SharedPtr<magic::Node> m_camera_node;
 
@@ -337,9 +346,12 @@ struct CApp: public App, public magic::Application
 		magic_log->SetTimeStamp(false);
 
 		// Set up event handlers
+		SubscribeToEvent(magic::E_BEGINFRAME, URHO3D_HANDLER(CApp, on_begin_frame));
 		SubscribeToEvent(magic::E_UPDATE, URHO3D_HANDLER(CApp, on_update));
 		SubscribeToEvent(magic::E_POSTRENDERUPDATE,
 				URHO3D_HANDLER(CApp, on_post_render_update));
+		SubscribeToEvent(magic::E_ENDRENDERING,
+				URHO3D_HANDLER(CApp, on_end_rendering));
 		SubscribeToEvent(magic::E_KEYDOWN, URHO3D_HANDLER(CApp, on_keydown));
 		SubscribeToEvent(magic::E_SCREENMODE, URHO3D_HANDLER(CApp, on_screenmode));
 		SubscribeToEvent(magic::E_LOGMESSAGE, URHO3D_HANDLER(CApp, on_logmessage));
@@ -369,7 +381,12 @@ struct CApp: public App, public magic::Application
 
 	int run()
 	{
-		return magic::Application::Run();
+		int r = magic::Application::Run();
+		if(m_command_seq_failed)
+			return 1;
+		if(m_command_seq_active)
+			return 1;
+		return r;
 	}
 
 	void shutdown()
@@ -392,6 +409,8 @@ struct CApp: public App, public magic::Application
 
 	bool reboot_requested()
 	{
+		if(g_client_config.get<bool>("command_seq_enabled"))
+			return false;
 		return m_reboot_requested;
 	}
 
@@ -600,6 +619,154 @@ struct CApp: public App, public magic::Application
 		magic::DebugHud *dhud = GetSubsystem<magic::Engine>()->CreateDebugHud();
 		dhud->SetDefaultStyle(magic_cache->GetResource<magic::XMLFile>(
 				"UI/DefaultStyle.xml"));
+
+		if(g_client_config.get<bool>("command_seq_enabled")){
+			ss_ text = g_client_config.get<ss_>("command_seq");
+			ss_ err;
+			if(!client::command_seq::parse(text, &m_commands, &err))
+				throw AppStartupError("command sequence: "+err);
+			m_command_seq_active = true;
+			client::command_seq::raise_window(GetSubsystem<magic::Graphics>());
+			log_i(MODULE, "Command sequence: %zu commands, will exit when done",
+					m_commands.size());
+		}
+	}
+
+	void command_seq_fail(const ss_ &err)
+	{
+		log_e(MODULE, "Command sequence failed: %s", cs(err));
+		m_command_seq_failed = true;
+		m_command_seq_active = false;
+		shutdown();
+	}
+
+	void command_seq_finish()
+	{
+		if(m_command_seq_failed)
+			return;
+		if(!m_command_seq_extra_frame){
+			m_command_seq_extra_frame = true;
+			return;
+		}
+		log_i(MODULE, "Command sequence complete");
+		m_command_seq_active = false;
+		shutdown();
+	}
+
+	// Game code may SetMouseVisible(false) / grab. Do not actually capture
+	// the OS mouse; injected mouse_move is relative (GetMouseMove) and does
+	// not need a cursor position.
+	void command_seq_keep_mouse_free()
+	{
+		if(!m_command_seq_active)
+			return;
+		magic::Input *input = GetSubsystem<magic::Input>();
+		if(!input)
+			return;
+		if(input->GetMouseMode() == magic::MM_RELATIVE ||
+				input->GetMouseMode() == magic::MM_WRAP)
+			input->SetMouseMode(magic::MM_ABSOLUTE);
+		if(!input->IsMouseVisible())
+			input->SetMouseVisible(true);
+		if(input->IsMouseGrabbed())
+			input->SetMouseGrabbed(false);
+	}
+
+	bool command_seq_exec(const client::command_seq::Command &c)
+	{
+		using client::command_seq::Type;
+		magic::Input *input = GetSubsystem<magic::Input>();
+		magic::Graphics *graphics = GetSubsystem<magic::Graphics>();
+		ss_ err;
+		bool ok = true;
+		switch(c.type){
+		case Type::KeyDown:
+			client::command_seq::raise_window(graphics);
+			ok = client::command_seq::inject_key(input, c.s, true, false, &err);
+			break;
+		case Type::KeyUp:
+			ok = client::command_seq::inject_key(input, c.s, false, false, &err);
+			break;
+		case Type::KeyPress:
+			client::command_seq::raise_window(graphics);
+			ok = client::command_seq::inject_key(input, c.s, true, true, &err);
+			break;
+		case Type::MousePos:
+			client::command_seq::raise_window(graphics);
+			ok = client::command_seq::inject_mouse_pos(input, c.x, c.y, &err);
+			break;
+		case Type::MouseMove:
+			ok = client::command_seq::inject_mouse_move(input, c.x, c.y, &err);
+			break;
+		case Type::MouseDown:
+			client::command_seq::raise_window(graphics);
+			ok = client::command_seq::inject_mouse_button(
+					input, c.x, true, false, &err);
+			break;
+		case Type::MouseUp:
+			ok = client::command_seq::inject_mouse_button(
+					input, c.x, false, false, &err);
+			break;
+		case Type::MouseClick:
+			client::command_seq::raise_window(graphics);
+			ok = client::command_seq::inject_mouse_button(
+					input, c.x, true, true, &err);
+			break;
+		case Type::MouseWheel:
+			ok = client::command_seq::inject_mouse_wheel(input, (int)c.n, &err);
+			break;
+		case Type::Text:
+			ok = client::command_seq::inject_text(input, c.s, &err);
+			break;
+		case Type::Quit:
+		case Type::Delay:
+		case Type::Screenshot:
+			return true;
+		}
+		if(!ok)
+			command_seq_fail(err);
+		return ok;
+	}
+
+	void command_seq_tick()
+	{
+		using client::command_seq::Type;
+		if(!m_command_seq_active)
+			return;
+		if(!m_pending_screenshot.empty())
+			return;
+		int64_t now = get_timeofday_us();
+		if(m_command_wait_until_us > now)
+			return;
+
+		while(m_command_index < m_commands.size()){
+			const client::command_seq::Command &c =
+					m_commands[m_command_index];
+			log_i(MODULE, "command: %s",
+					cs(client::command_seq::dump_command(c)));
+			if(c.type == Type::Delay){
+				m_command_wait_until_us = now + c.n * 1000;
+				m_command_index++;
+				return;
+			}
+			if(c.type == Type::Screenshot){
+				m_pending_screenshot = c.s;
+				m_command_index++;
+				return;
+			}
+			if(c.type == Type::Quit){
+				m_command_index = m_commands.size();
+				break;
+			}
+			if(!command_seq_exec(c))
+				return;
+			m_command_index++;
+		}
+
+		if(m_command_index >= m_commands.size() &&
+				m_pending_screenshot.empty() &&
+				m_command_wait_until_us <= now)
+			command_seq_finish();
 	}
 
 	void on_update(magic::StringHash event_type, magic::VariantMap &event_data)
@@ -627,11 +794,30 @@ struct CApp: public App, public magic::Application
 #endif
 	}
 
+	void on_begin_frame(magic::StringHash event_type, magic::VariantMap &event_data)
+	{
+		command_seq_keep_mouse_free();
+		command_seq_tick();
+	}
+
 	void on_post_render_update(
 			magic::StringHash event_type, magic::VariantMap &event_data)
 	{
 		if(m_draw_debug_geometry)
 			m_scene->GetComponent<magic::PhysicsWorld>()->DrawDebugGeometry(true);
+	}
+
+	void on_end_rendering(
+			magic::StringHash event_type, magic::VariantMap &event_data)
+	{
+		if(m_pending_screenshot.empty())
+			return;
+		ss_ path = m_pending_screenshot;
+		m_pending_screenshot.clear();
+		ss_ err;
+		if(!client::command_seq::save_screenshot(
+				GetSubsystem<magic::Graphics>(), path, &err))
+			command_seq_fail(err);
 	}
 
 	void on_keydown(magic::StringHash event_type, magic::VariantMap &event_data)

--- a/src/client/command_seq.cpp
+++ b/src/client/command_seq.cpp
@@ -1,0 +1,509 @@
+// http://www.apache.org/licenses/LICENSE-2.0
+// Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+#include "client/command_seq.h"
+#include "core/log.h"
+#include "interface/fs.h"
+#include <c55/string_util.h>
+#include <Graphics.h>
+#include <Image.h>
+#include <Input.h>
+#include <FileSystem.h>
+#include <SDL/SDL.h>
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <climits>
+#define MODULE "cmdseq"
+namespace magic = Urho3D;
+
+namespace client {
+namespace command_seq {
+
+static ss_ trim_copy(const ss_ &s)
+{
+	return c55::trim(s);
+}
+
+static bool parse_i64(const ss_ &s, int64_t *out)
+{
+	if(s.empty())
+		return false;
+	errno = 0;
+	char *end = nullptr;
+	long long v = strtoll(s.c_str(), &end, 10);
+	if(errno || end == s.c_str() || *end != '\0')
+		return false;
+	*out = (int64_t)v;
+	return true;
+}
+
+static bool parse_int(const ss_ &s, int *out)
+{
+	int64_t v = 0;
+	if(!parse_i64(s, &v))
+		return false;
+	if(v < (int64_t)INT_MIN || v > (int64_t)INT_MAX)
+		return false;
+	*out = (int)v;
+	return true;
+}
+
+static void split_cmd(const ss_ &line, ss_ *cmd, ss_ *rest)
+{
+	size_t i = 0;
+	while(i < line.size() && (line[i] == ' ' || line[i] == '\t'))
+		i++;
+	size_t j = i;
+	while(j < line.size() && line[j] != ' ' && line[j] != '\t')
+		j++;
+	*cmd = line.substr(i, j - i);
+	size_t k = j;
+	while(k < line.size() && (line[k] == ' ' || line[k] == '\t'))
+		k++;
+	*rest = line.substr(k);
+}
+
+static bool parse_button(const ss_ &s, int *sdl_button, ss_ *error)
+{
+	ss_ t;
+	t.reserve(s.size());
+	for(char c : s)
+		t.push_back((char)tolower((unsigned char)c));
+	if(t == "left" || t == "l" || t == "1" || t == "lmb"){
+		*sdl_button = SDL_BUTTON_LEFT;
+		return true;
+	}
+	if(t == "middle" || t == "m" || t == "2" || t == "mmb"){
+		*sdl_button = SDL_BUTTON_MIDDLE;
+		return true;
+	}
+	if(t == "right" || t == "r" || t == "3" || t == "rmb"){
+		*sdl_button = SDL_BUTTON_RIGHT;
+		return true;
+	}
+	if(t == "x1" || t == "4"){
+		*sdl_button = SDL_BUTTON_X1;
+		return true;
+	}
+	if(t == "x2" || t == "5"){
+		*sdl_button = SDL_BUTTON_X2;
+		return true;
+	}
+	*error = "Unknown mouse button \""+s+"\" (left, middle, right)";
+	return false;
+}
+
+static bool parse_xy(const ss_ &rest, int *x, int *y, ss_ *error)
+{
+	c55::Strfnd f(rest);
+	ss_ xs = trim_copy(f.next(" "));
+	ss_ ys = trim_copy(f.next(""));
+	if(xs.empty() || ys.empty() || !parse_int(xs, x) || !parse_int(ys, y)){
+		*error = "Expected two integers";
+		return false;
+	}
+	return true;
+}
+
+static bool parse_body(const ss_ &text, sv_<Command> *out, ss_ *error)
+{
+	out->clear();
+	int line_no = 0;
+	size_t i = 0;
+	while(i <= text.size()){
+		size_t nl = text.find('\n', i);
+		ss_ line;
+		if(nl == ss_::npos){
+			line = text.substr(i);
+			i = text.size() + 1;
+		} else {
+			line = text.substr(i, nl - i);
+			i = nl + 1;
+		}
+		line_no++;
+		if(!line.empty() && line.back() == '\r')
+			line.pop_back();
+		line = trim_copy(line);
+		if(line.empty() || line[0] == '#')
+			continue;
+
+		ss_ cmd;
+		ss_ rest;
+		split_cmd(line, &cmd, &rest);
+
+		auto fail = [&](const ss_ &msg){
+			*error = "line "+itos(line_no)+": "+msg;
+			out->clear();
+			return false;
+		};
+
+		Command c;
+		if(cmd == "delay"){
+			c.type = Type::Delay;
+			if(!parse_i64(rest, &c.n) || c.n < 0)
+				return fail("delay <ms> (non-negative integer)");
+		} else if(cmd == "screenshot"){
+			c.type = Type::Screenshot;
+			c.s = rest;
+			if(c.s.empty())
+				return fail("screenshot <path>");
+		} else if(cmd == "keydown"){
+			c.type = Type::KeyDown;
+			c.s = rest;
+			if(c.s.empty())
+				return fail("keydown <key>");
+		} else if(cmd == "keyup"){
+			c.type = Type::KeyUp;
+			c.s = rest;
+			if(c.s.empty())
+				return fail("keyup <key>");
+		} else if(cmd == "keypress"){
+			c.type = Type::KeyPress;
+			c.s = rest;
+			if(c.s.empty())
+				return fail("keypress <key>");
+		} else if(cmd == "mouse_pos"){
+			c.type = Type::MousePos;
+			if(!parse_xy(rest, &c.x, &c.y, error))
+				return fail(*error);
+		} else if(cmd == "mouse_move"){
+			c.type = Type::MouseMove;
+			if(!parse_xy(rest, &c.x, &c.y, error))
+				return fail(*error);
+		} else if(cmd == "mouse_down"){
+			c.type = Type::MouseDown;
+			if(!parse_button(rest, &c.x, error))
+				return fail(*error);
+		} else if(cmd == "mouse_up"){
+			c.type = Type::MouseUp;
+			if(!parse_button(rest, &c.x, error))
+				return fail(*error);
+		} else if(cmd == "mouse_click"){
+			c.type = Type::MouseClick;
+			if(!parse_button(rest, &c.x, error))
+				return fail(*error);
+		} else if(cmd == "mouse_wheel"){
+			c.type = Type::MouseWheel;
+			if(!parse_i64(rest, &c.n))
+				return fail("mouse_wheel <delta>");
+		} else if(cmd == "text"){
+			c.type = Type::Text;
+			c.s = rest;
+			if(c.s.empty())
+				return fail("text <string>");
+		} else if(cmd == "quit"){
+			c.type = Type::Quit;
+			if(!rest.empty())
+				return fail("quit takes no arguments");
+		} else {
+			return fail("unknown command \""+cmd+"\"");
+		}
+		out->push_back(c);
+	}
+	return true;
+}
+
+static void self_check()
+{
+	sv_<Command> cs;
+	ss_ err;
+	const char *sample =
+			"# comment\n"
+			"delay 100\n"
+			"keydown W\n"
+			"keyup W\n"
+			"keypress Space\n"
+			"mouse_pos 10 20\n"
+			"mouse_move -1 2\n"
+			"mouse_down left\n"
+			"mouse_up left\n"
+			"mouse_click right\n"
+			"mouse_wheel 3\n"
+			"text hello\n"
+			"screenshot /tmp/x.png\n"
+			"quit\n";
+	if(!parse_body(sample, &cs, &err))
+		throw Exception(ss_()+"command_seq self_check parse: "+err);
+	if(cs.size() != 13)
+		throw Exception("command_seq self_check count "+itos(cs.size()));
+	if(cs[0].type != Type::Delay || cs[0].n != 100)
+		throw Exception("command_seq self_check delay");
+	if(cs[5].type != Type::MouseMove || cs[5].x != -1 || cs[5].y != 2)
+		throw Exception("command_seq self_check mouse_move");
+	if(cs[6].x != SDL_BUTTON_LEFT || cs[8].x != SDL_BUTTON_RIGHT)
+		throw Exception("command_seq self_check buttons");
+	if(!parse_body("nope 1\n", &cs, &err) && err.find("unknown command") != ss_::npos)
+		return;
+	throw Exception("command_seq self_check unknown command");
+}
+
+bool parse(const ss_ &text, sv_<Command> *out, ss_ *error)
+{
+	self_check();
+	return parse_body(text, out, error);
+}
+
+static ss_ button_name(int sdl_button)
+{
+	if(sdl_button == SDL_BUTTON_LEFT)
+		return "left";
+	if(sdl_button == SDL_BUTTON_MIDDLE)
+		return "middle";
+	if(sdl_button == SDL_BUTTON_RIGHT)
+		return "right";
+	if(sdl_button == SDL_BUTTON_X1)
+		return "x1";
+	if(sdl_button == SDL_BUTTON_X2)
+		return "x2";
+	return itos(sdl_button);
+}
+
+ss_ dump_command(const Command &c)
+{
+	switch(c.type){
+	case Type::Delay:
+		return "delay "+itos(c.n);
+	case Type::Screenshot:
+		return "screenshot "+c.s;
+	case Type::KeyDown:
+		return "keydown "+c.s;
+	case Type::KeyUp:
+		return "keyup "+c.s;
+	case Type::KeyPress:
+		return "keypress "+c.s;
+	case Type::MousePos:
+		return "mouse_pos "+itos(c.x)+" "+itos(c.y);
+	case Type::MouseMove:
+		return "mouse_move "+itos(c.x)+" "+itos(c.y);
+	case Type::MouseDown:
+		return "mouse_down "+button_name(c.x);
+	case Type::MouseUp:
+		return "mouse_up "+button_name(c.x);
+	case Type::MouseClick:
+		return "mouse_click "+button_name(c.x);
+	case Type::MouseWheel:
+		return "mouse_wheel "+itos(c.n);
+	case Type::Text:
+		return "text "+c.s;
+	case Type::Quit:
+		return "quit";
+	}
+	return "?";
+}
+
+static const char *key_alias(const ss_ &name)
+{
+	ss_ t;
+	t.reserve(name.size());
+	for(char c : name)
+		t.push_back((char)tolower((unsigned char)c));
+	if(t == "enter")
+		return "Return";
+	if(t == "esc")
+		return "Escape";
+	if(t == "ctrl")
+		return "Left Ctrl";
+	if(t == "shift")
+		return "Left Shift";
+	if(t == "alt")
+		return "Left Alt";
+	if(t == "super" || t == "gui" || t == "win")
+		return "Left GUI";
+	return nullptr;
+}
+
+static int key_from_name(magic::Input *input, const ss_ &name)
+{
+	int key = input->GetKeyFromName(name.c_str());
+	if(key != 0)
+		return key;
+	const char *alias = key_alias(name);
+	if(alias)
+		key = input->GetKeyFromName(alias);
+	return key;
+}
+
+static Uint32 window_id(magic::Input *input)
+{
+	magic::Graphics *g = input->GetSubsystem<magic::Graphics>();
+	SDL_Window *w = g ? g->GetWindow() : nullptr;
+	return w ? SDL_GetWindowID(w) : 0;
+}
+
+void raise_window(magic::Graphics *graphics)
+{
+	if(!graphics)
+		return;
+	SDL_Window *w = graphics->GetWindow();
+	if(!w)
+		return;
+	SDL_ShowWindow(w);
+	SDL_RaiseWindow(w);
+	SDL_SetWindowInputFocus(w);
+}
+
+static bool push_key(magic::Input *input, int key, bool down, ss_ *error)
+{
+	SDL_Event e;
+	memset(&e, 0, sizeof(e));
+	e.type = down ? SDL_KEYDOWN : SDL_KEYUP;
+	e.key.state = down ? SDL_PRESSED : SDL_RELEASED;
+	e.key.repeat = 0;
+	e.key.windowID = window_id(input);
+	e.key.keysym.sym = key;
+	e.key.keysym.scancode = SDL_GetScancodeFromKey((SDL_Keycode)key);
+	if(SDL_PushEvent(&e) != 1){
+		*error = "SDL_PushEvent failed";
+		return false;
+	}
+	return true;
+}
+
+bool inject_key(magic::Input *input, const ss_ &name, bool down, bool up_too,
+		ss_ *error)
+{
+	int key = key_from_name(input, name);
+	if(key == 0){
+		*error = "Unknown key \""+name+"\"";
+		return false;
+	}
+	if(!push_key(input, key, down, error))
+		return false;
+	if(up_too && !push_key(input, key, false, error))
+		return false;
+	return true;
+}
+
+static bool push_mouse_button(magic::Input *input, int sdl_button, bool down,
+		ss_ *error)
+{
+	magic::IntVector2 p = input->GetMousePosition();
+	SDL_Event e;
+	memset(&e, 0, sizeof(e));
+	e.type = down ? SDL_MOUSEBUTTONDOWN : SDL_MOUSEBUTTONUP;
+	e.button.windowID = window_id(input);
+	e.button.button = (Uint8)sdl_button;
+	e.button.state = down ? SDL_PRESSED : SDL_RELEASED;
+	e.button.clicks = 1;
+	e.button.x = p.x_;
+	e.button.y = p.y_;
+	if(SDL_PushEvent(&e) != 1){
+		*error = "SDL_PushEvent failed";
+		return false;
+	}
+	return true;
+}
+
+bool inject_mouse_button(magic::Input *input, int sdl_button, bool down,
+		bool up_too, ss_ *error)
+{
+	if(!push_mouse_button(input, sdl_button, down, error))
+		return false;
+	if(up_too && !push_mouse_button(input, sdl_button, false, error))
+		return false;
+	return true;
+}
+
+bool inject_mouse_pos(magic::Input *input, int x, int y, ss_ *error)
+{
+	magic::IntVector2 old = input->GetMousePosition();
+	input->SetMousePosition(magic::IntVector2(x, y));
+	SDL_Event e;
+	memset(&e, 0, sizeof(e));
+	e.type = SDL_MOUSEMOTION;
+	e.motion.windowID = window_id(input);
+	e.motion.x = x;
+	e.motion.y = y;
+	e.motion.xrel = x - old.x_;
+	e.motion.yrel = y - old.y_;
+	if(SDL_PushEvent(&e) != 1){
+		*error = "SDL_PushEvent failed";
+		return false;
+	}
+	return true;
+}
+
+bool inject_mouse_move(magic::Input *input, int dx, int dy, ss_ *error)
+{
+	// Relative only. No warp: captured look has no persistent cursor position.
+	SDL_Event e;
+	memset(&e, 0, sizeof(e));
+	e.type = SDL_MOUSEMOTION;
+	e.motion.windowID = window_id(input);
+	e.motion.xrel = dx;
+	e.motion.yrel = dy;
+	if(SDL_PushEvent(&e) != 1){
+		*error = "SDL_PushEvent failed";
+		return false;
+	}
+	return true;
+}
+
+bool inject_mouse_wheel(magic::Input *input, int delta, ss_ *error)
+{
+	SDL_Event e;
+	memset(&e, 0, sizeof(e));
+	e.type = SDL_MOUSEWHEEL;
+	e.wheel.windowID = window_id(input);
+	e.wheel.y = delta;
+	if(SDL_PushEvent(&e) != 1){
+		*error = "SDL_PushEvent failed";
+		return false;
+	}
+	return true;
+}
+
+bool inject_text(magic::Input *input, const ss_ &text, ss_ *error)
+{
+	size_t i = 0;
+	while(i < text.size()){
+		SDL_Event e;
+		memset(&e, 0, sizeof(e));
+		e.type = SDL_TEXTINPUT;
+		e.text.windowID = window_id(input);
+		size_t n = text.size() - i;
+		if(n > sizeof(e.text.text) - 1)
+			n = sizeof(e.text.text) - 1;
+		memcpy(e.text.text, text.c_str() + i, n);
+		e.text.text[n] = 0;
+		if(SDL_PushEvent(&e) != 1){
+			*error = "SDL_PushEvent failed";
+			return false;
+		}
+		i += n;
+	}
+	return true;
+}
+
+bool save_screenshot(magic::Graphics *graphics, const ss_ &path, ss_ *error)
+{
+	if(!graphics){
+		*error = "Graphics not available";
+		return false;
+	}
+	magic::Image img(graphics->GetContext());
+	if(!graphics->TakeScreenShot(img)){
+		*error = "TakeScreenShot failed";
+		return false;
+	}
+	ss_ abs = interface::fs::get_absolute_path(path);
+	ss_ parent = interface::fs::strip_file_name(abs);
+	if(!parent.empty() && !interface::fs::create_directories(parent)){
+		*error = "Failed to create directory \""+parent+"\"";
+		return false;
+	}
+	magic::FileSystem *fs = graphics->GetSubsystem<magic::FileSystem>();
+	if(fs && !parent.empty())
+		fs->RegisterPath(parent.c_str());
+	if(!img.SavePNG(abs.c_str())){
+		*error = "Failed to write \""+abs+"\"";
+		return false;
+	}
+	log_i(MODULE, "Wrote screenshot %s", cs(abs));
+	return true;
+}
+
+}
+}
+// vim: set noet ts=4 sw=4:

--- a/src/client/command_seq.h
+++ b/src/client/command_seq.h
@@ -1,0 +1,59 @@
+// http://www.apache.org/licenses/LICENSE-2.0
+// Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+#pragma once
+#include "core/types.h"
+
+namespace Urho3D {
+	class Graphics;
+	class Input;
+}
+
+namespace client
+{
+namespace command_seq
+{
+	enum class Type
+	{
+		Delay,
+		Screenshot,
+		KeyDown,
+		KeyUp,
+		KeyPress,
+		MousePos,
+		MouseMove,
+		MouseDown,
+		MouseUp,
+		MouseClick,
+		MouseWheel,
+		Text,
+		Quit,
+	};
+
+	struct Command
+	{
+		Type type;
+		int64_t n = 0;
+		int x = 0;
+		int y = 0;
+		ss_ s;
+	};
+
+	// One command per line. Empty lines and '#' comments are ignored.
+	bool parse(const ss_ &text, sv_<Command> *out, ss_ *error);
+
+	ss_ dump_command(const Command &c);
+
+	void raise_window(Urho3D::Graphics *graphics);
+	bool inject_key(Urho3D::Input *input, const ss_ &name, bool down,
+			bool up_too, ss_ *error);
+	bool inject_mouse_button(Urho3D::Input *input, int sdl_button, bool down,
+			bool up_too, ss_ *error);
+	bool inject_mouse_pos(Urho3D::Input *input, int x, int y, ss_ *error);
+	bool inject_mouse_move(Urho3D::Input *input, int dx, int dy, ss_ *error);
+	bool inject_mouse_wheel(Urho3D::Input *input, int delta, ss_ *error);
+	bool inject_text(Urho3D::Input *input, const ss_ &text, ss_ *error);
+	bool save_screenshot(Urho3D::Graphics *graphics, const ss_ &path,
+			ss_ *error);
+}
+}
+// vim: set noet ts=4 sw=4:

--- a/src/client/config.cpp
+++ b/src/client/config.cpp
@@ -20,6 +20,8 @@ Config::Config()
 	set_default("boot_to_menu", false);
 	set_default("menu_extension_name", "__menu");
 	set_default("ui_scale", 0.0); // 0 = auto from short side / 1080
+	set_default("command_seq", "");
+	set_default("command_seq_enabled", false);
 }
 
 bool Config::check_paths()

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -7,10 +7,13 @@
 #include "client/config.h"
 #include "client/state.h"
 #include "client/app.h"
+#include "client/command_seq.h"
 #include "interface/os.h"
 #include <c55/getopt.h>
 #include <Context.h>
 #include <cstdlib> // srand()
+#include <fstream>
+#include <sstream>
 #include <signal.h>
 #define MODULE "__main"
 namespace magic = Urho3D;
@@ -41,7 +44,7 @@ int main(int argc, char *argv[])
 
 	client::Config &config = g_client_config;
 
-	const char opts[100] = "hs:P:C:U:l:L:m:u:";
+	const char opts[100] = "hs:P:C:U:l:L:m:u:c:";
 	const char usagefmt[1000] =
 			"Usage: %s [OPTION]...\n"
 			"  -h                   Show this help\n"
@@ -53,6 +56,9 @@ int main(int argc, char *argv[])
 			"  -L [log file path]   Append log to a specified file\n"
 			"  -m [name]            Choose menu extension name\n"
 			"  -u [scale]           UI scale (0 = auto from short side / 1080)\n"
+			"  -c [commands]        Run command sequence and exit\n"
+			"                       One command per line. @file reads a file.\n"
+			"                       See doc/client_commands.txt\n"
 			;
 
 	int c;
@@ -93,6 +99,39 @@ int main(int argc, char *argv[])
 			log_i(MODULE, "config.ui_scale: %s", c55_optarg);
 			config.set("ui_scale", atof(c55_optarg));
 			break;
+		case 'c': {
+			ss_ arg = c55_optarg ? c55_optarg : "";
+			ss_ text;
+			if(!arg.empty() && arg[0] == '@'){
+				ss_ path = arg.substr(1);
+				if(path.empty()){
+					fprintf(stderr, "-c @file: empty path\n");
+					return 1;
+				}
+				std::ifstream in(path.c_str());
+				if(!in){
+					fprintf(stderr, "Failed to read command file: %s\n",
+							path.c_str());
+					return 1;
+				}
+				std::ostringstream ss;
+				ss<<in.rdbuf();
+				text = ss.str();
+			} else {
+				text = arg;
+			}
+			sv_<client::command_seq::Command> parsed;
+			ss_ err;
+			if(!client::command_seq::parse(text, &parsed, &err)){
+				fprintf(stderr, "Invalid -c command sequence: %s\n",
+						err.c_str());
+				return 1;
+			}
+			log_i(MODULE, "config.command_seq: %zu commands", parsed.size());
+			config.set("command_seq", text);
+			config.set("command_seq_enabled", true);
+			break;
+		}
 		default:
 			fprintf(stderr, "Invalid command-line argument\n");
 			fprintf(stderr, usagefmt, argv[0]);


### PR DESCRIPTION
The client can run a one-shot command list (`-c`) and then exit. Intended for CI, visual checks of UI/rendering, and checking that an input action actually registers.

```
bin/buildat_client -c $'delay 2000\nscreenshot /tmp/menu.png'
bin/buildat_client -c @commands.txt
bin/buildat_client -s localhost -c @commands.txt
```

Commands: delay, screenshot, keydown/keyup/keypress, mouse_pos/mouse_move/mouse_down/mouse_up/mouse_click/mouse_wheel, text, quit.

In `-c` mode the OS mouse is not captured or grabbed even if the game requests it. `mouse_move` is relative (`GetMouseMove`) and does not warp the cursor. `mouse_pos` is for a visible UI cursor.

See `doc/client_commands.txt`.