### PR TITLE
Relight voxel_lighting on edit

### DIFF
--- a/builtin/voxelworld/api.h
+++ b/builtin/voxelworld/api.h
@@ -95,6 +95,24 @@ namespace voxelworld
 				const VoxelInstance &v,
 				bool disable_warnings = false) = 0;
 
+		// Maintain VoxelInstance::get_skylight() of every voxel in the world.
+		// Off by default; a world that does not want skylight pays nothing and
+		// keeps whatever is in those bits. Once on, the light is kept up to
+		// date by set_voxel(), including through generation, and is settled
+		// before commit() meshes anything.
+		//
+		// Light enters from above the top of the world region at full
+		// strength, falls through anything that transmits light without
+		// losing any, and spreads sideways and upwards losing one step per
+		// voxel. A voxel transmits light if its edge material is
+		// EDGEMATERIALID_EMPTY, which is the same test the mesher uses to
+		// decide whether a face is drawn against it.
+		//
+		// simplified: transparency is that one test, so glass would have to
+		// be a light barrier or a hole in the terrain. A voxel definition
+		// flag of its own is the upgrade path.
+		virtual void set_skylight_enabled(bool enabled) = 0;
+
 		virtual size_t num_buffers_loaded() = 0;
 
 		virtual void commit() = 0;

--- a/builtin/voxelworld/voxelworld.cpp
+++ b/builtin/voxelworld/voxelworld.cpp
@@ -6,6 +6,7 @@
 #include "replicate/api.h"
 #include "main_context/api.h"
 #include "core/log.h"
+#include <chrono>
 #include "interface/module.h"
 #include "interface/server.h"
 #include "interface/event.h"
@@ -209,6 +210,14 @@ struct QueuedNodePhysicsUpdate
 	}
 };
 
+// Skylight neighbour offsets. The last pair is +Y and -Y; LIGHT_DOWN is
+// straight down, the one direction light falls through without losing any.
+static const int LIGHT_OFF[6][3] = {
+	{1,0,0}, {-1,0,0}, {0,0,1}, {0,0,-1}, {0,1,0}, {0,-1,0}
+};
+static const size_t LIGHT_DOWN = 5;
+static const uint8_t SKYLIGHT_MAX = VoxelInstance::SKYLIGHT_MAX;
+
 struct CInstance: public voxelworld::Instance
 {
 	interface::Server *m_server;
@@ -252,10 +261,27 @@ struct CInstance: public voxelworld::Instance
 	// (as a sorted array in descending node_id order)
 	std::vector<QueuedNodePhysicsUpdate> m_nodes_needing_physics_update;
 
+	// Skylight. Off unless the world asks for it; see api.h.
+	bool m_skylight_enabled = false;
+	// The world region in sections, so that the top of it can be found. Light
+	// enters from above that; everything outside is a barrier.
+	pv::Region m_section_region;
+	// Voxels that started or stopped transmitting light since the last commit,
+	// with what they were before, because the new voxel has already replaced
+	// the old light value by the time this is looked at.
+	struct SkylightSeed
+	{
+		pv::Vector3DInt32 p;
+		uint8_t old_level;
+		bool was_transparent;
+	};
+	std::vector<SkylightSeed> m_skylight_seeds;
+
 	CInstance(interface::Server *server, SceneReference scene_ref,
 			const pv::Region &region):
 		m_server(server),
-		m_scene_ref(scene_ref)
+		m_scene_ref(scene_ref),
+		m_section_region(region)
 	{
 		m_voxel_reg.reset(interface::createVoxelRegistry());
 		m_block_reg.reset(interface::createBlockRegistry(m_voxel_reg.get()));
@@ -878,6 +904,17 @@ struct CInstance: public voxelworld::Instance
 	void set_voxel(const pv::Vector3DInt32 &p, const interface::VoxelInstance &v,
 			bool disable_warnings)
 	{
+		set_voxel_impl(p, v, disable_warnings, false);
+	}
+
+	// is_light_update: the skylight bits in v are meant to be written as they
+	// are. Every other caller gets them carried over from the voxel that was
+	// there, because once skylight is on those bits belong to voxelworld and a
+	// caller writing a plain voxel would otherwise wipe the light out of it.
+	void set_voxel_impl(const pv::Vector3DInt32 &p,
+			const interface::VoxelInstance &v, bool disable_warnings,
+			bool is_light_update)
+	{
 		// Don't log here; this is a too busy place for even ignored log calls
 		/*log_t(MODULE, "set_voxel() p=" PV3I_FORMAT ", v=%i",
 				PV3I_PARAMS(p), v.data);*/
@@ -913,7 +950,18 @@ struct CInstance: public voxelworld::Instance
 				p.getY() - chunk_p.getY() * m_chunk_size_voxels.getY(),
 				p.getZ() - chunk_p.getZ() * m_chunk_size_voxels.getZ()
 		);
-		buf.volume->setVoxelAt(voxel_p, v);
+		VoxelInstance nv = v;
+		if(m_skylight_enabled && !is_light_update){
+			VoxelInstance old = buf.volume->getVoxelAt(voxel_p);
+			bool old_transparent = voxel_transmits_light(old);
+			if(old_transparent != voxel_transmits_light(v)){
+				m_skylight_seeds.push_back(SkylightSeed{
+						p, old.get_skylight(), old_transparent});
+			}
+			nv.set_skylight(old.get_skylight());
+		}
+
+		buf.volume->setVoxelAt(voxel_p, nv);
 
 		// Set buffer dirty
 		if(!buf.dirty){
@@ -986,6 +1034,189 @@ struct CInstance: public voxelworld::Instance
 				}
 			}
 		}
+	}
+
+	// Skylight
+	//
+	// Air voxels hold the light itself. Voxels that block light hold the
+	// brightest light next to them instead, which is what the mesher reads
+	// when the air voxel in front of a face is in a chunk it is not meshing.
+
+	bool voxel_transmits_light(const VoxelInstance &v)
+	{
+		if(v.get_id() == interface::VOXELTYPEID_UNDEFINED)
+			return false;
+		const interface::CachedVoxelDefinition *def =
+				m_voxel_reg->get_cached(v);
+		if(def == nullptr)
+			return false;
+		return def->edge_material_id == interface::EDGEMATERIALID_EMPTY;
+	}
+
+	// Voxels in the topmost row of the world see the open sky
+	bool is_below_open_sky(const pv::Vector3DInt32 &p)
+	{
+		int section_h = m_section_size_chunks.getY() *
+				m_chunk_size_voxels.getY();
+		return p.getY() ==
+				(m_section_region.getUpperCorner().getY() + 1) * section_h - 1;
+	}
+
+	void set_skylight_at(const pv::Vector3DInt32 &p, const VoxelInstance &v,
+			uint8_t level)
+	{
+		VoxelInstance nv = v;
+		nv.set_skylight(level);
+		set_voxel_impl(p, nv, true, true);
+	}
+
+	struct LightNode
+	{
+		pv::Vector3DInt32 p;
+		uint8_t level;
+	};
+
+	// Bring the skylight up to date after the voxels in m_skylight_seeds
+	// changed. Light is taken out of everything the changed voxels were
+	// lighting, and then spread back in from whatever still has light, so the
+	// work done is proportional to how far the change reaches rather than to
+	// the size of the world. Neighbours are read in world coordinates, so this
+	// crosses chunk and section boundaries by itself; a section that is not in
+	// memory reads as undefined and stops the light, which keeps an edit next
+	// to the edge of the loaded world from running away.
+	void update_skylight()
+	{
+		std::vector<SkylightSeed> seeds;
+		seeds.swap(m_skylight_seeds);
+		if(!m_skylight_enabled || seeds.empty())
+			return;
+		auto t0 = std::chrono::steady_clock::now();
+
+		std::vector<LightNode> unlight;
+		std::vector<LightNode> spread;
+		// Voxels that block light and are next to something that changed.
+		// Duplicates are left in; recomputing one twice costs a little and is
+		// simpler than keeping a set.
+		std::vector<pv::Vector3DInt32> blockers;
+
+		for(const SkylightSeed &seed : seeds){
+			VoxelInstance v = get_voxel(seed.p, true);
+			bool now_transparent = voxel_transmits_light(v);
+			if(seed.was_transparent && !now_transparent){
+				// It took its light with it
+				unlight.push_back(LightNode{seed.p, seed.old_level});
+				blockers.push_back(seed.p);
+			} else if(!seed.was_transparent && now_transparent){
+				// It is dark and has to be filled from around it
+				uint8_t l = is_below_open_sky(seed.p) ? SKYLIGHT_MAX : 0;
+				set_skylight_at(seed.p, v, l);
+				if(l > 0)
+					spread.push_back(LightNode{seed.p, l});
+				for(size_t k = 0; k < 6; k++){
+					pv::Vector3DInt32 n(
+							seed.p.getX() + LIGHT_OFF[k][0],
+							seed.p.getY() + LIGHT_OFF[k][1],
+							seed.p.getZ() + LIGHT_OFF[k][2]);
+					VoxelInstance nv = get_voxel(n, true);
+					if(!voxel_transmits_light(nv)){
+						blockers.push_back(n);
+						continue;
+					}
+					if(nv.get_skylight() > 0)
+						spread.push_back(LightNode{n, nv.get_skylight()});
+				}
+			}
+		}
+
+		// Take the light out. A neighbour dimmer than where the light is being
+		// removed from was lit by it and goes dark too; one that is as bright
+		// or brighter is lit by something else and becomes a source to spread
+		// back from. Straight down is the exception: light does not dim on the
+		// way down, so a full strength voxel below a full strength one was
+		// still lit by it.
+		for(size_t i = 0; i < unlight.size(); i++){
+			LightNode node = unlight[i];
+			for(size_t k = 0; k < 6; k++){
+				pv::Vector3DInt32 n(
+						node.p.getX() + LIGHT_OFF[k][0],
+						node.p.getY() + LIGHT_OFF[k][1],
+						node.p.getZ() + LIGHT_OFF[k][2]);
+				VoxelInstance nv = get_voxel(n, true);
+				if(!voxel_transmits_light(nv)){
+					blockers.push_back(n);
+					continue;
+				}
+				uint8_t nl = nv.get_skylight();
+				if(nl == 0)
+					continue;
+				bool lit_from_above = (k == LIGHT_DOWN &&
+						node.level == SKYLIGHT_MAX && nl == SKYLIGHT_MAX);
+				if(nl < node.level || lit_from_above){
+					set_skylight_at(n, nv, 0);
+					unlight.push_back(LightNode{n, nl});
+				} else {
+					spread.push_back(LightNode{n, nl});
+				}
+			}
+		}
+
+		// Spread it back in
+		for(size_t i = 0; i < spread.size(); i++){
+			LightNode node = spread[i];
+			if(node.level == 0)
+				continue;
+			// Spread whatever the voxel holds now, not what it held when it
+			// was put on the list: a source can be unlit by another branch
+			// after it was queued, and spreading the level it used to have
+			// would put light back where it was just taken from.
+			VoxelInstance v = get_voxel(node.p, true);
+			if(!voxel_transmits_light(v))
+				continue;
+			node.level = v.get_skylight();
+			if(node.level == 0)
+				continue;
+			for(size_t k = 0; k < 6; k++){
+				pv::Vector3DInt32 n(
+						node.p.getX() + LIGHT_OFF[k][0],
+						node.p.getY() + LIGHT_OFF[k][1],
+						node.p.getZ() + LIGHT_OFF[k][2]);
+				VoxelInstance nv = get_voxel(n, true);
+				if(!voxel_transmits_light(nv)){
+					blockers.push_back(n);
+					continue;
+				}
+				uint8_t target = (k == LIGHT_DOWN &&
+						node.level == SKYLIGHT_MAX) ?
+						SKYLIGHT_MAX : node.level - 1;
+				if(target > nv.get_skylight()){
+					set_skylight_at(n, nv, target);
+					spread.push_back(LightNode{n, target});
+				}
+			}
+		}
+
+		// Give the voxels that block light the brightest light next to them
+		for(const pv::Vector3DInt32 &p : blockers){
+			VoxelInstance v = get_voxel(p, true);
+			if(voxel_transmits_light(v))
+				continue;
+			uint8_t best = 0;
+			for(size_t k = 0; k < 6; k++){
+				VoxelInstance nv = get_voxel(pv::Vector3DInt32(
+						p.getX() + LIGHT_OFF[k][0],
+						p.getY() + LIGHT_OFF[k][1],
+						p.getZ() + LIGHT_OFF[k][2]), true);
+				if(voxel_transmits_light(nv) && nv.get_skylight() > best)
+					best = nv.get_skylight();
+			}
+			if(v.get_skylight() != best)
+				set_skylight_at(p, v, best);
+		}
+
+		log_v(MODULE, "update_skylight(): %zu seeds, %zu unlit, %zu spread "
+				"in %i ms", seeds.size(), unlight.size(), spread.size(),
+				(int)std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now() - t0).count());
 	}
 
 	// Commit and unload chunk buffer
@@ -1084,8 +1315,17 @@ struct CInstance: public voxelworld::Instance
 		return m_total_buffers_loaded;
 	}
 
