### PR TITLE
impl/mesh: Keep voxel physics boxes inside the volume

### DIFF
--- a/src/impl/mesh.cpp
+++ b/src/impl/mesh.cpp
@@ -1084,6 +1084,12 @@ void generate_voxel_physics_boxes(
 			int z1 = z0;
 			for(;;){
 				x1++;
+				// getVoxelAt() past the region reads outside the volume's
+				// data, so the plane loops below would happily accept
+				// whatever is in that memory and stretch the box out of the
+				// world. Stop at the region instead.
+				if(x1 > uc.getX())
+					goto x_plane_does_not_fit;
 				for(int y = y0; y <= y1; y++){
 					for(int z = z0; z <= z1; z++){
 						uint8_t v = volume.getVoxelAt(x1, y, z);
@@ -1098,6 +1104,8 @@ void generate_voxel_physics_boxes(
 			}
 			for(;;){
 				y1++;
+				if(y1 > uc.getY())
+					goto y_plane_does_not_fit;
 				for(int x = x0; x <= x1; x++){
 					for(int z = z0; z <= z1; z++){
 						uint8_t v = volume.getVoxelAt(x, y1, z);
@@ -1112,6 +1120,8 @@ void generate_voxel_physics_boxes(
 			}
 			for(;;){
 				z1++;
+				if(z1 > uc.getZ())
+					goto z_plane_does_not_fit;
 				for(int x = x0; x <= x1; x++){
 					for(int y = y0; y <= y1; y++){
 						uint8_t v = volume.getVoxelAt(x, y, z1);


### PR DESCRIPTION
`generate_voxel_physics_boxes()` builds a chunk's collision out of boxes, growing each one along x, then y, then z until it meets a non-solid voxel. Nothing stopped the growth at the edge of the region, and past it `getVoxelAt()` reads outside the volume's data, so a box kept growing for as long as whatever was in that memory looked solid.

Logging the boxes of one 32-voxel chunk:

```
BOX world (-65.5..1022.5, 31.5..32.5, 254.5..255.5)
BOX world (-65.5..648.5,  31.5..32.5, 255.5..287.5)
BOX world (-65.5..308.5,  52.5..53.5, 258.5..284.5)
```

Each box also marks the voxels it covers as done, so the terrain those runaway boxes claimed to cover never got a box of its own: eight boxes for a chunk whose neighbour had 422.

Collision was therefore a handful of stray slabs. A player walked on air where one crossed empty space, fell through terrain that had no box at all, and ended up stuck inside another — in practice within a voxel or two of a chunk boundary, since that is where the growth ran off the edge.

The fix is a bound on each of the three stretch loops.

Checked in `games/digger` by walking the player down the 96-voxel spawn tunnel: before, they fell through the floor at the first chunk boundary (x=-33.5, boundary at -32.5); after, they cross four chunks at a constant height and stop at the rock face at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)