### PR TITLE
Add keyboard and mouse selection for launcher menus

### DIFF
--- a/extensions/launch_menu/init.lua
+++ b/extensions/launch_menu/init.lua
@@ -280,39 +280,31 @@ local function show_local_game()
 	local style = magic.cache:GetResource("XMLFile", "__menu/res/main_style.xml")
 	root.defaultStyle = style
 
-	local window = root:CreateChild("Window")
-	window:SetStyleAuto()
-	window:SetLayout(LM_VERTICAL, 10, magic.IntRect(10, 10, 10, 10))
-	window:SetAlignment(HA_LEFT, VA_CENTER)
+	local menu = ui_utils.vertical_menu(root, {min_width = MENU_BUTTON_WIDTH})
 
-	local title = window:CreateChild("Text")
+	local title = menu.window:CreateChild("Text")
 	title:SetStyleAuto()
 	title.text = "Local game"
 
 	local games = buildat.list_games()
 	if #games == 0 then
-		local empty = window:CreateChild("Text")
+		local empty = menu.window:CreateChild("Text")
 		empty:SetStyleAuto()
 		empty.text = "No games found"
 	else
 		for _, game in ipairs(games) do
 			local name = game.name
-			local button = make_game_button(window, name, game.size)
-			magic.SubscribeToEvent(button, "Released",
-			function(self, event_type, event_data)
+			local button = make_game_button(menu.window, name, game.size)
+			menu:add(button, function()
 				start_local_game(name)
 			end)
 		end
 	end
 
-	local back_button = make_button(window, "Back")
-	magic.SubscribeToEvent(back_button, "Released",
-	function(self, event_type, event_data)
+	menu:add("Back", function()
 		uistack.main:pop(root)
 	end)
-
-	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
-		local key = event_data:GetInt("Key")
+	menu:on_key(function(key)
 		if key == KEY_ESCAPE then
 			uistack.main:pop(root)
 		end
@@ -325,46 +317,30 @@ function M.boot()
 	local style = magic.cache:GetResource("XMLFile", "__menu/res/main_style.xml")
 	root.defaultStyle = style
 
-	local window = root:CreateChild("Window")
-	window:SetStyleAuto()
-	window:SetLayout(LM_VERTICAL, 16, magic.IntRect(10, 20, 10, 20))
-	window:SetAlignment(HA_LEFT, VA_CENTER)
+	local menu = ui_utils.vertical_menu(root, {
+		spacing = 16,
+		padding = magic.IntRect(10, 20, 10, 20),
+		min_width = MENU_BUTTON_WIDTH,
+	})
 
-	local logo = window:CreateChild("Sprite")
+	local logo = menu.window:CreateChild("Sprite")
 	logo:SetTexture(magic.cache:GetResource("Texture2D", "buildat_logo.png"))
 	logo:SetFixedSize(160, 160)
 
-	local title = window:CreateChild("Text")
+	local title = menu.window:CreateChild("Text")
 	title:SetStyleAuto()
 	title.text = "Buildat"
 	title:SetFontSize(28)
 	title:SetTextAlignment(HA_CENTER)
 
-	local local_button = make_button(window, "Local game")
-	magic.SubscribeToEvent(local_button, "Released",
-	function(self, event_type, event_data)
-		show_local_game()
-	end)
-
-	local connect_button = make_button(window, "Connect to server")
-	magic.SubscribeToEvent(connect_button, "Released",
-	function(self, event_type, event_data)
-		show_connect_to_server()
-	end)
-
-	local exit_button = make_button(window, "Exit")
-	magic.SubscribeToEvent(exit_button, "Released",
-	function(self, event_type, event_data)
+	menu:add("Local game", show_local_game)
+	menu:add("Connect to server", show_connect_to_server)
+	menu:add("Exit", function()
 		engine:Exit()
 	end)
-
-	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
-		local key = event_data:GetInt("Key")
+	menu:on_key(function(key)
 		if key == KEY_ESCAPE then
 			engine:Exit()
-		end
-		if key == KEY_RETURN then
-			show_local_game()
 		end
 	end)
 end

--- a/extensions/ui_utils/init.lua
+++ b/extensions/ui_utils/init.lua
@@ -9,6 +9,150 @@ local M = {safe = {}}
 -- show_*_notification()
 -- show_*_dialog()
 -- show_*_window() (?)
+-- vertical_menu() / bind_button_menu()
+
+-- One selected index for mouse hover and arrow keys. Button.selected uses
+-- pressedOffset; native hover would still highlight the mouse-over item if
+-- arrows move elsewhere, so copy hoverOffset onto pressedOffset and clear it.
+local function button_menu_nav(root)
+	local items = {}
+	local selected = 1
+	local on_other_key = nil
+
+	local function apply()
+		for i, item in ipairs(items) do
+			item.button.selected = (i == selected)
+		end
+	end
+
+	local function select_i(i)
+		local n = #items
+		if n == 0 then
+			return
+		end
+		if i < 1 then
+			i = n
+		elseif i > n then
+			i = 1
+		end
+		selected = i
+		apply()
+	end
+
+	local nav = {}
+
+	function nav:add(button, action)
+		if button == nil or action == nil then
+			error("button_menu: add() needs a button and an action")
+		end
+		local i = #items + 1
+		items[i] = {button = button, action = action}
+		local hover = button.hoverOffset
+		button.pressedOffset = magic.IntVector2(hover.x, hover.y)
+		button.hoverOffset = magic.IntVector2(0, 0)
+		magic.SubscribeToEvent(button, "Released",
+		function(self, event_type, event_data)
+			action()
+		end)
+		magic.SubscribeToEvent(button, "HoverBegin",
+		function(self, event_type, event_data)
+			select_i(i)
+		end)
+		apply()
+		return button
+	end
+
+	function nav:on_key(fn)
+		on_other_key = fn
+		return self
+	end
+
+	root:SubscribeToStackEvent("KeyDown", function(event_type, event_data)
+		local key = event_data:GetInt("Key")
+		if key == KEY_UP then
+			select_i(selected - 1)
+		elseif key == KEY_DOWN then
+			select_i(selected + 1)
+		elseif key == KEY_RETURN or key == KEY_RETURN2 or key == KEY_KP_ENTER then
+			if magic.input:GetKeyPress(key) and items[selected] then
+				items[selected].action()
+			end
+		elseif on_other_key then
+			on_other_key(key)
+		end
+	end)
+
+	return nav
+end
+
+-- Bind up/down/enter and hover selection to existing buttons on a uistack
+-- root. Each item is {button, action} or {button=..., action=...}.
+-- Subscribes Released on the buttons; don't also subscribe Released.
+-- Returns a handle with :add(button, action) and :on_key(fn).
+function M.safe.bind_button_menu(root, items, on_other_key)
+	local nav = button_menu_nav(root)
+	if items then
+		for _, item in ipairs(items) do
+			nav:add(item.button or item[1], item.action or item[2])
+		end
+	end
+	if on_other_key then
+		nav:on_key(on_other_key)
+	end
+	return nav
+end
+
+local function make_menu_button(parent, label, options)
+	local button = parent:CreateChild("Button")
+	button:SetStyleAuto()
+	button:SetName("Button")
+	button:SetLayout(LM_VERTICAL, 10, magic.IntRect(0, 0, 0, 0))
+	button.minHeight = options.min_height or 24
+	if options.min_width then
+		button.minWidth = options.min_width
+	end
+	local text = button:CreateChild("Text")
+	text:SetName("ButtonText")
+	text:SetStyleAuto()
+	text.text = label
+	text:SetTextAlignment(HA_CENTER)
+	return button
+end
+
+-- Vertical Window on a uistack root, with the same keyboard/mouse nav.
+-- Extra widgets (logo, titles) go on menu.window before :add().
+-- :add("Label", action) creates a button; :add(button, action) registers one.
+function M.safe.vertical_menu(root, options)
+	options = options or {}
+	local window = root:CreateChild("Window")
+	window:SetStyleAuto()
+	window:SetLayout(LM_VERTICAL, options.spacing or 10,
+			options.padding or magic.IntRect(10, 10, 10, 10))
+	window:SetAlignment(HA_LEFT, VA_CENTER)
+
+	local nav = button_menu_nav(root)
+	if options.on_key then
+		nav:on_key(options.on_key)
+	end
+
+	local menu = {window = window}
+
+	function menu:add(label_or_button, action)
+		local button = label_or_button
+		if type(label_or_button) == "string" then
+			button = make_menu_button(window, label_or_button, options)
+		end
+		nav:add(button, action)
+		return button
+	end
+
+	function menu:on_key(fn)
+		nav:on_key(fn)
+		return self
+	end
+
+	return menu
+end
 
 local message_handle = nil
 

--- a/extensions/urho3d/safe_classes.lua
+++ b/extensions/urho3d/safe_classes.lua
@@ -840,6 +840,7 @@ function M.define(dst, util)
 			fixedWidth = util.simple_property("number"),
 			fixedSize = util.simple_property("IntVector2"),
 			defaultStyle = util.simple_property("XMLFile"),
+			selected = util.simple_property("boolean"),
 		},
 	})
 
@@ -860,6 +861,7 @@ function M.define(dst, util)
 		inherited_from_by_wrapper = dst.UIElement,
 		properties = {
 			texture = util.simple_property("Texture"),
+			hoverOffset = util.simple_property(dst.IntVector2),
 		},
 	})
 
@@ -869,6 +871,9 @@ function M.define(dst, util)
 
 	util.wc("Button", {
 		inherited_from_by_wrapper = dst.BorderImage,
+		properties = {
+			pressedOffset = util.simple_property(dst.IntVector2),
+		},
 	})
 
 	util.wc("LineEdit", {


### PR DESCRIPTION
Launcher boot and local-game menus have a selected item. Hover, up/down, and enter share that highlight. Connect-to-server is unchanged.

`ui_utils.vertical_menu` is a vertical button list with that nav built in. `bind_button_menu` attaches the same nav to existing buttons on a uistack root.

```
bin/buildat
```