+	void set_skylight_enabled(bool enabled)
+	{
+		m_skylight_enabled = enabled;
+	}
+
 	void commit()
 	{
+		// Before anything is meshed, so that the light lands in the same
+		// remesh as the voxels that changed it
+		update_skylight();
+
 		if(m_sections_with_loaded_buffers.empty())
 			return;
 		log_d(MODULE, "Committing %zu dirty buffers in %zu sections",

--- a/builtin/voxelworld/voxelworld.cpp
+++ b/builtin/voxelworld/voxelworld.cpp
@@ -904,17 +904,6 @@ struct CInstance: public voxelworld::Instance
 	void set_voxel(const pv::Vector3DInt32 &p, const interface::VoxelInstance &v,
 			bool disable_warnings)
 	{
-		set_voxel_impl(p, v, disable_warnings, false);
-	}
-
-	// is_light_update: the skylight bits in v are meant to be written as they
-	// are. Every other caller gets them carried over from the voxel that was
-	// there, because once skylight is on those bits belong to voxelworld and a
-	// caller writing a plain voxel would otherwise wipe the light out of it.
-	void set_voxel_impl(const pv::Vector3DInt32 &p,
-			const interface::VoxelInstance &v, bool disable_warnings,
-			bool is_light_update)
-	{
 		// Don't log here; this is a too busy place for even ignored log calls
 		/*log_t(MODULE, "set_voxel() p=" PV3I_FORMAT ", v=%i",
 				PV3I_PARAMS(p), v.data);*/
@@ -951,13 +940,17 @@ struct CInstance: public voxelworld::Instance
 				p.getZ() - chunk_p.getZ() * m_chunk_size_voxels.getZ()
 		);
 		VoxelInstance nv = v;
-		if(m_skylight_enabled && !is_light_update){
+		if(m_skylight_enabled){
 			VoxelInstance old = buf.volume->getVoxelAt(voxel_p);
 			bool old_transparent = voxel_transmits_light(old);
 			if(old_transparent != voxel_transmits_light(v)){
 				m_skylight_seeds.push_back(SkylightSeed{
 						p, old.get_skylight(), old_transparent});
 			}
+			// Once skylight is on those bits belong to voxelworld, so they
+			// are carried over from the voxel that was there; a caller writing
+			// a plain voxel would otherwise wipe the light out of one whose
+			// transparency did not change, and nothing would put it back
 			nv.set_skylight(old.get_skylight());
 		}
 
@@ -1062,19 +1055,125 @@ struct CInstance: public voxelworld::Instance
 				(m_section_region.getUpperCorner().getY() + 1) * section_h - 1;
 	}
 
-	void set_skylight_at(const pv::Vector3DInt32 &p, const VoxelInstance &v,
-			uint8_t level)
-	{
-		VoxelInstance nv = v;
-		nv.set_skylight(level);
-		set_voxel_impl(p, nv, true, true);
-	}
-
 	struct LightNode
 	{
 		pv::Vector3DInt32 p;
 		uint8_t level;
 	};
+
+	// The light update walks one voxel at a time and nearly every step stays
+	// inside the chunk the last one was in, so it keeps that chunk's buffer
+	// rather than going through get_voxel()/set_voxel() and their section
+	// lookup and bookkeeping for every neighbour. Only crossing a chunk
+	// boundary costs a lookup. Nothing is unloaded while this is in use, so
+	// the buffer stays put.
+	pv::Vector3DInt32 m_light_chunk_p;
+	ChunkBuffer *m_light_buf = nullptr;
+	pv::Vector3DInt16 m_light_section_p;
+	Section *m_light_section = nullptr;
+	// World position of the cached chunk's first voxel, so that a position
+	// inside it can be turned into a local one by subtraction. Dividing to
+	// find the chunk costs more than everything else the light update does.
+	pv::Vector3DInt32 m_light_chunk_lc;
+	// Indexed by voxel type id: 1 transmits light, 0 does not, 2 not asked yet
+	sv_<uint8_t> m_light_transmits;
+
+	ChunkBuffer* light_buffer(const pv::Vector3DInt32 &chunk_p)
+	{
+		if(m_light_buf && chunk_p == m_light_chunk_p)
+			return m_light_buf;
+		pv::Vector3DInt16 section_p =
+				container_coord16(chunk_p, m_section_size_chunks);
+		Section *section = m_light_section;
+		if(section == nullptr || section_p != m_light_section_p){
+			section = get_section(section_p);
+			if(section == nullptr)
+				return nullptr;
+			auto it = std::lower_bound(m_sections_with_loaded_buffers.begin(),
+					m_sections_with_loaded_buffers.end(), section,
+					std::greater<Section*>());
+			if(it == m_sections_with_loaded_buffers.end() || *it != section)
+				m_sections_with_loaded_buffers.insert(it, section);
+			m_light_section = section;
+			m_light_section_p = section_p;
+		}
+		// Reached straight into rather than through get_buffer(), which reads
+		// the clock to timestamp the buffer on every call; the light update
+		// changes chunk often enough for that to be most of its time. Loading
+		// one that is not in memory still goes the long way.
+		ChunkBuffer &buf = section->chunk_buffers[section->get_chunk_i(chunk_p)];
+		if(!buf.volume){
+			if(!section->get_buffer(chunk_p, m_server,
+					&m_total_buffers_loaded).volume)
+				return nullptr;
+		}
+		m_light_chunk_p = chunk_p;
+		m_light_chunk_lc = pv::Vector3DInt32(
+				chunk_p.getX() * m_chunk_size_voxels.getX(),
+				chunk_p.getY() * m_chunk_size_voxels.getY(),
+				chunk_p.getZ() * m_chunk_size_voxels.getZ());
+		m_light_buf = &buf;
+		return m_light_buf;
+	}
+
+	pv::Vector3DInt32 light_local_p(const pv::Vector3DInt32 &p,
+			const pv::Vector3DInt32 &chunk_p)
+	{
+		return pv::Vector3DInt32(
+				p.getX() - chunk_p.getX() * m_chunk_size_voxels.getX(),
+				p.getY() - chunk_p.getY() * m_chunk_size_voxels.getY(),
+				p.getZ() - chunk_p.getZ() * m_chunk_size_voxels.getZ());
+	}
+
+	VoxelInstance light_get(const pv::Vector3DInt32 &p)
+	{
+		pv::Vector3DInt32 chunk_p = container_coord(p, m_chunk_size_voxels);
+		ChunkBuffer *buf = light_buffer(chunk_p);
+		if(buf == nullptr)
+			return VoxelInstance(interface::VOXELTYPEID_UNDEFINED);
+		return buf->volume->getVoxelAt(light_local_p(p, chunk_p));
+	}
+
+	// Give the voxels that block light the brightest light next to them, by
+	// pushing each new light value into the blocking neighbours of the voxel
+	// that got it. Only ever raises one, so it is right on its own as long as
+	// no light went away; update_skylight() recomputes the few that did.
+	void light_bleed_into_blockers(const pv::Vector3DInt32 &p, uint8_t level)
+	{
+		for(size_t k = 0; k < 6; k++){
+			pv::Vector3DInt32 n(p.getX() + LIGHT_OFF[k][0],
+					p.getY() + LIGHT_OFF[k][1], p.getZ() + LIGHT_OFF[k][2]);
+			VoxelInstance nv = light_get(n);
+			if(transmits_light(nv) || nv.get_skylight() >= level)
+				continue;
+			light_set(n, nv, level);
+		}
+	}
+
+	void light_set(const pv::Vector3DInt32 &p, VoxelInstance v, uint8_t level)
+	{
+		pv::Vector3DInt32 chunk_p = container_coord(p, m_chunk_size_voxels);
+		ChunkBuffer *buf = light_buffer(chunk_p);
+		if(buf == nullptr)
+			return;
+		v.set_skylight(level);
+		buf->volume->setVoxelAt(light_local_p(p, chunk_p), v);
+		if(!buf->dirty){
+			buf->dirty = true;
+			m_total_buffers_dirty++;
+		}
+	}
+
+	bool transmits_light(const VoxelInstance &v)
+	{
+		uint32_t id = v.get_id();
+		if(id >= m_light_transmits.size())
+			m_light_transmits.resize(id + 1, 2);
+		uint8_t &t = m_light_transmits[id];
+		if(t == 2)
+			t = voxel_transmits_light(v) ? 1 : 0;
+		return t == 1;
+	}
 
 	// Bring the skylight up to date after the voxels in m_skylight_seeds
 	// changed. Light is taken out of everything the changed voxels were
@@ -1091,17 +1190,19 @@ struct CInstance: public voxelworld::Instance
 		if(!m_skylight_enabled || seeds.empty())
 			return;
 		auto t0 = std::chrono::steady_clock::now();
+		m_light_buf = nullptr;
+		m_light_section = nullptr;
 
 		std::vector<LightNode> unlight;
 		std::vector<LightNode> spread;
-		// Voxels that block light and are next to something that changed.
-		// Duplicates are left in; recomputing one twice costs a little and is
-		// simpler than keeping a set.
+		// Voxels that block light next to light that went away. Only these
+		// have to be worked out the slow way; everywhere else the light is
+		// pushed into them as it is written.
 		std::vector<pv::Vector3DInt32> blockers;
 
 		for(const SkylightSeed &seed : seeds){
-			VoxelInstance v = get_voxel(seed.p, true);
-			bool now_transparent = voxel_transmits_light(v);
+			VoxelInstance v = light_get(seed.p);
+			bool now_transparent = transmits_light(v);
 			if(seed.was_transparent && !now_transparent){
 				// It took its light with it
 				unlight.push_back(LightNode{seed.p, seed.old_level});
@@ -1109,19 +1210,19 @@ struct CInstance: public voxelworld::Instance
 			} else if(!seed.was_transparent && now_transparent){
 				// It is dark and has to be filled from around it
 				uint8_t l = is_below_open_sky(seed.p) ? SKYLIGHT_MAX : 0;
-				set_skylight_at(seed.p, v, l);
-				if(l > 0)
+				light_set(seed.p, v, l);
+				if(l > 0){
 					spread.push_back(LightNode{seed.p, l});
+					light_bleed_into_blockers(seed.p, l);
+				}
 				for(size_t k = 0; k < 6; k++){
 					pv::Vector3DInt32 n(
 							seed.p.getX() + LIGHT_OFF[k][0],
 							seed.p.getY() + LIGHT_OFF[k][1],
 							seed.p.getZ() + LIGHT_OFF[k][2]);
-					VoxelInstance nv = get_voxel(n, true);
-					if(!voxel_transmits_light(nv)){
-						blockers.push_back(n);
+					VoxelInstance nv = light_get(n);
+					if(!transmits_light(nv))
 						continue;
-					}
 					if(nv.get_skylight() > 0)
 						spread.push_back(LightNode{n, nv.get_skylight()});
 				}
@@ -1141,8 +1242,9 @@ struct CInstance: public voxelworld::Instance
 						node.p.getX() + LIGHT_OFF[k][0],
 						node.p.getY() + LIGHT_OFF[k][1],
 						node.p.getZ() + LIGHT_OFF[k][2]);
-				VoxelInstance nv = get_voxel(n, true);
-				if(!voxel_transmits_light(nv)){
+				VoxelInstance nv = light_get(n);
+				if(!transmits_light(nv)){
+					// It may have been holding the light that is going away
 					blockers.push_back(n);
 					continue;
 				}
@@ -1152,7 +1254,7 @@ struct CInstance: public voxelworld::Instance
 				bool lit_from_above = (k == LIGHT_DOWN &&
 						node.level == SKYLIGHT_MAX && nl == SKYLIGHT_MAX);
 				if(nl < node.level || lit_from_above){
-					set_skylight_at(n, nv, 0);
+					light_set(n, nv, 0);
 					unlight.push_back(LightNode{n, nl});
 				} else {
 					spread.push_back(LightNode{n, nl});
@@ -1169,8 +1271,8 @@ struct CInstance: public voxelworld::Instance
 			// was put on the list: a source can be unlit by another branch
 			// after it was queued, and spreading the level it used to have
 			// would put light back where it was just taken from.
-			VoxelInstance v = get_voxel(node.p, true);
-			if(!voxel_transmits_light(v))
+			VoxelInstance v = light_get(node.p);
+			if(!transmits_light(v))
 				continue;
 			node.level = v.get_skylight();
 			if(node.level == 0)
@@ -1180,41 +1282,55 @@ struct CInstance: public voxelworld::Instance
 						node.p.getX() + LIGHT_OFF[k][0],
 						node.p.getY() + LIGHT_OFF[k][1],
 						node.p.getZ() + LIGHT_OFF[k][2]);
-				VoxelInstance nv = get_voxel(n, true);
-				if(!voxel_transmits_light(nv)){
-					blockers.push_back(n);
+				VoxelInstance nv = light_get(n);
+				if(!transmits_light(nv)){
+					if(nv.get_skylight() < node.level)
+						light_set(n, nv, node.level);
 					continue;
 				}
 				uint8_t target = (k == LIGHT_DOWN &&
 						node.level == SKYLIGHT_MAX) ?
 						SKYLIGHT_MAX : node.level - 1;
 				if(target > nv.get_skylight()){
-					set_skylight_at(n, nv, target);
+					light_set(n, nv, target);
 					spread.push_back(LightNode{n, target});
 				}
 			}
 		}
 
-		// Give the voxels that block light the brightest light next to them
+		// Give the voxels that block light the brightest light next to them.
+		// The same one is reached from every transparent voxel around it, so
+		// this is mostly duplicates by now and recomputing each of them costs
+		// seven voxel reads.
+		auto before = [](const pv::Vector3DInt32 &a, const pv::Vector3DInt32 &b){
+			if(a.getX() != b.getX()) return a.getX() < b.getX();
+			if(a.getY() != b.getY()) return a.getY() < b.getY();
+			return a.getZ() < b.getZ();
+		};
+		std::sort(blockers.begin(), blockers.end(), before);
+		blockers.erase(std::unique(blockers.begin(), blockers.end()),
+				blockers.end());
+		size_t n_blockers = blockers.size();
 		for(const pv::Vector3DInt32 &p : blockers){
-			VoxelInstance v = get_voxel(p, true);
-			if(voxel_transmits_light(v))
+			VoxelInstance v = light_get(p);
+			if(transmits_light(v))
 				continue;
 			uint8_t best = 0;
 			for(size_t k = 0; k < 6; k++){
-				VoxelInstance nv = get_voxel(pv::Vector3DInt32(
+				VoxelInstance nv = light_get(pv::Vector3DInt32(
 						p.getX() + LIGHT_OFF[k][0],
 						p.getY() + LIGHT_OFF[k][1],
-						p.getZ() + LIGHT_OFF[k][2]), true);
-				if(voxel_transmits_light(nv) && nv.get_skylight() > best)
+						p.getZ() + LIGHT_OFF[k][2]));
+				if(transmits_light(nv) && nv.get_skylight() > best)
 					best = nv.get_skylight();
 			}
 			if(v.get_skylight() != best)
-				set_skylight_at(p, v, best);
+				light_set(p, v, best);
 		}
 
-		log_v(MODULE, "update_skylight(): %zu seeds, %zu unlit, %zu spread "
-				"in %i ms", seeds.size(), unlight.size(), spread.size(),
+		log_v(MODULE, "update_skylight(): %zu seeds, %zu unlit, %zu spread, "
+				"%zu blockers in %i ms", seeds.size(), unlight.size(),
+				spread.size(), n_blockers,
 				(int)std::chrono::duration_cast<std::chrono::milliseconds>(
 				std::chrono::steady_clock::now() - t0).count());
 	}

--- a/doc/client_commands.txt
+++ b/doc/client_commands.txt
@@ -11,6 +11,9 @@ exits after the sequence finishes (exit status 1 if a command fails).
     $ bin/buildat_client -c @commands.txt
     $ bin/buildat_client -s localhost -c @commands.txt
 
+-w WxH runs windowed at a fixed size without changing the size the client
+remembers between runs. Use it for anything that compares images between runs.
+
 @path reads the commands from a file. Empty lines and lines starting with # are
 ignored.
 

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -75,8 +75,9 @@ out and the two can be alternated for as long as anyone wants to watch them.
 
 Relighting is voxelworld's, not this game's: it is turned on with
 set_skylight_enabled(true) and from then on every set_voxel keeps the light up
-to date, generation included. An edit costs 2-3 ms here, and what it costs
-depends on how far the light moves rather than on how big the world is.
+to date, generation included. An edit costs well under a millisecond
+here, and what it costs depends on how far the light moves rather than on how
+big the world is. Lighting the whole section at generation costs 40 ms.
 
 V (or the last HUD button) checks that: it runs a skylight flood fill from
 scratch over the whole scene and compares it voxel by voxel against what

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -56,6 +56,24 @@ keys 1, 2 and 3:
 Tab (or the top HUD button) toggles free move: WASD on the horizontal plane
 whatever the camera is pitched at, Space up, Shift down, mouse to look.
 
+Editing
+-------
+
+In free move, left mouse digs the pointed voxel and right mouse places rock
+next to it. P and O (or the last two HUD buttons) make the two fixed edits used
+for comparing images: P digs a 3x3x3 pit into the ground beside the cave mouth,
+and O hangs a 5x2x5 slab above both of them. Both are placed relative to the
+cave mouth the generator chose, on the side the benchmark cameras look from,
+and the slab hangs high enough that it does not sit in front of the mouth in
+benchmark 2.
+
+Every edit relights the whole scene: the skylight flood fill is run again over
+all of it and only the voxels whose skylight actually changed are written back,
+so only the chunks the light really moved in are remeshed. That costs about
+130 ms for this 64^3 scene, which is fine for one section and would not be for
+a streaming world; an incremental relight, unlighting outwards from the changed
+voxels and refilling, is what that would need.
+
 Running
 -------
 
@@ -65,7 +83,13 @@ Running
 check.txt visits all three benchmarks and screenshots each, for comparing a
 rendering change against the previous run:
 
-    $ bin/buildat_client -s localhost -c @../games/voxel_lighting/check.txt
+    $ bin/buildat_client -s localhost -w 1600x900 \
+            -c @../games/voxel_lighting/check.txt
+
+-w gives the run a fixed window size without changing the remembered one, so
+the images come out the same size whatever the window was left at last time.
+It also shoots both benchmark edits, so a run is: three images of the scene as
+generated, then the same views after the pit and after the slab.
 
 NOTE: the server reads client_lua and client_data once at startup, so restart
 it after editing init.lua or the client will be served the previous version.

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -61,11 +61,17 @@ Editing
 
 In free move, left mouse digs the pointed voxel and right mouse places rock
 next to it. P and O (or the last two HUD buttons) make the two fixed edits used
-for comparing images: P digs a 3x3x3 pit into the ground beside the cave mouth,
-and O hangs a 5x2x5 slab above both of them. Both are placed relative to the
-cave mouth the generator chose, on the side the benchmark cameras look from,
-and the slab hangs high enough that it does not sit in front of the mouth in
-benchmark 2.
+for comparing images.
+
+P digs a 3x3 shaft straight up out of the cave to the open air, starting far
+enough in that the skylight there was 0. That is the strong test: a whole part
+of the scene that had no skylight at all has to come up to daylight, and
+benchmark 3 goes from near-black rock to a lit cave.
+
+O hangs a 5x2x5 slab over the cave mouth, high enough that it does not sit in
+front of the mouth in benchmark 2. It takes light back out of the entrance, but
+note that after the shaft is dug the cave is lit mostly through the shaft, so
+this second step reads much more weakly than it did on its own.
 
 Every edit relights the whole scene: the skylight flood fill is run again over
 all of it and only the voxels whose skylight actually changed are written back,
@@ -88,8 +94,8 @@ rendering change against the previous run:
 
 -w gives the run a fixed window size without changing the remembered one, so
 the images come out the same size whatever the window was left at last time.
-It also shoots both benchmark edits, so a run is: three images of the scene as
-generated, then the same views after the pit and after the slab.
+It also shoots both benchmark edits, so a run is: all three views of the scene
+as generated, then the same three after the shaft and after the slab.
 
 NOTE: the server reads client_lua and client_data once at startup, so restart
 it after editing init.lua or the client will be served the previous version.

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -70,15 +70,20 @@ benchmark 3 goes from near-black rock to a lit cave.
 
 O caps the shaft with a 5x2x5 slab filling the two air voxels above the ground,
 which takes back the light the shaft let in: benchmark 3 returns to the dark it
-started at. The two edits change a similar number of voxels in opposite
-directions, so they check the relight both ways.
+started at. The shaft reaches through the cap, so digging again cuts it back
+out and the two can be alternated for as long as anyone wants to watch them.
 
-Every edit relights the whole scene: the skylight flood fill is run again over
-all of it and only the voxels whose skylight actually changed are written back,
-so only the chunks the light really moved in are remeshed. That costs about
-130 ms for this 64^3 scene, which is fine for one section and would not be for
-a streaming world; an incremental relight, unlighting outwards from the changed
-voxels and refilling, is what that would need.
+Relighting is voxelworld's, not this game's: it is turned on with
+set_skylight_enabled(true) and from then on every set_voxel keeps the light up
+to date, generation included. An edit costs 2-3 ms here, and what it costs
+depends on how far the light moves rather than on how big the world is.
+
+V (or the last HUD button) checks that: it runs a skylight flood fill from
+scratch over the whole scene and compares it voxel by voxel against what
+voxelworld stored, logging either "skylight verify: ok" or the number of voxels
+that differ and the first one. check.txt runs it after generation and after
+every edit, so a run says outright whether the incremental relight got the same
+answer as doing it all again.
 
 Running
 -------

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -68,10 +68,10 @@ enough in that the skylight there was 0. That is the strong test: a whole part
 of the scene that had no skylight at all has to come up to daylight, and
 benchmark 3 goes from near-black rock to a lit cave.
 
-O hangs a 5x2x5 slab over the cave mouth, high enough that it does not sit in
-front of the mouth in benchmark 2. It takes light back out of the entrance, but
-note that after the shaft is dug the cave is lit mostly through the shaft, so
-this second step reads much more weakly than it did on its own.
+O caps the shaft with a 5x2x5 slab filling the two air voxels above the ground,
+which takes back the light the shaft let in: benchmark 3 returns to the dark it
+started at. The two edits change a similar number of voxels in opposite
+directions, so they check the relight both ways.
 
 Every edit relights the whole scene: the skylight flood fill is run again over
 all of it and only the voxels whose skylight actually changed are written back,

--- a/games/voxel_lighting/check.txt
+++ b/games/voxel_lighting/check.txt
@@ -23,6 +23,8 @@ screenshot ../tmp/voxel_lighting_check/3_inside_cave.png
 # mouth. All three views are shot after each, so each edit can be followed as a
 # sequence of three images. View 3 is the telling one for the shaft: the part of
 # the cave it opens up had no skylight at all before.
+keypress V
+delay 1500
 keypress P
 delay 1500
 keypress 1
@@ -34,6 +36,8 @@ screenshot ../tmp/voxel_lighting_check/5_shaft_cave_mouth.png
 keypress 3
 delay 500
 screenshot ../tmp/voxel_lighting_check/6_shaft_inside_cave.png
+keypress V
+delay 1500
 keypress O
 delay 1500
 keypress 1
@@ -45,3 +49,14 @@ screenshot ../tmp/voxel_lighting_check/8_slab_cave_mouth.png
 keypress 3
 delay 500
 screenshot ../tmp/voxel_lighting_check/9_slab_inside_cave.png
+keypress V
+delay 1500
+# Dig the shaft a second time. It reaches through the cap, so this cuts the cap
+# back out and the cave lights up again; the scene can be cycled like this.
+keypress P
+delay 1500
+keypress V
+delay 1500
+keypress 3
+delay 500
+screenshot ../tmp/voxel_lighting_check/10_recycled_inside_cave.png

--- a/games/voxel_lighting/check.txt
+++ b/games/voxel_lighting/check.txt
@@ -1,5 +1,9 @@
 # Client command sequence for a visual check. Run from Build/:
-#   bin/buildat_client -s localhost -c @../games/voxel_lighting/check.txt
+#   bin/buildat_client -s localhost -w 1600x900 \
+#           -c @../games/voxel_lighting/check.txt
+#
+# -w fixes the window size for the run without touching the remembered one, so
+# the images are the same size whatever the window was left at last time.
 # See doc/client_commands.txt.
 #
 # The benchmark cameras are keys 1/2/3, so nothing here depends on timing a
@@ -14,3 +18,26 @@ screenshot ../tmp/voxel_lighting_check/2_cave_mouth.png
 keypress 3
 delay 500
 screenshot ../tmp/voxel_lighting_check/3_inside_cave.png
+
+# Relight on edit: dig the pit next to the cave mouth, then hang the slab over
+# it. Views 1 and 2 are shot after each, so the two edits can be followed as a
+# sequence of three images each.
+keypress P
+delay 1500
+keypress 1
+delay 500
+screenshot ../tmp/voxel_lighting_check/4_pit_overview.png
+keypress 2
+delay 500
+screenshot ../tmp/voxel_lighting_check/5_pit_cave_mouth.png
+keypress O
+delay 1500
+keypress 1
+delay 500
+screenshot ../tmp/voxel_lighting_check/6_slab_overview.png
+keypress 2
+delay 500
+screenshot ../tmp/voxel_lighting_check/7_slab_cave_mouth.png
+keypress 3
+delay 500
+screenshot ../tmp/voxel_lighting_check/8_slab_inside_cave.png

--- a/games/voxel_lighting/check.txt
+++ b/games/voxel_lighting/check.txt
@@ -19,25 +19,29 @@ keypress 3
 delay 500
 screenshot ../tmp/voxel_lighting_check/3_inside_cave.png
 
-# Relight on edit: dig the pit next to the cave mouth, then hang the slab over
-# it. Views 1 and 2 are shot after each, so the two edits can be followed as a
-# sequence of three images each.
+# Relight on edit: dig the shaft up out of the cave, then hang the slab over the
+# mouth. All three views are shot after each, so each edit can be followed as a
+# sequence of three images. View 3 is the telling one for the shaft: the part of
+# the cave it opens up had no skylight at all before.
 keypress P
 delay 1500
 keypress 1
 delay 500
-screenshot ../tmp/voxel_lighting_check/4_pit_overview.png
+screenshot ../tmp/voxel_lighting_check/4_shaft_overview.png
 keypress 2
 delay 500
-screenshot ../tmp/voxel_lighting_check/5_pit_cave_mouth.png
+screenshot ../tmp/voxel_lighting_check/5_shaft_cave_mouth.png
+keypress 3
+delay 500
+screenshot ../tmp/voxel_lighting_check/6_shaft_inside_cave.png
 keypress O
 delay 1500
 keypress 1
 delay 500
-screenshot ../tmp/voxel_lighting_check/6_slab_overview.png
+screenshot ../tmp/voxel_lighting_check/7_slab_overview.png
 keypress 2
 delay 500
-screenshot ../tmp/voxel_lighting_check/7_slab_cave_mouth.png
+screenshot ../tmp/voxel_lighting_check/8_slab_cave_mouth.png
 keypress 3
 delay 500
-screenshot ../tmp/voxel_lighting_check/8_slab_inside_cave.png
+screenshot ../tmp/voxel_lighting_check/9_slab_inside_cave.png

--- a/games/voxel_lighting/main/client_lua/init.lua
+++ b/games/voxel_lighting/main/client_lua/init.lua
@@ -339,8 +339,8 @@ do
 	add_button("1 Overview", function() go_to_benchmark(1) end)
 	add_button("2 Cave mouth", function() go_to_benchmark(2) end)
 	add_button("3 Inside cave", function() go_to_benchmark(3) end)
-	add_button("Dig pit (P)", function()
-		buildat.send_packet("main:bench_pit", "")
+	add_button("Dig shaft (P)", function()
+		buildat.send_packet("main:bench_shaft", "")
 	end)
 	add_button("Place slab (O)", function()
 		buildat.send_packet("main:bench_slab", "")
@@ -360,7 +360,7 @@ magic.SubscribeToEvent("KeyDown", function(event_type, event_data)
 	elseif key == magic.KEY_3 then
 		go_to_benchmark(3)
 	elseif key == magic.KEY_P then
-		buildat.send_packet("main:bench_pit", "")
+		buildat.send_packet("main:bench_shaft", "")
 	elseif key == magic.KEY_O then
 		buildat.send_packet("main:bench_slab", "")
 	elseif key == magic.KEY_ESCAPE then
@@ -412,5 +412,5 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 end)
 
 log:info("voxel_lighting client ready; Tab = free move, 1/2/3 = benchmarks, "..
-		"P/O = benchmark pit/slab")
+		"P/O = benchmark shaft/slab")
 -- vim: set noet ts=4 sw=4:

--- a/games/voxel_lighting/main/client_lua/init.lua
+++ b/games/voxel_lighting/main/client_lua/init.lua
@@ -2,6 +2,7 @@
 -- http://www.apache.org/licenses/LICENSE-2.0
 -- Copyright 2026 Perttu Ahola <celeron55@gmail.com>
 local log = buildat.Logger("voxel_lighting")
+local cereal = require("buildat/extension/cereal")
 local magic = require("buildat/extension/urho3d")
 local replicate = require("buildat/extension/replicate")
 local voxelworld = require("buildat/module/voxelworld")
@@ -203,6 +204,110 @@ buildat.sub_packet("main:cave", function(data)
 			"%.2f); benchmarks 2 and 3 ready", mx, my, mz, dx, dy, dz))
 end)
 
+-- Voxel pointing and digging, so the relighting can be poked at by hand. Only
+-- active in free move mode; the benchmark cameras must not be disturbed.
+-- The highlight is a thin outline drawn on the +Y face of a unit cube and
+-- rotated onto whichever face is being pointed at.
+local pointed_voxel_p = nil
+local pointed_voxel_p_above = nil
+local pointed_node = scene:CreateChild("PointedVoxel")
+do
+	local g = pointed_node:CreateComponent("CustomGeometry")
+	g:BeginGeometry(0, magic.TRIANGLE_LIST)
+	g:SetNumGeometries(1)
+	local c = magic.Color(0.12, 0.36, 0.12)
+	local function define_face(lc, uc)
+		local function v(x, y, z)
+			g:DefineVertex(magic.Vector3(x, y, z))
+			g:DefineColor(c)
+		end
+		v(lc.x, uc.y, uc.z) v(uc.x, uc.y, uc.z) v(uc.x, uc.y, lc.z)
+		v(uc.x, uc.y, lc.z) v(lc.x, uc.y, lc.z) v(lc.x, uc.y, uc.z)
+	end
+	local d = 0.502
+	local d2 = 1.0 / 16
+	define_face(magic.Vector3(-d, d, d-d2), magic.Vector3(d, d, d))
+	define_face(magic.Vector3(-d, d, -d), magic.Vector3(d, d, -d+d2))
+	define_face(magic.Vector3(d-d2, d, -d+d2), magic.Vector3(d, d, d-d2))
+	define_face(magic.Vector3(-d, d, -d+d2), magic.Vector3(-d+d2, d, d-d2))
+	g:Commit()
+	local m = magic.Material.new()
+	m:SetTechnique(0, magic.cache:GetResource("Technique",
+			"Techniques/NoTextureVColMultiply.xml"))
+	g:SetMaterial(0, m)
+	pointed_node.enabled = false
+end
+
+local DIG_REACH = 8
+
+-- Returns nil, or the pointed voxel and the empty one just before it
+local function find_pointed_voxel()
+	local d_per_step = 0.1
+	local p0 = buildat.Vector3(camera_node.worldPosition)
+	local dir = buildat.Vector3(camera_node.worldDirection)
+	local last_p = nil
+	for i = 1, math.floor(DIG_REACH / d_per_step) do
+		local p = (p0 + dir * i * d_per_step):round()
+		if p ~= last_p then
+			local v = voxelworld.get_static_voxel(p)
+			-- 0 is "not loaded", 1 is air
+			if v.id ~= 1 and v.id ~= 0 then
+				return p, last_p
+			end
+			last_p = p
+		end
+	end
+	return nil
+end
+
+local function send_voxel_p(name, p)
+	buildat.send_packet(name, cereal.binary_output({
+		p = {
+			x = math.floor(p.x+0.5),
+			y = math.floor(p.y+0.5),
+			z = math.floor(p.z+0.5),
+		},
+	}, {"object",
+		{"p", {"object",
+			{"x", "int32_t"},
+			{"y", "int32_t"},
+			{"z", "int32_t"},
+		}},
+	}))
+end
+
+local function update_pointed_voxel()
+	local p, p_above = find_pointed_voxel()
+	pointed_voxel_p = p
+	pointed_voxel_p_above = p_above
+	if not (p and p_above) then
+		pointed_node.enabled = false
+		return
+	end
+	pointed_node.position = magic.Vector3.from_buildat(p)
+	local d = p_above - p
+	if d.x > 0 then pointed_node.rotation = magic.Quaternion(90, 0, -90)
+	elseif d.x < 0 then pointed_node.rotation = magic.Quaternion(90, 0, 90)
+	elseif d.y > 0 then pointed_node.rotation = magic.Quaternion(0, 0, 0)
+	elseif d.y < 0 then pointed_node.rotation = magic.Quaternion(0, 0, -180)
+	elseif d.z > 0 then pointed_node.rotation = magic.Quaternion(90, 0, 0)
+	elseif d.z < 0 then pointed_node.rotation = magic.Quaternion(-90, 0, 0)
+	end
+	pointed_node.enabled = true
+end
+
+magic.SubscribeToEvent("MouseButtonDown", function(event_type, event_data)
+	if not free_look then
+		return
+	end
+	local button = event_data:GetInt("Button")
+	if button == magic.MOUSEB_LEFT and pointed_voxel_p then
+		send_voxel_p("main:dig_voxel", pointed_voxel_p)
+	elseif button == magic.MOUSEB_RIGHT and pointed_voxel_p_above then
+		send_voxel_p("main:place_voxel", pointed_voxel_p_above)
+	end
+end)
+
 -- HUD, so the scene can be inspected without remembering the keys
 do
 	local ui_root = magic.ui.root
@@ -234,6 +339,12 @@ do
 	add_button("1 Overview", function() go_to_benchmark(1) end)
 	add_button("2 Cave mouth", function() go_to_benchmark(2) end)
 	add_button("3 Inside cave", function() go_to_benchmark(3) end)
+	add_button("Dig pit (P)", function()
+		buildat.send_packet("main:bench_pit", "")
+	end)
+	add_button("Place slab (O)", function()
+		buildat.send_packet("main:bench_slab", "")
+	end)
 
 	magic.ui:SetFocusElement(nil)
 end
@@ -248,6 +359,10 @@ magic.SubscribeToEvent("KeyDown", function(event_type, event_data)
 		go_to_benchmark(2)
 	elseif key == magic.KEY_3 then
 		go_to_benchmark(3)
+	elseif key == magic.KEY_P then
+		buildat.send_packet("main:bench_pit", "")
+	elseif key == magic.KEY_O then
+		buildat.send_packet("main:bench_slab", "")
 	elseif key == magic.KEY_ESCAPE then
 		if free_look then
 			set_free_look(false)
@@ -257,8 +372,10 @@ end)
 
 magic.SubscribeToEvent("Update", function(event_type, event_data)
 	if not free_look then
+		pointed_node.enabled = false
 		return
 	end
+	update_pointed_voxel()
 	local dt = event_data:GetFloat("TimeStep")
 
 	local dmouse = magic.input:GetMouseMove()
@@ -294,5 +411,6 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 	apply_angles(camera_node, yaw, pitch)
 end)
 
-log:info("voxel_lighting client ready; Tab = free move, 1/2/3 = benchmarks")
+log:info("voxel_lighting client ready; Tab = free move, 1/2/3 = benchmarks, "..
+		"P/O = benchmark pit/slab")
 -- vim: set noet ts=4 sw=4:

--- a/games/voxel_lighting/main/client_lua/init.lua
+++ b/games/voxel_lighting/main/client_lua/init.lua
@@ -342,7 +342,7 @@ do
 	add_button("Dig shaft (P)", function()
 		buildat.send_packet("main:bench_shaft", "")
 	end)
-	add_button("Place slab (O)", function()
+	add_button("Cap shaft (O)", function()
 		buildat.send_packet("main:bench_slab", "")
 	end)
 
@@ -412,5 +412,5 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 end)
 
 log:info("voxel_lighting client ready; Tab = free move, 1/2/3 = benchmarks, "..
-		"P/O = benchmark shaft/slab")
+		"P/O = benchmark shaft dig/cap")
 -- vim: set noet ts=4 sw=4:

--- a/games/voxel_lighting/main/client_lua/init.lua
+++ b/games/voxel_lighting/main/client_lua/init.lua
@@ -345,6 +345,9 @@ do
 	add_button("Cap shaft (O)", function()
 		buildat.send_packet("main:bench_slab", "")
 	end)
+	add_button("Verify light (V)", function()
+		buildat.send_packet("main:verify_skylight", "")
+	end)
 
 	magic.ui:SetFocusElement(nil)
 end
@@ -363,6 +366,8 @@ magic.SubscribeToEvent("KeyDown", function(event_type, event_data)
 		buildat.send_packet("main:bench_shaft", "")
 	elseif key == magic.KEY_O then
 		buildat.send_packet("main:bench_slab", "")
+	elseif key == magic.KEY_V then
+		buildat.send_packet("main:verify_skylight", "")
 	elseif key == magic.KEY_ESCAPE then
 		if free_look then
 			set_free_look(false)
@@ -412,5 +417,5 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 end)
 
 log:info("voxel_lighting client ready; Tab = free move, 1/2/3 = benchmarks, "..
-		"P/O = benchmark shaft dig/cap")
+		"P/O = benchmark shaft dig/cap, V = verify light")
 -- vim: set noet ts=4 sw=4:

