### PR TITLE
client: Install the shutdown signal handler, and handle SIGTERM

### DIFF
--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -67,7 +67,7 @@ static const int MIN_WINDOW_W = 640;
 static const int MIN_WINDOW_H = 360;
 
 extern client::Config g_client_config;
-extern bool g_sigint_received;
+extern volatile sig_atomic_t g_shutdown_signal;
 
 static ss_ window_state_path()
 {
@@ -407,6 +407,9 @@ struct CApp: public App, public magic::Application
 	magic::LuaScript *m_script;
 	lua_State *L;
 	bool m_reboot_requested = false;
+	// shutdown() is not instant; the frames until the window closes must not
+	// each call it again
+	bool m_shutdown_signal_handled = false;
 	float m_ui_scale_lua = 0.f; // 0 = not set by Lua
 	bool m_restore_maximized = false;
 	Options m_options;
@@ -947,8 +950,15 @@ struct CApp: public App, public magic::Application
 		/*magic::AutoProfileBlock profiler_block(
 				GetSubsystem<magic::Profiler>(), "App::on_update");*/
 
-		if(g_sigint_received)
+		if(g_shutdown_signal != 0 && !m_shutdown_signal_handled){
+			m_shutdown_signal_handled = true;
+			// SIGINT leaves a "^C" on the terminal to write past
+			if(g_shutdown_signal == SIGINT)
+				fprintf(stdout, "\n");
+			log_i(MODULE, "%s; shutting down",
+					g_shutdown_signal == SIGINT ? "SIGINT" : "SIGTERM");
 			shutdown();
+		}
 		if(m_state)
 			m_state->update();
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -21,22 +21,32 @@ namespace magic = Urho3D;
 
 client::Config g_client_config;
 
-// TODO: This isn't thread-safe
-bool g_sigint_received = false;
-void sigint_handler(int sig)
+// The signal that asked for shutdown, read by App::on_update(). Only things a
+// signal handler may touch belong in here: no logging, no locking, no
+// allocation. The frame that sees this does all of that.
+volatile sig_atomic_t g_shutdown_signal = 0;
+
+void shutdown_signal_handler(int sig)
 {
-	if(!g_sigint_received){
-		fprintf(stdout, "\n"); // Newline after "^C"
-		log_i("process", "SIGINT");
-		g_sigint_received = true;
+	if(g_shutdown_signal == 0){
+		g_shutdown_signal = sig;
 	} else {
-		(void)signal(SIGINT, SIG_DFL);
+		// Asked twice: the shutdown is not getting anywhere -- or the frame
+		// loop is not running yet -- so let the default action have the
+		// process
+		(void)signal(sig, SIG_DFL);
+		(void)raise(sig);
 	}
 }
 
 void signal_handler_init()
 {
-	(void)signal(SIGINT, sigint_handler);
+	(void)signal(SIGINT, shutdown_signal_handler);
+	(void)signal(SIGTERM, shutdown_signal_handler);
+#ifndef _WIN32
+	// A write to a socket the server has dropped must not kill the client
+	(void)signal(SIGPIPE, SIG_IGN);
+#endif
 }
 
 int main(int argc, char *argv[])
@@ -150,6 +160,8 @@ int main(int argc, char *argv[])
 			return 1;
 		}
 	}
+
+	signal_handler_init();
 
 	if(!boot::autodetect::detect_client_paths(config))
 		return 1;


### PR DESCRIPTION
The same defect #33 fixed in the server, in the client: `sigint_handler()` and `signal_handler_init()` were written but `main()` never called the latter, so neither signal was handled. Both took their default action and the client died where it stood, and the per-frame `g_sigint_received` check in `app.cpp` could never fire.

What that skipped: `shutdown()` and `~CApp()`, and with them `stop_local_server()`. A client that had started a local server left it running, with a stale `cache/local_server.pid` beside it. `adopt_pidfile()` picks such a leftover up on the next client start and can stop it, so it is recoverable — but until then there is a server running that nobody asked for. `shutdown()` also writes back the graphics options, so the remembered window size was lost too.

`main()` now installs the handler, and it covers SIGTERM as well as SIGINT. SIGPIPE is ignored as the server already does it, so that a write to a socket the server has dropped does not kill the client outright.

The handler itself only assigns to a `volatile sig_atomic_t` — the old one wrote a plain `bool` and called `fprintf()` and `log_i()`, none of which a handler may do. The frame that sees the flag does the logging and calls `shutdown()`, once: shutdown takes several frames to close the window, and the check had no guard against re-entering it. A second signal restores the default action and re-raises, which matters more here than in the server, since the client can wedge before the frame loop ever runs — SDL's `X11_SetWindowGrab` retries `XGrabPointer` forever if the grab is refused, and nothing would poll the flag while it does.

Tested against a running `games/digger` server:

| | |
|---|---|
| SIGTERM, interactive client | clean shutdown, status 0 |
| SIGINT, interactive client | clean shutdown, status 0 |
| SIGTERM, client running a `-c` sequence | clean shutdown, status 1, as any interrupted sequence gives |
| SIGINT twice | dies by signal, status 130, nothing left running |

And the local server path, by writing a running `buildat_server` pid into `cache/local_server.pid` and then sending SIGTERM to the client:

```
SIGTERM; shutting down
Adopted leftover local server pid 2729626
Stopping local server
SIGTERM pid 2729626
```

The server was gone within a second and the pidfile removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)