### PR TITLE
server: Shut down on SIGINT and SIGTERM, and tear modules down in order

### DIFF
--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -9,7 +9,6 @@
 #include "server/state.h"
 #include "interface/server.h"
 #include "interface/debug.h"
-#include "interface/mutex.h"
 #include "interface/os.h"
 #include <c55/getopt.h>
 #include <c55/os.h>
@@ -23,24 +22,27 @@
 
 server::Config g_server_config;
 
-bool g_sigint_received = false;
-interface::Mutex g_sigint_received_mutex;
+// The signal that asked for shutdown, read by the main loop. Only things a
+// signal handler may touch belong in here: no logging, no locking, no
+// allocation. The loop does all of that once it sees this.
+volatile sig_atomic_t g_shutdown_signal = 0;
 
-void sigint_handler(int sig)
+void shutdown_signal_handler(int sig)
 {
-	interface::MutexScope ms(g_sigint_received_mutex);
-	if(!g_sigint_received){
-		fprintf(stdout, "\n"); // Newline after "^C"
-		log_i("process", "SIGINT");
-		g_sigint_received = true;
+	if(g_shutdown_signal == 0){
+		g_shutdown_signal = sig;
 	} else {
-		(void)signal(SIGINT, SIG_DFL);
+		// Asked twice: the shutdown is not getting anywhere, so let the
+		// default action have the process
+		(void)signal(sig, SIG_DFL);
+		(void)raise(sig);
 	}
 }
 
 void signal_handler_init()
 {
-	(void)signal(SIGINT, sigint_handler);
+	(void)signal(SIGINT, shutdown_signal_handler);
+	(void)signal(SIGTERM, shutdown_signal_handler);
 #ifndef _WIN32
 	(void)signal(SIGPIPE, SIG_IGN);
 #endif
@@ -125,6 +127,8 @@ int main(int argc, char *argv[])
 
 	std::cerr<<"Buildat server"<<std::endl;
 
+	signal_handler_init();
+
 	if(!boot::autodetect::detect_server_paths(config))
 		return 1;
 
@@ -150,10 +154,14 @@ int main(int argc, char *argv[])
 		uint64_t t_per_tick = 1000000 / 30; // Same as physics FPS
 
 		for(;;){
-			{
-				interface::MutexScope ms(g_sigint_received_mutex);
-				if(g_sigint_received)
-					break;
+			if(g_shutdown_signal != 0){
+				// SIGINT leaves a "^C" on the terminal to write past
+				if(g_shutdown_signal == SIGINT)
+					fprintf(stdout, "\n");
+				log_i(MODULE, "%s; shutting down",
+						g_shutdown_signal == SIGINT ? "SIGINT" : "SIGTERM");
+				shutdown_reason = "Signal";
+				break;
 			}
 			uint64_t current_us = get_timeofday_us();
 			int64_t delay_us = next_tick_us - current_us;

--- a/src/server/state.cpp
+++ b/src/server/state.cpp
@@ -543,13 +543,14 @@ struct CState: public State, public interface::Server
 	void thread_request_stop()
 	{
 		m_file_watch_thread->request_stop();
-
-		sv_<sp_<ModuleContainer>> mcs = get_modules_in_unload_order();
-
-		for(sp_<ModuleContainer> &mc : mcs){
-			log_t(MODULE, "Requesting module to stop: [%s]", cs(mc->info.name));
-			mc->thread_request_stop();
-		}
+		// The modules are not stopped here. A module is destructed by its own
+		// thread as it stops, and a destructor may still call into the modules
+		// it was built on -- replicate clears its replication state inside
+		// main_context, on purpose, because Urho3D's weak pointers are not
+		// thread safe. Asking every module to stop up front makes every one of
+		// those calls fail, so each is stopped in thread_join() instead, one at
+		// a time and in reverse load order, with the ones below it still
+		// running.
 	}
 
 	void thread_join()
@@ -559,10 +560,10 @@ struct CState: public State, public interface::Server
 
 		sv_<sp_<ModuleContainer>> mcs = get_modules_in_unload_order();
 
-		// Wait for threads to stop and delete module container references
 		log_v(MODULE, "Waiting: modules");
 		for(sp_<ModuleContainer> &mc : mcs){
-			log_d(MODULE, "Waiting for module to stop: [%s]", cs(mc->info.name));
+			log_d(MODULE, "Stopping module: [%s]", cs(mc->info.name));
+			mc->thread_request_stop();
 			mc->thread_join();
 			// Remove our reference to the module container, so that any child
 			// threads it will now delete will not get deadlocked in trying to


### PR DESCRIPTION
Two defects on the shutdown path.

## Signals were not handled at all

`sigint_handler()` and `signal_handler_init()` were written but `main()` never called the latter, so neither signal was handled: both took their default action and killed the process where it stood, with modules not unloaded and peers told nothing. The main loop's `g_sigint_received` check could never fire.

`main()` now installs the handler, and it covers SIGTERM as well as SIGINT — SIGTERM is what a service manager, a script, or a plain `kill` sends, and it was not handled in any form.

The handler itself now only assigns to a `volatile sig_atomic_t`. Logging, locking and allocation are not things a signal handler may do, and the old one took a mutex and called `log_i()`; the main loop does all of that when it sees the flag, which is what it was already written to do. A second signal restores the default action and re-raises it, so a shutdown that gets stuck can still be interrupted.

## Modules were all stopped before any was joined

`thread_request_stop()` asked every module to stop, and only then did `thread_join()` walk them in reverse load order. A module is destructed by its own thread as it stops, and a destructor may call into the modules it was built on — but those had been told to stop as well, so every such call threw `TargetModuleNotAvailable`, which `access_module()` swallows, since an exception must not escape a destructor.

`replicate`'s destructor is where this showed, as a warning on every shutdown:

```
access_module[main_context]: Ignoring exception in [replicate] destructor:
  "Target module [main_context] is stopping - called by [replicate]"
```

It clears each peer's `SceneReplicationState` inside `main_context` deliberately, because Urho3D's weak pointers are not thread safe. With the call refused, that state was instead destructed on `replicate`'s own thread while `main_context` was still running — the exact race the code was written to avoid.

Each module is now stopped and joined in turn, in reverse load order, so a destructor still has the modules below it. Ordering was already the intent; only the up-front `request_stop` of everything got in its way. The stop order for `games/digger` runs `main`, `worldgen`, `voxel_shading`, `voxelworld`, `replicate`, `client_lua`, `client_data`, `client_file`, `network`, `main_context`, `loader`, `__loader`.

## Checked

Against `games/digger`, in each case that the process exits rather than being killed, and that the log carries the shutdown through:

| | | |
|---|---|---|
| no client | SIGTERM | exits, status 0 |
| no client | SIGINT | exits, status 0 |
| client connected | SIGTERM | exits, status 0 |
| after the client quit | SIGINT | exits, status 0 |
| twice | SIGINT, SIGINT | dies by signal, status 130 |

With the teardown change the warning is gone, `replicate destruct` completes with a client connected, and shutdown takes under a second rather than two — stopping the modules in order turns out to be quicker than stopping them all at once and waiting.

`src/client/main.cpp` has the same never-installed handler, and `app.cpp:950` is already waiting on the flag. Left alone here since the ask was the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)