--- a/games/voxel_lighting/main/main.cpp
+++ b/games/voxel_lighting/main/main.cpp
@@ -12,8 +12,13 @@
 #include "interface/event.h"
 #include "interface/voxel.h"
 #include "interface/noise.h"
+#include "interface/polyvox_std.h"
+#include "interface/polyvox_cereal.h"
+#include <cereal/archives/portable_binary.hpp>
 #include <cmath>
 #include <cstdio>
+#include <sstream>
+#include <chrono>
 #define MODULE "main"
 
 namespace magic = Urho3D;
@@ -53,6 +58,100 @@ static const float CAVE_LENGTH = 62.0f;
 // Positive is clockwise seen from above.
 static const float CAVE_YAW_DEGREES = 20.0f;
 
+// The benchmark edits: a cube dug out of the ground next to the cave mouth,
+// and a slab hung over both of them. Sized so that the change in skylight is
+// obvious in benchmark views 1 and 2 without the slab filling the frame.
+static const int BENCH_PIT_SIZE = 3;
+static const int BENCH_SLAB_W = 5;
+static const int BENCH_SLAB_H = 2;
+
+static const uint8_t AIR_ID = 1;
+
+static inline size_t sky_idx(int x, int y, int z, int W, int D)
+{
+	return ((size_t)y * D + z) * W + x;
+}
+
+// Skylight over a W*H*D block of voxel ids. Sunlight falls straight down
+// through air at full strength and stops at the first solid voxel; from there
+// it spreads sideways and downwards losing one step per voxel, which is what
+// makes a cave get darker the deeper it goes while a hollow just under the
+// surface stays bright.
+//
+// sky is the light in air voxels. solid_sky is the brightest skylight next to
+// a solid voxel: the mesher normally reads the air voxel in front of a face,
+// but at a chunk edge that voxel is outside the chunk it is meshing, and it
+// falls back to this.
+static void compute_skylight(const sv_<uint8_t> &ids, int W, int H, int D,
+		sv_<uint8_t> &sky, sv_<uint8_t> &solid_sky)
+{
+	const uint8_t SKY_MAX = VoxelInstance::SKYLIGHT_MAX;
+	static const int off[6][3] = {
+		{1,0,0}, {-1,0,0}, {0,1,0}, {0,-1,0}, {0,0,1}, {0,0,-1}
+	};
+	auto inside = [&](int x, int y, int z){
+		return x >= 0 && x < W && y >= 0 && y < H && z >= 0 && z < D;
+	};
+
+	sky.assign((size_t)W * H * D, 0);
+	solid_sky.assign((size_t)W * H * D, 0);
+
+	for(int z = 0; z < D; z++){
+		for(int x = 0; x < W; x++){
+			uint8_t l = SKY_MAX;
+			for(int y = H - 1; y >= 0; y--){
+				size_t i = sky_idx(x, y, z, W, D);
+				if(ids[i] != AIR_ID)
+					l = 0;
+				sky[i] = l;
+			}
+		}
+	}
+	// One pass per level, brightest first: a voxel written during the pass for
+	// level L is picked up by the pass for L-1, so this is a breadth-first
+	// spread without a queue.
+	for(int level = SKY_MAX; level >= 2; level--){
+		for(int y = 0; y < H; y++){
+		for(int z = 0; z < D; z++){
+		for(int x = 0; x < W; x++){
+			if(sky[sky_idx(x, y, z, W, D)] != level)
+				continue;
+			for(size_t k = 0; k < 6; k++){
+				int nx = x + off[k][0], ny = y + off[k][1];
+				int nz = z + off[k][2];
+				if(!inside(nx, ny, nz))
+					continue;
+				size_t ni = sky_idx(nx, ny, nz, W, D);
+				if(ids[ni] != AIR_ID || sky[ni] >= level - 1)
+					continue;
+				sky[ni] = level - 1;
+			}
+		}
+		}
+		}
+	}
+	for(int y = 0; y < H; y++){
+	for(int z = 0; z < D; z++){
+	for(int x = 0; x < W; x++){
+		size_t i = sky_idx(x, y, z, W, D);
+		if(ids[i] == AIR_ID)
+			continue;
+		uint8_t best = 0;
+		for(size_t k = 0; k < 6; k++){
+			int nx = x + off[k][0], ny = y + off[k][1];
+			int nz = z + off[k][2];
+			if(!inside(nx, ny, nz))
+				continue;
+			size_t ni = sky_idx(nx, ny, nz, W, D);
+			if(ids[ni] == AIR_ID && sky[ni] > best)
+				best = sky[ni];
+		}
+		solid_sky[i] = best;
+	}
+	}
+	}
+}
+
 struct Worldgen: public worldgen::GeneratorInterface
 {
 	// The client places its benchmark cameras relative to the cave, so it is
@@ -61,6 +160,12 @@ struct Worldgen: public worldgen::GeneratorInterface
 	bool cave_valid = false;
 	float cave_mouth[3] = {0, 0, 0};
 	float cave_dir[3] = {0, 0, 0};
+
+	// Where the benchmark edits go. Both sit on the +X +Z side of the cave
+	// mouth, which is the side both benchmark cameras look from, and the slab
+	// floats above the sight line rather than across it.
+	pv::Vector3DInt32 bench_pit_centre;   // BENCH_PIT_SIZE^3 dug out here
+	pv::Vector3DInt32 bench_slab_centre;  // BENCH_SLAB_W x 2 x BENCH_SLAB_W
 
 	void generate_section(interface::Server *server,
 			SceneReference scene_ref,
@@ -115,7 +220,7 @@ struct Worldgen: public worldgen::GeneratorInterface
 			const int W = uc.getX() - lc.getX() + 1;
 			const int H = uc.getY() - lc.getY() + 1;
 			const int D = uc.getZ() - lc.getZ() + 1;
-			const uint8_t AIR = 1;
+			const uint8_t AIR = AIR_ID;
 			sv_<uint8_t> ids((size_t)W * H * D, AIR);
 			auto idx = [&](int x, int y, int z) -> size_t {
 				return ((size_t)(y - lc.getY()) * D + (z - lc.getZ())) * W +
@@ -231,82 +336,32 @@ struct Worldgen: public worldgen::GeneratorInterface
 			cave_dir[2] = dz;
 			cave_valid = true;
 
+			// The pit breaks the ground next to the mouth; the slab hangs over
+			// both of them, so pressing the two buttons in order takes skylight
+			// away from the pit and out of the cave entrance.
+			auto clamp_xz = [&](int v, int lo, int hi){
+				return v < lo ? lo : (v > hi ? hi : v);
+			};
+			int pit_x = clamp_xz(mouth_x + 3, lc.getX() + 2, uc.getX() - 2);
+			int pit_z = clamp_xz(mouth_z + 3, lc.getZ() + 2, uc.getZ() - 2);
+			int slab_x = clamp_xz(mouth_x + 2, lc.getX() + 3, uc.getX() - 3);
+			int slab_z = clamp_xz(mouth_z + 2, lc.getZ() + 3, uc.getZ() - 3);
+			// surface_at() + 10 is the topmost solid voxel, so a pit centred
+			// one below it breaks the ground open instead of leaving a pocket
+			bench_pit_centre = pv::Vector3DInt32(pit_x,
+					(int)std::floor(surface_at(pit_x, pit_z)) + 9, pit_z);
+			// The slab hangs clear above the mouth rather than following the
+			// ground: benchmark camera 2 looks down at the mouth from the +X +Z
+			// side, and anything level with the mouth would sit in front of it.
+			bench_slab_centre = pv::Vector3DInt32(slab_x,
+					(int)std::floor(sy) + 6, slab_z);
+
 			log_v(MODULE, "Cave: mouth (%i, %.0f, %i), dir (%.2f, %.2f, %.2f), "
 					"%zu brush writes", mouth_x, sy, mouth_z, dx, dy, dz,
 					carved);
 
-			// Skylight. Sunlight falls straight down through air at full
-			// strength and stops at the first solid voxel; from there it
-			// spreads sideways and downwards losing one step per voxel, which
-			// is what makes a cave get darker the deeper it goes while a
-			// hollow just under the surface stays bright.
-			const uint8_t SKY_MAX = VoxelInstance::SKYLIGHT_MAX;
-			sv_<uint8_t> sky((size_t)W * H * D, 0);
-			for(int z = lc.getZ(); z <= uc.getZ(); z++){
-				for(int x = lc.getX(); x <= uc.getX(); x++){
-					uint8_t l = SKY_MAX;
-					for(int y = uc.getY(); y >= lc.getY(); y--){
-						size_t i = idx(x, y, z);
-						if(ids[i] != AIR)
-							l = 0;
-						sky[i] = l;
-					}
-				}
-			}
-			// One pass per level, brightest first: a voxel written during the
-			// pass for level L is picked up by the pass for L-1, so this is a
-			// breadth-first spread without a queue.
-			for(int level = SKY_MAX; level >= 2; level--){
-				for(int y = lc.getY(); y <= uc.getY(); y++){
-				for(int z = lc.getZ(); z <= uc.getZ(); z++){
-				for(int x = lc.getX(); x <= uc.getX(); x++){
-					if(sky[idx(x, y, z)] != level)
-						continue;
-					static const int off[6][3] = {
-						{1,0,0}, {-1,0,0}, {0,1,0}, {0,-1,0}, {0,0,1}, {0,0,-1}
-					};
-					for(size_t k = 0; k < 6; k++){
-						int nx = x + off[k][0], ny = y + off[k][1];
-						int nz = z + off[k][2];
-						if(!inside(nx, ny, nz))
-							continue;
-						size_t ni = idx(nx, ny, nz);
-						if(ids[ni] != AIR || sky[ni] >= level - 1)
-							continue;
-						sky[ni] = level - 1;
-					}
-				}
-				}
-				}
-			}
-			// Solid voxels keep the brightest skylight next to them. The
-			// mesher normally reads the air voxel in front of a face, but at a
-			// chunk edge that voxel is outside the chunk it is meshing, and it
-			// falls back to this.
-			sv_<uint8_t> solid_sky((size_t)W * H * D, 0);
-			for(int y = lc.getY(); y <= uc.getY(); y++){
-			for(int z = lc.getZ(); z <= uc.getZ(); z++){
-			for(int x = lc.getX(); x <= uc.getX(); x++){
-				size_t i = idx(x, y, z);
-				if(ids[i] == AIR)
-					continue;
-				static const int off[6][3] = {
-					{1,0,0}, {-1,0,0}, {0,1,0}, {0,-1,0}, {0,0,1}, {0,0,-1}
-				};
-				uint8_t best = 0;
-				for(size_t k = 0; k < 6; k++){
-					int nx = x + off[k][0], ny = y + off[k][1];
-					int nz = z + off[k][2];
-					if(!inside(nx, ny, nz))
-						continue;
-					size_t ni = idx(nx, ny, nz);
-					if(ids[ni] == AIR && sky[ni] > best)
-						best = sky[ni];
-				}
-				solid_sky[i] = best;
-			}
-			}
-			}
+			sv_<uint8_t> sky, solid_sky;
+			compute_skylight(ids, W, H, D, sky, solid_sky);
 
 			size_t dark_air = 0, lit_air = 0;
 			for(int y = lc.getY(); y <= uc.getY(); y++){
@@ -350,6 +405,14 @@ struct Module: public interface::Module
 		m_server->sub_event(this, Event::t("core:continue"));
 		m_server->sub_event(this, Event::t("client_file:files_transmitted"));
 		m_server->sub_event(this, Event::t("worldgen:queue_modified"));
+		m_server->sub_event(this, Event::t(
+				"network:packet_received/main:dig_voxel"));
+		m_server->sub_event(this, Event::t(
+				"network:packet_received/main:place_voxel"));
+		m_server->sub_event(this, Event::t(
+				"network:packet_received/main:bench_pit"));
+		m_server->sub_event(this, Event::t(
+				"network:packet_received/main:bench_slab"));
 	}
 
 	void event(const Event::Type &type, const Event::Private *p)
@@ -361,6 +424,14 @@ struct Module: public interface::Module
 				on_files_transmitted, client_file::FilesTransmitted)
 		EVENT_TYPEN("worldgen:queue_modified",
 				on_worldgen_queue_modified, worldgen::QueueModifiedEvent)
+		EVENT_TYPEN("network:packet_received/main:dig_voxel",
+				on_dig_voxel, network::Packet)
+		EVENT_TYPEN("network:packet_received/main:place_voxel",
+				on_place_voxel, network::Packet)
+		EVENT_TYPEN("network:packet_received/main:bench_pit",
+				on_bench_pit, network::Packet)
+		EVENT_TYPEN("network:packet_received/main:bench_slab",
+				on_bench_slab, network::Packet)
 	}
 
 	void add_voxel(interface::VoxelRegistry *reg, const ss_ &name,
@@ -467,6 +538,128 @@ struct Module: public interface::Module
 			if(m_worldgen && m_worldgen->cave_valid)
 				inetwork->send(event.recipient, "main:cave", cave_packet());
 		});
