### PR TITLE
doc: coordinate convention and the Urho3D fork's patches

### DIFF
--- a/3rdparty/Urho3D/Source/Urho3D/Graphics/GLTFLoader.cpp
+++ b/3rdparty/Urho3D/Source/Urho3D/Graphics/GLTFLoader.cpp
@@ -71,6 +71,19 @@ namespace tg = tinygltf;
 namespace
 {
 
+// glTF is right-handed and Urho3D is left-handed, so one axis has to be
+// mirrored on the way in. X is the one to pick: it leaves +Y up and +Z
+// forward reading the same in both, where mirroring Z would turn the model
+// around. Every piece of geometry that meets another has to be mirrored the
+// same way or they come apart, so all of these go together:
+//   node translation and rotation    GetNodeLocalTRS
+//   inverse bind matrices            BuildSkeleton
+//   positions and normals            LoadGLTFModel
+//   position and rotation tracks     LoadGLTFAnimation
+// and mirroring reverses triangle winding, which LoadGLTFModel undoes by
+// swapping two indices of every triangle. Drop any one of these and the
+// result still nearly works -- inside-out faces, or animation that slides off
+// the mesh -- so treat them as one change.
 Vector3 MirrorX(const Vector3& v)
 {
     return Vector3(-v.x_, v.y_, v.z_);

--- a/doc/conventions.txt
+++ b/doc/conventions.txt
@@ -131,7 +131,27 @@ something, the "add" verb should be left out. Fine enough examples:
 - client: Disable Urho3D log file
 - extensions/__menu: Fix UI warnings
 
+Coordinates
+-----------
+Urho3D's convention, unchanged: left-handed, Y up, +X right, +Z forward. It is
+the Direct3D convention, and the one Unity uses.
+
+Rotations are in degrees. Yaw turns around Y and grows turning right, so yaw 0
+looks towards +Z and yaw 90 towards +X. Pitch turns around X and grows looking
+down. This is the order Quaternion(pitch, yaw, roll) takes them in.
+
+Voxel coordinates are the same axes, and a voxel is centred on its integer
+coordinate: it spans from -0.5 to +0.5 around it (impl/mesh.cpp shifts the
+PolyVox vertices by that half unit).
+
+Content authored elsewhere generally is not in this convention. glTF is
+right-handed, and Blender is right-handed and Z up. The glTF loader converts
+(3rdparty/Urho3D/Source/Urho3D/Graphics/GLTFLoader.cpp); anything else that
+imports geometry has to.
+
 Urho3D
 ------
 Urho3D's namespace should generally be aliased to be "magic".
+
+The bundled copy is patched. See urho3d_fork.txt before updating it.
 

--- a/doc/urho3d_fork.txt
+++ b/doc/urho3d_fork.txt
@@ -1,0 +1,53 @@
+Urho3D fork
+===========
+3rdparty/Urho3D is official Urho3D 1.7.1 with the changes below. They are not
+upstream and will not survive an update of the bundled copy unless carried
+over. Keep this list current when patching further.
+
+"git log -- 3rdparty/Urho3D" is the authoritative history; the commit hashes
+here are where to read the actual diff.
+
+Shader names that carry a path (bf72454)
+----------------------------------------
+Graphics/{OpenGL/OGLGraphics,Direct3D9/D3D9Graphics,Direct3D11/D3D11Graphics}.cpp
+Graphics/Graphics.h
+Graphics/Shader.cpp
+
+GetShader() treats a name containing '/' as a full resource name instead of
+prefixing shaderPath_ ("Shaders/GLSL/"), and Shader::ProcessSource falls back
+to shaderPath_ when an #include is not found next to the including shader.
+Together these let a module ship a shader under its own resource namespace and
+still use the engine's includes; without them every game would have to occupy
+the one shader directory they all share. Graphics::GetShaderPath() is the
+accessor the fallback needs. See builtin/voxel_shading.
+
+glTF 2.0 loading, Assimp dropped (4e20d9e)
+------------------------------------------
+Graphics/GLTFLoader.{cpp,h}, Graphics/Model.cpp, Graphics/Animation.cpp
+Source/ThirdParty/tinygltf (added), Source/ThirdParty/Assimp (removed)
+
+Model and Animation load .gltf/.glb at runtime through tinygltf, so a game can
+ship a glTF file as client data with no conversion step. The parse path follows
+rbfx's Utility/GLTFImporter. Assimp was removed with it; nothing else used it.
+
+The right-handed to left-handed conversion is an X mirror applied in several
+places at once, and the comment above MirrorX in GLTFLoader.cpp says which and
+why. Read it before touching any of them.
+
+Sharp scaled UI text (de35f88)
+------------------------------
+UI/FontFaceFreeType.{cpp,h}, UI/UI.cpp
+
+FontFaceFreeType remembers the UI scale it rasterised at and stores glyphs in
+virtual units, and UI::SetScale releases the font faces when the scale actually
+changes so they are rasterised again at the new one. Without it, scaled UI text
+is a magnified bitmap. The Overpass fonts that go with it are in
+client/data/Fonts and are not part of the fork.
+
+UI/MessageBox.xml (5d2117a)
+---------------------------
+Bin/Data/UI/MessageBox.xml
+
+Kept from an earlier bundled version; 1.7.1 does not ship it, and
+UI/MessageBox.cpp loads it by name when a MessageBox is created without a
+layout of its own.


### PR DESCRIPTION
Two things the repository relied on without writing down anywhere.

**The coordinate convention.** It was stated only in a comment in one game's client Lua, so every game had to rediscover it. `doc/conventions.txt` gains a Coordinates section: Urho3D's own convention unchanged (left-handed, Y up, +X right, +Z forward), the direction yaw and pitch grow in, voxels centred on their integer coordinate, and a note that glTF and Blender content does not arrive in this convention.

**The bundled Urho3D's patches.** `3rdparty/Urho3D` is official 1.7.1 plus four changes, findable only by reading its git log. `doc/urho3d_fork.txt` lists them with files, commit and reason: shader names that carry a path, runtime glTF 2.0 loading with Assimp dropped, sharp scaled UI text, and a kept `UI/MessageBox.xml`. `doc/todo.txt` already proposes fetching and patching Urho3D at build time, which presumes such a list.

`GLTFLoader.cpp` also gains a comment above `MirrorX`: which four places mirror and which undoes the triangle winding, and why the mirror is on X rather than Z. Dropping any one of them leaves a model that nearly works, so they are named together.

Documentation only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)