+	}
+
+	// Skylight is generated for the whole scene at once, and the scene is a
+	// single 64^3 section, so an edit is relit by simply doing that again over
+	// all of it. Only voxels whose skylight actually changed are written back,
+	// which keeps the number of chunks that have to be remeshed down to the
+	// ones the light really moved in.
+	void relight(voxelworld::Instance *world)
+	{
+		auto t0 = std::chrono::steady_clock::now();
+		pv::Region region = world->get_section_region_voxels(
+				pv::Vector3DInt16(0, 0, 0));
+		auto lc = region.getLowerCorner();
+		auto uc = region.getUpperCorner();
+		const int W = uc.getX() - lc.getX() + 1;
+		const int H = uc.getY() - lc.getY() + 1;
+		const int D = uc.getZ() - lc.getZ() + 1;
+
+		sv_<uint8_t> ids((size_t)W * H * D, AIR_ID);
+		for(int y = 0; y < H; y++)
+		for(int z = 0; z < D; z++)
+		for(int x = 0; x < W; x++){
+			VoxelInstance v = world->get_voxel(pv::Vector3DInt32(
+					lc.getX() + x, lc.getY() + y, lc.getZ() + z), true);
+			ids[sky_idx(x, y, z, W, D)] = (uint8_t)v.get_id();
+		}
+
+		sv_<uint8_t> sky, solid_sky;
+		compute_skylight(ids, W, H, D, sky, solid_sky);
+
+		size_t changed = 0;
+		for(int y = 0; y < H; y++)
+		for(int z = 0; z < D; z++)
+		for(int x = 0; x < W; x++){
+			size_t i = sky_idx(x, y, z, W, D);
+			uint8_t l = (ids[i] == AIR_ID) ? sky[i] : solid_sky[i];
+			pv::Vector3DInt32 p(lc.getX() + x, lc.getY() + y, lc.getZ() + z);
+			VoxelInstance v = world->get_voxel(p, true);
+			if(v.get_skylight() == l)
+				continue;
+			v.set_skylight(l);
+			world->set_voxel(p, v, true);
+			changed++;
+		}
+		log_v(MODULE, "relight(): %zu voxels changed skylight in %i ms",
+				changed, (int)std::chrono::duration_cast<
+						std::chrono::milliseconds>(
+						std::chrono::steady_clock::now() - t0).count());
+	}
+
+	void edit_voxel(const pv::Vector3DInt32 &p, uint32_t id)
+	{
+		voxelworld::access(m_server, m_main_scene,
+				[&](voxelworld::Instance *world)
+		{
+			world->set_voxel(p, VoxelInstance(id));
+			relight(world);
+		});
+	}
+
+	pv::Vector3DInt32 read_voxel_p(const network::Packet &packet)
+	{
+		pv::Vector3DInt32 p;
+		std::istringstream is(packet.data, std::ios::binary);
+		cereal::PortableBinaryInputArchive ar(is);
+		ar(p);
+		return p;
+	}
+
+	void on_dig_voxel(const network::Packet &packet)
+	{
+		pv::Vector3DInt32 p = read_voxel_p(packet);
+		log_v(MODULE, "C%i: dig " PV3I_FORMAT, packet.sender, PV3I_PARAMS(p));
+		edit_voxel(p, AIR_ID);
+	}
+
+	void on_place_voxel(const network::Packet &packet)
+	{
+		pv::Vector3DInt32 p = read_voxel_p(packet);
+		log_v(MODULE, "C%i: place " PV3I_FORMAT, packet.sender, PV3I_PARAMS(p));
+		edit_voxel(p, 2); // rock
+	}
+
+	// The two benchmark edits. Their positions come from worldgen so that they
+	// stay next to the cave mouth whatever the terrain noise does.
+	void bench_box(const pv::Vector3DInt32 &centre, int w, int h, int d,
+			uint32_t id)
+	{
+		if(!m_worldgen || !m_worldgen->cave_valid){
+			log_w(MODULE, "bench_box(): world is not generated yet");
+			return;
+		}
+		voxelworld::access(m_server, m_main_scene,
+				[&](voxelworld::Instance *world)
+		{
+			for(int y = -(h/2); y <= (h-1)/2; y++)
+			for(int z = -(d/2); z <= (d-1)/2; z++)
+			for(int x = -(w/2); x <= (w-1)/2; x++){
+				world->set_voxel(pv::Vector3DInt32(centre.getX() + x,
+						centre.getY() + y, centre.getZ() + z),
+						VoxelInstance(id), true);
+			}
+			relight(world);
+		});
+		log_v(MODULE, "bench_box(): %ix%ix%i id %i at " PV3I_FORMAT,
+				w, h, d, id, PV3I_PARAMS(centre));
+	}
+
+	void on_bench_pit(const network::Packet &packet)
+	{
+		(void)packet;
+		if(!m_worldgen) return;
+		bench_box(m_worldgen->bench_pit_centre, BENCH_PIT_SIZE, BENCH_PIT_SIZE,
+				BENCH_PIT_SIZE, AIR_ID);
+	}
+
+	void on_bench_slab(const network::Packet &packet)
+	{
+		(void)packet;
+		if(!m_worldgen) return;
+		bench_box(m_worldgen->bench_slab_centre, BENCH_SLAB_W, BENCH_SLAB_H,
+				BENCH_SLAB_W, 2); // rock
 	}
 
 	void on_worldgen_queue_modified(const worldgen::QueueModifiedEvent &event)

--- a/games/voxel_lighting/main/main.cpp
+++ b/games/voxel_lighting/main/main.cpp
@@ -58,10 +58,14 @@ static const float CAVE_LENGTH = 62.0f;
 // Positive is clockwise seen from above.
 static const float CAVE_YAW_DEGREES = 20.0f;
 
-// The benchmark edits: a cube dug out of the ground next to the cave mouth,
-// and a slab hung over both of them. Sized so that the change in skylight is
-// obvious in benchmark views 1 and 2 without the slab filling the frame.
-static const int BENCH_PIT_SIZE = 3;
+// The benchmark edits: a shaft dug straight up out of the cave to the open air,
+// and a slab hung over the cave mouth. The shaft starts this far along the cave
+// axis, which is deep enough that the skylight there is 0 before it is dug, so
+// what the relight has to do is bring a whole column of daylight into a part of
+// the scene that had none. It is also in front of benchmark camera 3, so the
+// change shows from inside the cave as well as from above.
+static const float BENCH_SHAFT_T = 20.0f;
+static const int BENCH_SHAFT_W = 3;
 static const int BENCH_SLAB_W = 5;
 static const int BENCH_SLAB_H = 2;
 
@@ -164,8 +168,9 @@ struct Worldgen: public worldgen::GeneratorInterface
 	// Where the benchmark edits go. Both sit on the +X +Z side of the cave
 	// mouth, which is the side both benchmark cameras look from, and the slab
 	// floats above the sight line rather than across it.
-	pv::Vector3DInt32 bench_pit_centre;   // BENCH_PIT_SIZE^3 dug out here
-	pv::Vector3DInt32 bench_slab_centre;  // BENCH_SLAB_W x 2 x BENCH_SLAB_W
+	pv::Vector3DInt32 bench_shaft_centre;  // BENCH_SHAFT_W^2 x bench_shaft_h
+	int bench_shaft_h = 0;
+	pv::Vector3DInt32 bench_slab_centre;   // BENCH_SLAB_W x 2 x BENCH_SLAB_W
 
 	void generate_section(interface::Server *server,
 			SceneReference scene_ref,
@@ -336,29 +341,38 @@ struct Worldgen: public worldgen::GeneratorInterface
 			cave_dir[2] = dz;
 			cave_valid = true;
 
-			// The pit breaks the ground next to the mouth; the slab hangs over
-			// both of them, so pressing the two buttons in order takes skylight
-			// away from the pit and out of the cave entrance.
+			// The shaft goes straight up out of the cave to the open air; the
+			// slab hangs over the mouth. Together they swap where the cave gets
+			// its light from, which is the thing the relight has to get right.
 			auto clamp_xz = [&](int v, int lo, int hi){
 				return v < lo ? lo : (v > hi ? hi : v);
 			};
-			int pit_x = clamp_xz(mouth_x + 3, lc.getX() + 2, uc.getX() - 2);
-			int pit_z = clamp_xz(mouth_z + 3, lc.getZ() + 2, uc.getZ() - 2);
+			int shaft_x = clamp_xz((int)std::floor(sx + dx * BENCH_SHAFT_T +
+					0.5f), lc.getX() + 2, uc.getX() - 2);
+			int shaft_z = clamp_xz((int)std::floor(sz + dz * BENCH_SHAFT_T +
+					0.5f), lc.getZ() + 2, uc.getZ() - 2);
+			int shaft_bottom = (int)std::floor(sy + dy * BENCH_SHAFT_T + 0.5f);
+			// surface_at() + 11 is the first air voxel above the ground, so
+			// this breaks the surface open rather than stopping under it
+			int shaft_top = (int)std::floor(
+					surface_at(shaft_x, shaft_z)) + 11;
+			if(shaft_top < shaft_bottom)
+				shaft_top = shaft_bottom;
+			bench_shaft_h = shaft_top - shaft_bottom + 1;
+			bench_shaft_centre = pv::Vector3DInt32(shaft_x,
+					(shaft_bottom + shaft_top) / 2, shaft_z);
+
 			int slab_x = clamp_xz(mouth_x + 2, lc.getX() + 3, uc.getX() - 3);
 			int slab_z = clamp_xz(mouth_z + 2, lc.getZ() + 3, uc.getZ() - 3);
-			// surface_at() + 10 is the topmost solid voxel, so a pit centred
-			// one below it breaks the ground open instead of leaving a pocket
-			bench_pit_centre = pv::Vector3DInt32(pit_x,
-					(int)std::floor(surface_at(pit_x, pit_z)) + 9, pit_z);
 			// The slab hangs clear above the mouth rather than following the
 			// ground: benchmark camera 2 looks down at the mouth from the +X +Z
 			// side, and anything level with the mouth would sit in front of it.
 			bench_slab_centre = pv::Vector3DInt32(slab_x,
 					(int)std::floor(sy) + 6, slab_z);
 
-			log_v(MODULE, "Cave: mouth (%i, %.0f, %i), dir (%.2f, %.2f, %.2f), "
-					"%zu brush writes", mouth_x, sy, mouth_z, dx, dy, dz,
-					carved);
+			log_v(MODULE, "Bench: shaft " PV3I_FORMAT " h %i, slab "
+					PV3I_FORMAT, PV3I_PARAMS(bench_shaft_centre),
+					bench_shaft_h, PV3I_PARAMS(bench_slab_centre));
 
 			sv_<uint8_t> sky, solid_sky;
 			compute_skylight(ids, W, H, D, sky, solid_sky);
@@ -410,7 +424,7 @@ struct Module: public interface::Module
 		m_server->sub_event(this, Event::t(
 				"network:packet_received/main:place_voxel"));
 		m_server->sub_event(this, Event::t(
-				"network:packet_received/main:bench_pit"));
+				"network:packet_received/main:bench_shaft"));
 		m_server->sub_event(this, Event::t(
 				"network:packet_received/main:bench_slab"));
 	}
@@ -428,8 +442,8 @@ struct Module: public interface::Module
 				on_dig_voxel, network::Packet)
 		EVENT_TYPEN("network:packet_received/main:place_voxel",
 				on_place_voxel, network::Packet)
-		EVENT_TYPEN("network:packet_received/main:bench_pit",
-				on_bench_pit, network::Packet)
+		EVENT_TYPEN("network:packet_received/main:bench_shaft",
+				on_bench_shaft, network::Packet)
 		EVENT_TYPEN("network:packet_received/main:bench_slab",
 				on_bench_slab, network::Packet)
 	}
@@ -646,12 +660,12 @@ struct Module: public interface::Module
 				w, h, d, id, PV3I_PARAMS(centre));
 	}
 
-	void on_bench_pit(const network::Packet &packet)
+	void on_bench_shaft(const network::Packet &packet)
 	{
 		(void)packet;
 		if(!m_worldgen) return;
-		bench_box(m_worldgen->bench_pit_centre, BENCH_PIT_SIZE, BENCH_PIT_SIZE,
-				BENCH_PIT_SIZE, AIR_ID);
+		bench_box(m_worldgen->bench_shaft_centre, BENCH_SHAFT_W,
+				m_worldgen->bench_shaft_h, BENCH_SHAFT_W, AIR_ID);
 	}
 
 	void on_bench_slab(const network::Packet &packet)

--- a/games/voxel_lighting/main/main.cpp
+++ b/games/voxel_lighting/main/main.cpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <cstdio>
 #include <sstream>
-#include <chrono>
 #define MODULE "main"
 
 namespace magic = Urho3D;
@@ -70,91 +69,6 @@ static const int BENCH_SLAB_W = 5;
 static const int BENCH_SLAB_H = 2;
 
 static const uint8_t AIR_ID = 1;
-
-static inline size_t sky_idx(int x, int y, int z, int W, int D)
-{
-	return ((size_t)y * D + z) * W + x;
-}
-
-// Skylight over a W*H*D block of voxel ids. Sunlight falls straight down
-// through air at full strength and stops at the first solid voxel; from there
-// it spreads sideways and downwards losing one step per voxel, which is what
-// makes a cave get darker the deeper it goes while a hollow just under the
-// surface stays bright.
-//
-// sky is the light in air voxels. solid_sky is the brightest skylight next to
-// a solid voxel: the mesher normally reads the air voxel in front of a face,
-// but at a chunk edge that voxel is outside the chunk it is meshing, and it
-// falls back to this.
-static void compute_skylight(const sv_<uint8_t> &ids, int W, int H, int D,
-		sv_<uint8_t> &sky, sv_<uint8_t> &solid_sky)
-{
-	const uint8_t SKY_MAX = VoxelInstance::SKYLIGHT_MAX;
-	static const int off[6][3] = {
-		{1,0,0}, {-1,0,0}, {0,1,0}, {0,-1,0}, {0,0,1}, {0,0,-1}
-	};
-	auto inside = [&](int x, int y, int z){
-		return x >= 0 && x < W && y >= 0 && y < H && z >= 0 && z < D;
-	};
-
-	sky.assign((size_t)W * H * D, 0);
-	solid_sky.assign((size_t)W * H * D, 0);
-
-	for(int z = 0; z < D; z++){
-		for(int x = 0; x < W; x++){
-			uint8_t l = SKY_MAX;
-			for(int y = H - 1; y >= 0; y--){
-				size_t i = sky_idx(x, y, z, W, D);
-				if(ids[i] != AIR_ID)
-					l = 0;
-				sky[i] = l;
-			}
-		}
-	}
-	// One pass per level, brightest first: a voxel written during the pass for
-	// level L is picked up by the pass for L-1, so this is a breadth-first
-	// spread without a queue.
-	for(int level = SKY_MAX; level >= 2; level--){
-		for(int y = 0; y < H; y++){
-		for(int z = 0; z < D; z++){
-		for(int x = 0; x < W; x++){
-			if(sky[sky_idx(x, y, z, W, D)] != level)
-				continue;
-			for(size_t k = 0; k < 6; k++){
-				int nx = x + off[k][0], ny = y + off[k][1];
-				int nz = z + off[k][2];
-				if(!inside(nx, ny, nz))
-					continue;
-				size_t ni = sky_idx(nx, ny, nz, W, D);
-				if(ids[ni] != AIR_ID || sky[ni] >= level - 1)
-					continue;
-				sky[ni] = level - 1;
-			}
-		}
-		}
-		}
-	}
-	for(int y = 0; y < H; y++){
-	for(int z = 0; z < D; z++){
-	for(int x = 0; x < W; x++){
-		size_t i = sky_idx(x, y, z, W, D);
-		if(ids[i] == AIR_ID)
-			continue;
-		uint8_t best = 0;
-		for(size_t k = 0; k < 6; k++){
-			int nx = x + off[k][0], ny = y + off[k][1];
-			int nz = z + off[k][2];
-			if(!inside(nx, ny, nz))
-				continue;
-			size_t ni = sky_idx(nx, ny, nz, W, D);
-			if(ids[ni] == AIR_ID && sky[ni] > best)
-				best = sky[ni];
-		}
-		solid_sky[i] = best;
-	}
-	}
-	}
-}
 
 struct Worldgen: public worldgen::GeneratorInterface
 {
@@ -353,18 +267,24 @@ struct Worldgen: public worldgen::GeneratorInterface
 					0.5f), lc.getZ() + 2, uc.getZ() - 2);
 			int shaft_bottom = (int)std::floor(sy + dy * BENCH_SHAFT_T + 0.5f);
 			// surface_at() + 11 is the first air voxel above the ground, so
-			// this breaks the surface open rather than stopping under it
+			// this breaks the surface open rather than stopping under it. The
+			// shaft goes two voxels past that, which is where the cap sits, so
+			// digging it again cuts the cap out and the two edits can be
+			// cycled for as long as anyone wants to watch them.
 			int shaft_top = (int)std::floor(
 					surface_at(shaft_x, shaft_z)) + 11;
 			if(shaft_top < shaft_bottom)
 				shaft_top = shaft_bottom;
-			bench_shaft_h = shaft_top - shaft_bottom + 1;
+			// A box of height h centred at c covers c-(h/2) .. c+(h-1)/2
+			bench_shaft_h = (shaft_top + 1) - shaft_bottom + 1;
 			bench_shaft_centre = pv::Vector3DInt32(shaft_x,
-					(shaft_bottom + shaft_top) / 2, shaft_z);
+					shaft_bottom + bench_shaft_h / 2, shaft_z);
 
 			// The slab caps the shaft, filling the two air voxels directly
 			// above the ground, so the second edit takes back exactly the light
 			// the first one let in and the cave returns to where it started.
+			// The shaft reaches through both of them, so digging again cuts the
+			// cap back out.
 			bench_slab_centre = pv::Vector3DInt32(
 					clamp_xz(shaft_x, lc.getX() + 3, uc.getX() - 3),
 					shaft_top + 1,
@@ -374,26 +294,16 @@ struct Worldgen: public worldgen::GeneratorInterface
 					PV3I_FORMAT, PV3I_PARAMS(bench_shaft_centre),
 					bench_shaft_h, PV3I_PARAMS(bench_slab_centre));
 
-			sv_<uint8_t> sky, solid_sky;
-			compute_skylight(ids, W, H, D, sky, solid_sky);
-
-			size_t dark_air = 0, lit_air = 0;
+			// voxelworld keeps the skylight of every voxel up to date from
+			// here on, so these go in as plain ids
 			for(int y = lc.getY(); y <= uc.getY(); y++){
 				for(int z = lc.getZ(); z <= uc.getZ(); z++){
 					for(int x = lc.getX(); x <= uc.getX(); x++){
-						size_t i = idx(x, y, z);
-						VoxelInstance v(ids[i]);
-						v.set_skylight(ids[i] == AIR ? sky[i] : solid_sky[i]);
-						world->set_voxel(pv::Vector3DInt32(x, y, z), v);
-						if(ids[i] == AIR){
-							if(sky[i] == 0) dark_air++;
-							else lit_air++;
-						}
+						world->set_voxel(pv::Vector3DInt32(x, y, z),
+								VoxelInstance(ids[idx(x, y, z)]));
 					}
 				}
 			}
-			log_v(MODULE, "Skylight: %zu lit air voxels, %zu fully dark",
-					lit_air, dark_air);
 		});
 	}
 };
@@ -427,6 +337,8 @@ struct Module: public interface::Module
 				"network:packet_received/main:bench_shaft"));
 		m_server->sub_event(this, Event::t(
 				"network:packet_received/main:bench_slab"));
+		m_server->sub_event(this, Event::t(
+				"network:packet_received/main:verify_skylight"));
 	}
 
 	void event(const Event::Type &type, const Event::Private *p)
@@ -446,6 +358,8 @@ struct Module: public interface::Module
 				on_bench_shaft, network::Packet)
 		EVENT_TYPEN("network:packet_received/main:bench_slab",
 				on_bench_slab, network::Packet)
+		EVENT_TYPEN("network:packet_received/main:verify_skylight",
+				on_verify_skylight, network::Packet)
 	}
 
 	void add_voxel(interface::VoxelRegistry *reg, const ss_ &name,
@@ -504,6 +418,10 @@ struct Module: public interface::Module
 			add_voxel(reg, "grass", "main/grass.png", true); // id 4
 			add_voxel(reg, "leaves", "main/leaves.png", true); // id 5
 			add_voxel(reg, "tree", "main/tree.png", true); // id 6
+
+			// The whole point of this scene: let voxelworld light it
+			ivoxelworld->get_instance(m_main_scene)->
+					set_skylight_enabled(true);
 		});
 
 		worldgen::access(m_server, m_main_scene,
@@ -554,61 +472,12 @@ struct Module: public interface::Module
 		});
 	}
 
-	// Skylight is generated for the whole scene at once, and the scene is a
-	// single 64^3 section, so an edit is relit by simply doing that again over
-	// all of it. Only voxels whose skylight actually changed are written back,
-	// which keeps the number of chunks that have to be remeshed down to the
-	// ones the light really moved in.
-	void relight(voxelworld::Instance *world)
-	{
-		auto t0 = std::chrono::steady_clock::now();
-		pv::Region region = world->get_section_region_voxels(
-				pv::Vector3DInt16(0, 0, 0));
-		auto lc = region.getLowerCorner();
-		auto uc = region.getUpperCorner();
-		const int W = uc.getX() - lc.getX() + 1;
-		const int H = uc.getY() - lc.getY() + 1;
-		const int D = uc.getZ() - lc.getZ() + 1;
-
-		sv_<uint8_t> ids((size_t)W * H * D, AIR_ID);
-		for(int y = 0; y < H; y++)
-		for(int z = 0; z < D; z++)
-		for(int x = 0; x < W; x++){
-			VoxelInstance v = world->get_voxel(pv::Vector3DInt32(
-					lc.getX() + x, lc.getY() + y, lc.getZ() + z), true);
-			ids[sky_idx(x, y, z, W, D)] = (uint8_t)v.get_id();
-		}
-
-		sv_<uint8_t> sky, solid_sky;
-		compute_skylight(ids, W, H, D, sky, solid_sky);
-
-		size_t changed = 0;
-		for(int y = 0; y < H; y++)
-		for(int z = 0; z < D; z++)
-		for(int x = 0; x < W; x++){
-			size_t i = sky_idx(x, y, z, W, D);
-			uint8_t l = (ids[i] == AIR_ID) ? sky[i] : solid_sky[i];
-			pv::Vector3DInt32 p(lc.getX() + x, lc.getY() + y, lc.getZ() + z);
-			VoxelInstance v = world->get_voxel(p, true);
-			if(v.get_skylight() == l)
-				continue;
-			v.set_skylight(l);
-			world->set_voxel(p, v, true);
-			changed++;
-		}
-		log_v(MODULE, "relight(): %zu voxels changed skylight in %i ms",
-				changed, (int)std::chrono::duration_cast<
-						std::chrono::milliseconds>(
-						std::chrono::steady_clock::now() - t0).count());
-	}
-
 	void edit_voxel(const pv::Vector3DInt32 &p, uint32_t id)
 	{
 		voxelworld::access(m_server, m_main_scene,
 				[&](voxelworld::Instance *world)
 		{
 			world->set_voxel(p, VoxelInstance(id));
-			relight(world);
 		});
 	}
 
@@ -654,7 +523,6 @@ struct Module: public interface::Module
 						centre.getY() + y, centre.getZ() + z),
 						VoxelInstance(id), true);
 			}
-			relight(world);
 		});
 		log_v(MODULE, "bench_box(): %ix%ix%i id %i at " PV3I_FORMAT,
 				w, h, d, id, PV3I_PARAMS(centre));
@@ -674,6 +542,125 @@ struct Module: public interface::Module
 		if(!m_worldgen) return;
 		bench_box(m_worldgen->bench_slab_centre, BENCH_SLAB_W, BENCH_SLAB_H,
 				BENCH_SLAB_W, 2); // rock
+	}
+
+	// Check voxelworld's incremental skylight against a flood fill done from
+	// scratch over the whole scene. The scene is one section, so the whole
+	// thing fits in memory and the two can be compared voxel by voxel; this is
+	// what says whether an edit relit everything it should have.
+	void verify_skylight()
+	{
+		voxelworld::access(m_server, m_main_scene,
+				[&](voxelworld::Instance *world)
+		{
+			pv::Region region = world->get_section_region_voxels(
+					pv::Vector3DInt16(0, 0, 0));
+			auto lc = region.getLowerCorner();
+			auto uc = region.getUpperCorner();
+			const int W = uc.getX() - lc.getX() + 1;
+			const int H = uc.getY() - lc.getY() + 1;
+			const int D = uc.getZ() - lc.getZ() + 1;
+			auto idx = [&](int x, int y, int z){
+				return ((size_t)y * D + z) * W + x;
+			};
+			auto inside = [&](int x, int y, int z){
+				return x >= 0 && x < W && y >= 0 && y < H && z >= 0 && z < D;
+			};
+
+			sv_<uint8_t> ids((size_t)W * H * D, 0);
+			sv_<uint8_t> stored((size_t)W * H * D, 0);
+			for(int y = 0; y < H; y++)
+			for(int z = 0; z < D; z++)
+			for(int x = 0; x < W; x++){
+				VoxelInstance v = world->get_voxel(pv::Vector3DInt32(
+						lc.getX() + x, lc.getY() + y, lc.getZ() + z), true);
+				ids[idx(x, y, z)] = (uint8_t)v.get_id();
+				stored[idx(x, y, z)] = v.get_skylight();
+			}
+
+			// Straight down at full strength until something stops it, then
+			// one step lost per voxel in every direction
+			const uint8_t SKY_MAX = VoxelInstance::SKYLIGHT_MAX;
+			sv_<uint8_t> sky((size_t)W * H * D, 0);
+			for(int z = 0; z < D; z++){
+				for(int x = 0; x < W; x++){
+					uint8_t l = SKY_MAX;
+					for(int y = H - 1; y >= 0; y--){
+						size_t i = idx(x, y, z);
+						if(ids[i] != AIR_ID)
+							l = 0;
+						sky[i] = l;
+					}
+				}
+			}
+			static const int off[6][3] = {
+				{1,0,0}, {-1,0,0}, {0,1,0}, {0,-1,0}, {0,0,1}, {0,0,-1}
+			};
+			for(int level = SKY_MAX; level >= 2; level--){
+				for(int y = 0; y < H; y++)
+				for(int z = 0; z < D; z++)
+				for(int x = 0; x < W; x++){
+					if(sky[idx(x, y, z)] != level)
+						continue;
+					for(size_t k = 0; k < 6; k++){
+						int nx = x + off[k][0], ny = y + off[k][1];
+						int nz = z + off[k][2];
+						if(!inside(nx, ny, nz))
+							continue;
+						size_t ni = idx(nx, ny, nz);
+						if(ids[ni] != AIR_ID || sky[ni] >= level - 1)
+							continue;
+						sky[ni] = level - 1;
+					}
+				}
+			}
+
+			size_t mismatches = 0;
+			pv::Vector3DInt32 first(0, 0, 0);
+			uint8_t first_want = 0, first_got = 0;
+			for(int y = 0; y < H; y++)
+			for(int z = 0; z < D; z++)
+			for(int x = 0; x < W; x++){
+				size_t i = idx(x, y, z);
+				uint8_t want = sky[i];
+				if(ids[i] != AIR_ID){
+					// Voxels that block light hold the brightest light next
+					// to them instead
+					want = 0;
+					for(size_t k = 0; k < 6; k++){
+						int nx = x + off[k][0], ny = y + off[k][1];
+						int nz = z + off[k][2];
+						if(!inside(nx, ny, nz))
+							continue;
+						size_t ni = idx(nx, ny, nz);
+						if(ids[ni] == AIR_ID && sky[ni] > want)
+							want = sky[ni];
+					}
+				}
+				if(want == stored[i])
+					continue;
+				if(mismatches == 0){
+					first = pv::Vector3DInt32(lc.getX() + x, lc.getY() + y,
+							lc.getZ() + z);
+					first_want = want;
+					first_got = stored[i];
+				}
+				mismatches++;
+			}
+			if(mismatches == 0){
+				log_v(MODULE, "skylight verify: ok");
+			} else {
+				log_w(MODULE, "skylight verify: %zu voxels differ from a "
+						"fresh fill; first " PV3I_FORMAT " wants %i, has %i",
+						mismatches, PV3I_PARAMS(first), first_want, first_got);
+			}
+		});
+	}
+
+	void on_verify_skylight(const network::Packet &packet)
+	{
+		(void)packet;
+		verify_skylight();
 	}
 
 	void on_worldgen_queue_modified(const worldgen::QueueModifiedEvent &event)

--- a/games/voxel_lighting/main/main.cpp
+++ b/games/voxel_lighting/main/main.cpp
@@ -362,13 +362,13 @@ struct Worldgen: public worldgen::GeneratorInterface
 			bench_shaft_centre = pv::Vector3DInt32(shaft_x,
 					(shaft_bottom + shaft_top) / 2, shaft_z);
 
-			int slab_x = clamp_xz(mouth_x + 2, lc.getX() + 3, uc.getX() - 3);
-			int slab_z = clamp_xz(mouth_z + 2, lc.getZ() + 3, uc.getZ() - 3);
-			// The slab hangs clear above the mouth rather than following the
-			// ground: benchmark camera 2 looks down at the mouth from the +X +Z
-			// side, and anything level with the mouth would sit in front of it.
-			bench_slab_centre = pv::Vector3DInt32(slab_x,
-					(int)std::floor(sy) + 6, slab_z);
+			// The slab caps the shaft, filling the two air voxels directly
+			// above the ground, so the second edit takes back exactly the light
+			// the first one let in and the cave returns to where it started.
+			bench_slab_centre = pv::Vector3DInt32(
+					clamp_xz(shaft_x, lc.getX() + 3, uc.getX() - 3),
+					shaft_top + 1,
+					clamp_xz(shaft_z, lc.getZ() + 3, uc.getZ() - 3));
 
 			log_v(MODULE, "Bench: shaft " PV3I_FORMAT " h %i, slab "
 					PV3I_FORMAT, PV3I_PARAMS(bench_shaft_centre),

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -185,6 +185,8 @@ static bool load_window_state(int desk_w, int desk_h, app::GraphicsOptions *opt)
 
 static void save_window_state(const app::GraphicsOptions &opt)
 {
+	if(opt.size_forced)
+		return;
 	if(opt.window_w < MIN_WINDOW_W || opt.window_h < MIN_WINDOW_H)
 		return;
 	json::Value o = json::object();
@@ -436,6 +438,10 @@ struct CApp: public App, public magic::Application
 		check_pick_default_window_size();
 		if(m_options.graphics.window_w <= 0 || m_options.graphics.window_h <= 0){
 			resolve_window_size(&m_options.graphics);
+		}
+		if(m_options.graphics.size_forced){
+			m_options.graphics.fullscreen = false;
+			m_options.graphics.maximized = false;
 		}
 		m_restore_maximized = m_options.graphics.maximized;
 		log_v(MODULE, "window size: %ix%i maximized=%i fullscreen=%i",

--- a/src/client/app.h
+++ b/src/client/app.h
@@ -44,6 +44,9 @@ namespace app
 		bool vsync = true;
 		bool triple_buffer = false;
 		int multisampling = 1; // 2 looks much better but is much heavier(?)
+		// Set by -w: the size came from the command line, so it is not
+		// remembered across runs and the saved size is left alone
+		bool size_forced = false;
 
 		void apply(Urho3D::Graphics *magic_graphics);
 	};

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -11,6 +11,7 @@
 #include "interface/os.h"
 #include <c55/getopt.h>
 #include <Context.h>
+#include <cstdio> // sscanf()
 #include <cstdlib> // srand()
 #include <fstream>
 #include <sstream>
@@ -44,7 +45,7 @@ int main(int argc, char *argv[])
 
 	client::Config &config = g_client_config;
 
-	const char opts[100] = "hs:P:C:U:l:L:m:u:c:";
+	const char opts[100] = "hs:P:C:U:l:L:m:u:w:c:";
 	const char usagefmt[1000] =
 			"Usage: %s [OPTION]...\n"
 			"  -h                   Show this help\n"
@@ -56,10 +57,13 @@ int main(int argc, char *argv[])
 			"  -L [log file path]   Append log to a specified file\n"
 			"  -m [name]            Choose menu extension name\n"
 			"  -u [scale]           UI scale (0 = auto from short side / 1080)\n"
+			"  -w [WxH]             Windowed at this size; not remembered\n"
 			"  -c [commands]        Run command sequence and exit\n"
 			"                       One command per line. @file reads a file.\n"
 			"                       See doc/client_commands.txt\n"
 			;
+
+	int forced_w = 0, forced_h = 0;
 
 	int c;
 	while((c = c55_getopt(argc, argv, opts)) != -1)
@@ -98,6 +102,14 @@ int main(int argc, char *argv[])
 		case 'u':
 			log_i(MODULE, "config.ui_scale: %s", c55_optarg);
 			config.set("ui_scale", atof(c55_optarg));
+			break;
+		case 'w':
+			if(sscanf(c55_optarg, "%dx%d", &forced_w, &forced_h) != 2 ||
+					forced_w <= 0 || forced_h <= 0){
+				fprintf(stderr, "-w: expected WxH, got \"%s\"\n", c55_optarg);
+				return 1;
+			}
+			log_i(MODULE, "window size: %ix%i", forced_w, forced_h);
 			break;
 		case 'c': {
 			ss_ arg = c55_optarg ? c55_optarg : "";
@@ -147,6 +159,11 @@ int main(int argc, char *argv[])
 	}
 
 	app::Options app_options;
+	if(forced_w > 0){
+		app_options.graphics.window_w = forced_w;
+		app_options.graphics.window_h = forced_h;
+		app_options.graphics.size_forced = true;
+	}
 
 	int exit_status = 0;
 	while(exit_status == 0){

--- a/src/server/rccpp.cpp
+++ b/src/server/rccpp.cpp
@@ -74,6 +74,16 @@ struct RCCPP_Info {
 	RCCPP_Constructor constructor;
 };
 
+// Without an -O flag gcc defaults to -O0, which in a voxel module is the
+// difference between an array access and a function call per voxel: lighting a
+// section measured 178 ms at -O0 and 40 ms here. -O2 gets that to 37 ms but
+// costs a third more compile time on every module reload, which is the thing
+// this engine does constantly.
+ss_ cxxflags_optimize()
+{
+	return "-O1";
+}
+
 struct CCompiler: public Compiler
 {
 	ss_ m_compiler_command;
@@ -88,7 +98,11 @@ struct CCompiler: public Compiler
 			const ss_ &extra_cxxflags, const ss_ &extra_ldflags)
 	{
 		ss_ command = m_compiler_command;
-		command += " -DRCCPP -g -fPIC -fvisibility=hidden -shared";
+		// Without an -O flag gcc defaults to -O0, which for a voxel module is
+		// the difference between an array access and a function call per
+		// voxel. Modules are compiled once at startup, so the extra compile
+		// time is paid once and the code runs for the life of the server.
+		command += " -DRCCPP "+cxxflags_optimize()+" -g -fPIC -fvisibility=hidden -shared";
 		command += " -std=c++11";
 		if(extra_cxxflags != "")
 			command += ss_()+" "+extra_cxxflags;

--- a/src/server/rccpp.h
+++ b/src/server/rccpp.h
@@ -9,6 +9,10 @@ namespace interface {
 
 namespace rccpp
 {
+	// Optimization flags modules are compiled with. Part of the build cache
+	// hash, so changing it rebuilds what is already cached.
+	ss_ cxxflags_optimize();
+
 	struct Compiler {
 		virtual ~Compiler(){}
 

--- a/src/server/rccpp_util.cpp
+++ b/src/server/rccpp_util.cpp
@@ -51,9 +51,10 @@ sv_<ss_> list_includes(const ss_ &path, const sv_<ss_> &include_dirs)
 	return result;
 }
 
-ss_ hash_files(const sv_<ss_> &paths)
+ss_ hash_files(const sv_<ss_> &paths, const ss_ &extra)
 {
 	std::ostringstream os(std::ios::binary);
+	os<<extra;
 	for(const ss_ &path : paths){
 		std::ifstream f(path);
 		try {

--- a/src/server/rccpp_util.h
+++ b/src/server/rccpp_util.h
@@ -6,6 +6,8 @@
 namespace server
 {
 	sv_<ss_> list_includes(const ss_ &path, const sv_<ss_> &include_dirs);
-	ss_ hash_files(const sv_<ss_> &paths);
+	// extra is hashed along with the files, for things that change what the
+	// build produces without being in any of them
+	ss_ hash_files(const sv_<ss_> &paths, const ss_ &extra = "");
 }
 // vim: set noet ts=4 sw=4:

--- a/src/server/state.cpp
+++ b/src/server/state.cpp
@@ -657,7 +657,10 @@ struct CState: public State, public interface::Server
 		sv_<ss_> files_to_hash = {init_cpp_path};
 		files_to_hash.insert(
 				files_to_hash.begin(), includes.begin(), includes.end());
-		ss_ content_hash = hash_files(files_to_hash);
+		// The optimization flags go in too; without them a cache built at a
+		// different level is kept and silently used
+		ss_ content_hash = hash_files(files_to_hash,
+				rccpp::cxxflags_optimize());
 		log_d(MODULE, "Module hash: %s", cs(interface::sha1::hex(content_hash)));
 
 #ifdef _WIN32


### PR DESCRIPTION
Makes skylight something voxelworld maintains rather than something each game
computes for itself, keeps it up to date incrementally when the world is
edited, and gives voxel_lighting the edits and the check that prove it works.
Along the way it turns on the optimizer for runtime-compiled modules, which
were being built without one.

## voxelworld

A world turns skylight on with `set_skylight_enabled(true)`. From then on
`set_voxel()` keeps the light of every voxel current, through generation and
through edits alike, and it is settled at the start of `commit()` so it lands
in the same remesh as the voxels that moved it.

The update is incremental: light is taken out of whatever the changed voxels
were lighting, then spread back in from whatever still has some, so the work
done is proportional to how far the change reaches rather than to the size of
the world. Neighbours are addressed in world coordinates, so it crosses chunk
and section boundaries by itself; a section that is not in memory reads as
undefined and stops the light, which keeps an edit at the edge of the loaded
world from running away.

Light enters from above the top of the world region at full strength, falls
through anything transparent without dimming, and spreads sideways and upwards
losing one step per voxel. Voxels that block light hold the brightest light
next to them instead, which is what the mesher reads at a chunk edge.

Once skylight is on, those bits belong to voxelworld: `set_voxel()` carries
them over from the voxel that was there rather than taking them from the
caller. Without that, a caller writing a plain `VoxelInstance` wipes the light
out of a voxel whose transparency did not change, and since nothing changed
transparency there is no seed and nothing ever puts it back.

A voxel transmits light if its edge material is `EDGEMATERIALID_EMPTY`, the
same test the mesher uses to decide whether a face is drawn against it.

## voxel_lighting

Digging and placing are taken from digger: in free move the pointed voxel is
outlined, left mouse digs it and right mouse places rock.

Two fixed edits make the change comparable between runs. P digs a 3x3 shaft
straight up out of the cave, starting 20 voxels along the cave axis where the
skylight was 0, so a part of the scene that had none has to come up to
daylight. O caps it with a 5x2x5 slab, taking that light back out. The shaft
reaches through the cap, so the two can be alternated indefinitely.

The game drops its own flood fill and asks voxelworld for the light instead. It
keeps a copy of the fill as a check: V runs a fill from scratch over the whole
scene and compares it voxel by voxel against what voxelworld stored. check.txt
runs it after generation and after each edit, so a run states outright whether
the incremental update got the same answer as doing it all again. It does, in
all four places.

That check earned its place twice over. It caught the spread phase re-spreading
levels from sources another branch had since unlit, and the wiped light bits
that led to the `set_voxel()` ownership rule above. Neither was visible in a
screenshot.

## Compiling modules with -O1

Runtime-compiled modules were built with no `-O` flag at all, so gcc used -O0.
In a module that walks voxels one at a time that is the difference between an
array access and a function call, and it applies to every module in the engine,
not only to this work. Lighting a section measured 178 ms at -O0 and 40 ms at
-O1.

-O2 reaches 37 ms but costs a third more compile time on every module reload,
which this engine does constantly: rebuilding one module after an edit takes
3.0 s at -O1 against 4.0 s at -O2. The last 8% is not worth that.

The flags are part of the build cache hash. Without that, a cache built at
another level is kept and used, and changing the flag quietly does nothing.

## Client

`-w WxH` runs windowed at a fixed size and leaves the remembered window size
alone. Without it the images from a command sequence come out at whatever size
the window was last left at, which makes them useless for comparing runs.

## Numbers

| | before | after |
|---|---|---|
| edit | 130 ms | under 1 ms |
| 64^3 section at generation | 417 ms | 40 ms |

The generation figure is against the first working version of this, not against
master, which had no engine-side lighting to measure. Three things account for
the difference: the -O1 change above; not recomputing what the light-blocking
voxels hold once per side, which was six million voxel reads for a section
against nineteen thousand voxels that needed a value; and keeping the chunk
buffer the update last used, reaching into it directly rather than through
`get_buffer()`, which reads the clock on every call.

## Known limits

Light stops at a section that is not loaded and is not revisited when that
section arrives, so a world that streams will have seams at the edge of what
was loaded when an edit happened. Making light flow into a section as it loads
is the next piece, and it needs a streaming world to test against.

Transparency is the one edge material test, so glass would have to be either a
light barrier or a hole in the terrain. A voxel definition flag of its own is
the upgrade path.
