### PR TITLE
voxel_shading: Steady the reflected sky, and make it cheap enough to sample properly

### DIFF
--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -181,6 +181,14 @@ void VS()
     // pads every element out to four.
     uniform vec4 cSkyVis[54];
 
+    // Multiplies the reflected sky, for looking at the reflections rather
+    // than at the scene. 1 is what a game renders; the benchmarks turn it up
+    // so that changes to the sky visibility sampling are visible at all --
+    // most of a cave is rock reflecting almost nothing, and a change worth
+    // arguing about moves a wall by a fraction of a value out of 255. Zero
+    // when nothing sets it, so voxel_shading pushes it every frame.
+    uniform float cSpecEmphasis;
+
     const float TRANSMISSION_CELLS = 16.0;   // Cells per voxel, per axis
     // A material whose own roughness is already below this cannot glint, so
     // water is given a duller base than a still pond would have
@@ -546,7 +554,7 @@ void PS()
             // how much is visible along the reflection: the cube map answers
             // for the direction, the vertex color for the place.
             finalColor.rgb += cube * EnvBRDFApprox(specColor, roughness, ndv) *
-                vSkyVisibility;
+                vSkyVisibility * cSpecEmphasis;
         #endif
 
         #ifdef ENVCUBEMAP

--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -170,9 +170,9 @@ void VS()
     // once. A slow term along the wind direction is added to the phase, which
     // turns what would be an even twinkle into gusts crossing the surface.
 
-    // How much of the sky the camera can see, per direction: a cube of 6x6
-    // values per face, 1 for full sky and 0 for none. 216 numbers, packed four
-    // to a vec4 in face, row, column order. The client writes them as one
+    // How much of the sky the camera can see, per direction: a cube of
+    // SKYVIS_CELLS squared values per face, 1 for full sky and 0 for none,
+    // packed four to a vec4 in face, row, column order. The client writes them as one
     // buffer parameter, which Urho hands to a float array uniform; a cube map
     // texture would have to be built and uploaded per update instead.
     //

--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -179,7 +179,12 @@ void VS()
     // vec4 rather than a float array so the packing is the same whether or not
     // the driver lays uniforms out as std140, where an array of float or vec3
     // pads every element out to four.
-    uniform vec4 cSkyVis[54];
+    // Cells per cube face, per axis. Six faces of SKYVIS_CELLS squared values,
+    // packed four to a vec4, so the array is 6*C*C/4 long -- keep the two in
+    // step, and in step with CELLS in the client's module.lua, which fills
+    // them.
+    const int SKYVIS_CELLS = 12;
+    uniform vec4 cSkyVis[216];
 
     // Multiplies the reflected sky, for looking at the reflections rather
     // than at the scene. 1 is what a game renders; the benchmarks turn it up
@@ -250,7 +255,7 @@ void VS()
     float SkyVisCell(int face, int row, int col)
     {
         // "flat" is a reserved word in GLSL, hence the name
-        int cell = face * 36 + row * 6 + col;
+        int cell = (face * SKYVIS_CELLS + row) * SKYVIS_CELLS + col;
         return cSkyVis[cell / 4][cell - (cell / 4) * 4];
     }
 
@@ -289,13 +294,16 @@ void VS()
         }
         m = max(m, M_EPSILON);
         // Cell centers sit half a cell in from each edge, so the position in
-        // cells is the position across the face times six, less a half
-        float fu = clamp((u / m + 1.0) * 3.0 - 0.5, 0.0, 5.0);
-        float fv = clamp((v / m + 1.0) * 3.0 - 0.5, 0.0, 5.0);
+        // cells is the position across the face times the cell count, less a
+        // half
+        float half_cells = float(SKYVIS_CELLS) * 0.5;
+        float last = float(SKYVIS_CELLS - 1);
+        float fu = clamp((u / m + 1.0) * half_cells - 0.5, 0.0, last);
+        float fv = clamp((v / m + 1.0) * half_cells - 0.5, 0.0, last);
         int c0 = int(fu);
-        int c1 = min(c0 + 1, 5);
+        int c1 = min(c0 + 1, SKYVIS_CELLS - 1);
         int r0 = int(fv);
-        int r1 = min(r0 + 1, 5);
+        int r1 = min(r0 + 1, SKYVIS_CELLS - 1);
         float tu = fu - float(c0);
         return mix(
             mix(SkyVisCell(face, r0, c0), SkyVisCell(face, r0, c1), tu),

--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -183,8 +183,8 @@ void VS()
     // packed four to a vec4, so the array is 6*C*C/4 long -- keep the two in
     // step, and in step with CELLS in the client's module.lua, which fills
     // them.
-    const int SKYVIS_CELLS = 12;
-    uniform vec4 cSkyVis[216];
+    const int SKYVIS_CELLS = 6;
+    uniform vec4 cSkyVis[54];
 
     // Multiplies the reflected sky, for looking at the reflections rather
     // than at the scene. 1 is what a game renders; the benchmarks turn it up

--- a/builtin/voxel_shading/client_lua/module.lua
+++ b/builtin/voxel_shading/client_lua/module.lua
@@ -50,11 +50,15 @@ local TECHNIQUE = magic.cache:GetResource("Technique",
 --
 -- The values come from marching rays through the voxel data from the camera.
 -- No geometry, depth buffer or render pass is involved. buildat.cast_voxel_rays
--- does the marching, which is what makes this many rays affordable: the same
--- loop written in Lua cost half a millisecond a frame for four rays of twenty
--- voxels, where the engine does 36 of sixty-four in 0.33 ms. It also decides
--- what stops a ray by the voxel registry's own physically_solid, so glass and
--- water are whatever the world says they are.
+-- does the marching, on a worker thread, which is what makes this many rays
+-- affordable: the same loop written in Lua cost half a millisecond a frame for
+-- four rays of twenty voxels, where the engine marches one in a third of a
+-- microsecond. It also decides what stops a ray by the voxel registry's own
+-- physically_solid, so glass and water are whatever the world says they are.
+--
+-- Handing the rays over costs several times more than marching them does --
+-- see the note in games/voxel_lighting/README.txt for where the time goes, and
+-- for why making the marching itself faster would be the wrong thing to try.
 --
 -- A ray answers no if something solid stops it, and otherwise the skylight of
 -- the air it ended in. Partial values come from sampling rather
@@ -72,24 +76,26 @@ local CELL_COUNT = FACES * CELLS * CELLS
 -- clumping the way K independent samples would.
 local RAYS_PER_CELL = 4
 -- Cells refreshed per frame. A sweep is every cell once, so this is how often
--- the whole cube is renewed: 36 cells of a 12x12x6 cube is a sweep every 24
--- frames. Rays per frame is this times RAYS_PER_CELL.
+-- the whole cube is renewed: 36 cells of the 216 here is a sweep every six
+-- frames, or every three at the rate MAX_IN_FLIGHT actually keeps up -- read
+-- its comment before taking this or RAYS_PER_CELL as rays per frame.
 local CELLS_PER_UPDATE = 36
 -- How far a ray looks. Long, because the length is what makes the answer
 -- strict: a ray down digger's tunnel has to reach the end of it to find out
 -- that the tunnel is not a way to the sky, and the tunnel is tens of voxels
 -- long. Cheap enough that this is not the thing to save on.
 local RAY_VOXELS = 64
--- How much of a cell's new ray is taken into its value. One ray is a yes or a
--- no, so this average is what turns the rays into the fraction of a cell that
--- sees sky. At 0.15, with a ray per cell every sixth frame, a cell settles in
--- under a second and the reflections trail the camera by about that. Taking
--- more of each ray puts their own noise on the screen, which reads as the
--- speculars flickering several times a second.
+-- How much of a cell's new value is taken into the one the shader sees. What a
+-- sweep hands over is already an average of RAYS_PER_CELL rays; this averages
+-- those over time as well. At 0.10 a cell settles in about a second and the
+-- reflections trail the camera by about that. Taking more of each sweep puts
+-- the sampling's own noise on the screen, which reads as the speculars
+-- flickering several times a second.
 local SKY_VIS_BLEND = 0.10
 -- Sweeps averaged when snapping, for a camera that has been moved rather than
 -- has moved: the same averaging done at once, so a screenshot taken right
--- after a teleport is as settled as one taken later. This is some thousands of
+-- after a teleport is as settled as one taken later. Two rather than more
+-- because a sweep is already RAYS_PER_CELL deep. This is some thousands of
 -- rays in one frame and drops one, which is what a teleport does anyway.
 local SNAP_SWEEPS = 2
 -- Chunks are collected around the camera out to the reach of a ray, and the
@@ -154,9 +160,10 @@ local volumes_age = VOLUME_REFRESH_SWEEPS
 local ray_args = {
 	directions = DIRS,
 	max_steps = RAY_VOXELS,
-	-- Not used: see ray_visibility() on why skylight cannot say which way the
-	-- sky is. The engine will stop a ray at a skylight level for callers that
-	-- do want that.
+	-- Not used: skylight says the sky is open above a voxel, which is nothing
+	-- to do with whether the sky lies along the ray, so stopping a ray at it
+	-- answers the wrong question -- see the note further down. The engine will
+	-- do it for callers that do want it.
 	stop_skylight = 0,
 	-- Consecutive rays are one cell's, and the engine hands back their average
 	-- per cell rather than what each of them found: a few hundred numbers a
@@ -211,7 +218,7 @@ end)
 -- wobbling on its own. Coherent like that it reads as the scene pulsing, which
 -- is far more visible than the same amount of noise spread over cells, and
 -- since the step is a fixed sequence the pulsing is periodic. More rays does
--- not help: it is not a shortage of samples, it is 216 cells making the same
+-- not help: it is not a shortage of samples, it is every cell making the same
 -- error at the same moment.
 --
 -- The offsets are the R2 low discrepancy sequence over the cells, which spreads
@@ -400,6 +407,12 @@ end
 -- have nothing to collect and nothing to submit, and the sweep would take
 -- twice as long for no reason. Two is enough to keep a worker fed. The pool
 -- has four of them and the mesher is the other caller.
+--
+-- Note what this does to the rate. The queue is topped back up to this depth
+-- every frame, so when the workers keep up, two slices are submitted per frame
+-- and the rays cast are twice CELLS_PER_UPDATE times RAYS_PER_CELL: 288 a
+-- frame where those two constants read 144. Worth knowing before reading
+-- either of them as a rate.
 local MAX_IN_FLIGHT = 2
 local in_flight = {}
 

--- a/builtin/voxel_shading/client_lua/module.lua
+++ b/builtin/voxel_shading/client_lua/module.lua
@@ -121,12 +121,14 @@ local FACE_AXES = {
 
 local CELL_SIZE = 2.0 / CELLS
 
--- One table per ray, reused: the sweep rewrites their components rather than
--- building thousands of tables of three numbers every time. RAYS_PER_CELL of
--- them per cell, in cell order, so a slice of cells is a run of directions.
+-- The directions, three numbers to a ray, in cell order: RAYS_PER_CELL of them
+-- per cell, so a slice of cells is a run of directions. One flat array rather
+-- than a table per ray because the engine reads every one of these every
+-- frame, and a table each was most of what the sampling cost.
+local AXIS_OFFSET = {x = 0, y = 1, z = 2}
 local DIRS = {}
-for i = 1, CELL_COUNT * RAYS_PER_CELL do
-	DIRS[i] = {x = 0, y = 0, z = 0}
+for i = 1, CELL_COUNT * RAYS_PER_CELL * 3 do
+	DIRS[i] = 0.0
 end
 
 local camera_node = nil
@@ -156,6 +158,12 @@ local ray_args = {
 	-- sky is. The engine will stop a ray at a skylight level for callers that
 	-- do want that.
 	stop_skylight = 0,
+	-- Consecutive rays are one cell's, and the engine hands back their average
+	-- per cell rather than what each of them found: a few hundred numbers a
+	-- frame instead of four per ray. What a ray is worth is then the engine's
+	-- rule; see cast_voxel_rays() in src/lua_bindings/voxel_volume.cpp. A game
+	-- wanting its own leaves this unset and reads the rays itself.
+	rays_per_cell = RAYS_PER_CELL,
 	first = 1,
 	count = 1,
 	origin = {x = 0, y = 0, z = 0},
@@ -165,6 +173,7 @@ local ray_args = {
 -- per frame
 local sky_vis_buffer = magic.VectorBuffer:new()
 local sky_vis_param = nil
+local sky_vis_dirty = false
 -- Multiplies the reflected sky in the shader. 1 is what a game renders; the
 -- benchmarks turn it up to look at the reflections themselves. See
 -- M.set_specular_emphasis().
@@ -246,18 +255,21 @@ local function aim_dirs(index)
 	local i = 1
 	for face = 1, FACES do
 		local a = FACE_AXES[face]
+		local mo = AXIS_OFFSET[a.major] + 1
+		local uo = AXIS_OFFSET[a.u] + 1
+		local vo = AXIS_OFFSET[a.v] + 1
 		for row = 0, CELLS - 1 do
 			for col = 0, CELLS - 1 do
 				local bu = CELL_JITTER_U[i] + su
 				local bv = CELL_JITTER_V[i] + sv
-				local base = (i - 1) * RAYS_PER_CELL
+				local base = (i - 1) * RAYS_PER_CELL * 3
 				for k = 1, RAYS_PER_CELL do
-					local d = DIRS[base + k]
 					local ju = (bu + STRAT_U[k]) % 1.0 - 0.5
 					local jv = (bv + STRAT_V[k]) % 1.0 - 0.5
-					d[a.major] = a.sign
-					d[a.u] = (col + 0.5 + ju) * CELL_SIZE - 1.0
-					d[a.v] = (row + 0.5 + jv) * CELL_SIZE - 1.0
+					DIRS[base + mo] = a.sign
+					DIRS[base + uo] = (col + 0.5 + ju) * CELL_SIZE - 1.0
+					DIRS[base + vo] = (row + 0.5 + jv) * CELL_SIZE - 1.0
+					base = base + 3
 				end
 				i = i + 1
 			end
@@ -272,38 +284,17 @@ end
 -- however brightly lit the air in between happens to be. Partial values come
 -- from the sampling, not from softening this.
 --
--- Where the ray got to without being stopped, the skylight of the air it
--- ended in is the answer: skylight says the sky is open straight up from
--- there, and a ray that has travelled its whole length has put that point
--- where the reflection is looking. Fully lit air at the far end is sky, dark
--- air deep inside a cavern is not, which is the case a fixed length gets
--- wrong on its own -- a ray crossing sixty-four voxels of unlit cavern has
--- met nothing and seen no sky either.
+-- What a ray is worth is the engine's rule now, since averaging rays into a
+-- cell means deciding that: nothing if something solid stopped it, otherwise
+-- the skylight of the air it ended in. See ray_visibility() in
+-- src/lua_bindings/voxel_volume.cpp for why it is there and what it means.
 --
--- Note where skylight is not used: not as something that stops a ray. It
--- says the sky is open above a point, which is nothing to do with whether the
--- sky lies along the ray, and stopping rays at full skylight looked right and
--- was badly wrong -- at the mouth of digger's tunnel the air is fully lit, so
--- every direction, the tunnel included, came back at 1 and the tunnel got
--- full outdoor reflections. At the far end of a ray it answers a question it
--- can answer, about the place the ray reached.
---
--- Running out of loaded chunks part way is the same answer for the same
--- reason. A ray that never got into voxel data at all is outdoors, which is a
--- camera above the world.
-local SKYLIGHT_MAX = 15
-local RAY = buildat.VOXEL_RAY
-
-local function ray_visibility(status, skylight, steps)
-	if status == RAY.BLOCKED then
-		return 0.0
-	elseif steps <= 1 then
-		return 1.0 -- Left the voxel data at once: nothing is around us
-	elseif skylight < 0 then
-		return 0.0
-	end
-	return skylight / SKYLIGHT_MAX
-end
+-- Note what that rule does not do: stop a ray at full skylight. Skylight says
+-- the sky is open above a point, which is nothing to do with whether the sky
+-- lies along the ray, and stopping rays on it looked right and was badly wrong
+-- -- at the mouth of digger's tunnel the air is fully lit, so every direction
+-- including the tunnel came back at 1. At the far end of a ray it answers
+-- about the place the ray reached, which is a question it can answer.
 
 -- The chunks a ray could reach. The engine picks the one it needs per step out
 -- of this list, so it only has to be the right set, not a short one.
@@ -354,18 +345,12 @@ local function collect_volumes(origin)
 	return n > 0
 end
 
--- What a finished slice's rays found, into the sweep: a cell's RAYS_PER_CELL
--- rays are consecutive, and the cell keeps their average
+-- What a finished slice found, into the sweep: the engine has already averaged
+-- each cell's rays into one value
 local function keep_slice(first_cell, count_cells, out)
-	local status, skylight, steps = out.status, out.skylight, out.steps
-	local n = 0
+	local vis = out.visibility
 	for c = 1, count_cells do
-		local sum = 0.0
-		for k = 1, RAYS_PER_CELL do
-			n = n + 1
-			sum = sum + ray_visibility(status[n], skylight[n], steps[n])
-		end
-		sweep_vis[first_cell + c - 1] = sum / RAYS_PER_CELL
+		sweep_vis[first_cell + c - 1] = vis[c]
 	end
 end
 
@@ -387,10 +372,20 @@ local function blend_cells(first, count, f)
 	for i = first, first + count - 1 do
 		sky_vis[i] = sky_vis[i] + (sweep_vis[i] - sky_vis[i]) * f
 	end
-	-- One parameter of 216 floats rather than 216 parameters: Urho sets a
-	-- Variant buffer as a float array, sized by what the uniform declares.
-	-- Packed by the engine because this happens every frame and WriteFloat()
-	-- per value is a sandbox call each.
+	sky_vis_dirty = true
+end
+
+-- The values as the shader takes them. One parameter of CELL_COUNT floats
+-- rather than that many parameters: Urho sets a Variant buffer as a float
+-- array, sized by what the uniform declares. Packed by the engine because
+-- WriteFloat() per value is a sandbox call each.
+--
+-- Once a frame, however many slices landed in it. Repacking per slice meant
+-- reading every cell out of Lua twice a frame to publish a cube that only the
+-- shader ever reads, and the shader reads it once.
+local function repack_sky_vis()
+	if not sky_vis_dirty then return end
+	sky_vis_dirty = false
 	buildat.write_floats(sky_vis_buffer, sky_vis)
 	sky_vis_param = magic.Variant(sky_vis_buffer)
 end
@@ -473,6 +468,7 @@ end
 local DECLARE_EVERY_FRAMES = 60
 
 local function push_sky_vis()
+	repack_sky_vis()
 	if sky_vis_param == nil then return end
 	local viewport = magic.renderer:GetViewport(0)
 	if viewport == nil then return end

--- a/builtin/voxel_shading/client_lua/module.lua
+++ b/builtin/voxel_shading/client_lua/module.lua
@@ -289,16 +289,77 @@ local function collect_volumes(origin)
 	return n > 0
 end
 
--- One slice of a sweep: cast the rays for cells first..first+count-1 and keep
--- what they found
-local function cast_slice(first, count)
-	ray_args.first = first
-	ray_args.count = count
-	local out = buildat.cast_voxel_rays(ray_args)
+-- What a finished slice's rays found, into the sweep
+local function keep_slice(first, out)
 	local status, skylight, steps = out.status, out.skylight, out.steps
 	for i = 1, out.count do
 		sweep_vis[first + i - 1] =
 				ray_visibility(status[i], skylight[i], steps[i])
+	end
+end
+
+-- One slice of a sweep, marched here and now. Only the snap uses this: it is
+-- thousands of rays wanted before the next frame is drawn, which is what
+-- blocking is for.
+local function cast_slice(first, count)
+	ray_args.first = first
+	ray_args.count = count
+	keep_slice(first, buildat.cast_voxel_rays(ray_args))
+end
+
+-- f is how much of the sweep's rays to take; 1.0 replaces the values outright
+local function blend_cells(first, count, f)
+	for i = first, first + count - 1 do
+		sky_vis[i] = sky_vis[i] + (sweep_vis[i] - sky_vis[i]) * f
+	end
+	-- One parameter of 216 floats rather than 216 parameters: Urho sets a
+	-- Variant buffer as a float array, sized by what the uniform declares.
+	-- Packed by the engine because this happens every frame and WriteFloat()
+	-- per value is a sandbox call each.
+	buildat.write_floats(sky_vis_buffer, sky_vis)
+	sky_vis_param = magic.Variant(sky_vis_buffer)
+end
+
+-- Slices out on worker threads, oldest first. The marching is the same work
+-- wherever it runs; what moves it off the frame is that the frame has better
+-- uses for a third of a millisecond, and that the sampling wants several times
+-- more rays than that.
+--
+-- More than one is kept in flight because a slice submitted in one frame is
+-- collected in a later one: with a single slice out, every other frame would
+-- have nothing to collect and nothing to submit, and the sweep would take
+-- twice as long for no reason. Two is enough to keep a worker fed. The pool
+-- has four of them and the mesher is the other caller.
+local MAX_IN_FLIGHT = 2
+local in_flight = {}
+
+local function submit_slice(first, count)
+	ray_args.first = first
+	ray_args.count = count
+	in_flight[#in_flight + 1] = {first = first, count = count,
+			job = buildat.cast_voxel_rays_start(ray_args)}
+end
+
+-- Blends in what has finished, oldest first, and stops at the first slice that
+-- has not: they are taken in the order they were cast.
+local function collect_slices(f)
+	while in_flight[1] ~= nil do
+		local slice = in_flight[1]
+		local out = buildat.cast_voxel_rays_collect(slice.job)
+		if out == nil then
+			return
+		end
+		table.remove(in_flight, 1)
+		keep_slice(slice.first, out)
+		blend_cells(slice.first, slice.count, f)
+	end
+end
+
+-- Anything in flight is reading volumes it holds itself, so dropping the
+-- handles is enough; what they find is no longer wanted.
+local function drop_slices()
+	for i = #in_flight, 1, -1 do
+		in_flight[i] = nil
 	end
 end
 
@@ -316,18 +377,6 @@ local function begin_sweep()
 	aim_dirs(sweep_index)
 end
 
--- f is how much of the sweep's rays to take; 1.0 replaces the values outright
-local function blend_cells(first, count, f)
-	for i = first, first + count - 1 do
-		sky_vis[i] = sky_vis[i] + (sweep_vis[i] - sky_vis[i]) * f
-	end
-	-- One parameter of 216 floats rather than 216 parameters: Urho sets a
-	-- Variant buffer as a float array, sized by what the uniform declares.
-	-- Packed by the engine because this happens every frame and WriteFloat()
-	-- per value is a sandbox call each.
-	buildat.write_floats(sky_vis_buffer, sky_vis)
-	sky_vis_param = magic.Variant(sky_vis_buffer)
-end
 
 -- The values go on the render path's scene pass commands rather than on
 -- materials. Urho hands a scene pass command's shader parameters to every
@@ -398,6 +447,10 @@ function M.update(dt)
 		-- Several sweeps at once, averaged the way the easing would have
 		-- averaged them over a second. A single sweep is one ray per cell,
 		-- which is too coarse to look at.
+		--
+		-- What is already out on a worker was cast from where the camera used
+		-- to be, and blending it in afterwards would undo part of the snap.
+		drop_slices()
 		for sweep = 1, SNAP_SWEEPS do
 			begin_sweep()
 			if collect_volumes(origin) then
@@ -411,27 +464,31 @@ function M.update(dt)
 		push_sky_vis()
 		return
 	end
-	if sweep_next == 1 and not collect_volumes(origin) then
-		sweep_all_open()
-		blend_cells(1, CELL_COUNT, SKY_VIS_BLEND)
-		begin_sweep()
-		push_sky_vis()
-		return
-	end
 	-- Each frame's cells are blended in and handed to the shader as their own
 	-- rays land, rather than a whole sweep at a time: waiting for the sweep
 	-- steps every reflection in the scene together, six frames apart, where
 	-- this spreads the same change out. Reasoning rather than measurement --
 	-- see the note in games/voxel_lighting/README.txt.
-	local first = sweep_next
-	local count = math.min(RAYS_PER_UPDATE, CELL_COUNT - sweep_next + 1)
-	cast_slice(first, count)
-	blend_cells(first, count, SKY_VIS_BLEND)
-	push_sky_vis()
-	sweep_next = sweep_next + count
-	if sweep_next > CELL_COUNT then
-		begin_sweep()
+	collect_slices(SKY_VIS_BLEND)
+	-- Topped back up to the same depth every frame, so what is submitted is
+	-- what came back: if the workers are busy, nothing is submitted and the
+	-- sweep waits rather than piling up.
+	while #in_flight < MAX_IN_FLIGHT do
+		if sweep_next == 1 and not collect_volumes(origin) then
+			sweep_all_open()
+			blend_cells(1, CELL_COUNT, SKY_VIS_BLEND)
+			begin_sweep()
+			break
+		end
+		local first = sweep_next
+		local count = math.min(RAYS_PER_UPDATE, CELL_COUNT - sweep_next + 1)
+		submit_slice(first, count)
+		sweep_next = sweep_next + count
+		if sweep_next > CELL_COUNT then
+			begin_sweep()
+		end
 	end
+	push_sky_vis()
 end
 
 -- The sky the world stands under, drawn by VoxelSkybox.glsl in the same

--- a/builtin/voxel_shading/client_lua/module.lua
+++ b/builtin/voxel_shading/client_lua/module.lua
@@ -179,18 +179,47 @@ voxelworld.sub_material_update(function(node)
 	end)
 end)
 
--- Where in its cell this sweep samples. Two irrational steps, so the point
--- walks the cell instead of landing on a few spots, and the same sequence
--- every run.
+-- Where in its cell each ray of this sweep samples.
+--
+-- Two parts: a fixed offset per cell, and a step the whole sweep takes. The
+-- step is two irrationals, so a cell's sample point walks its cell instead of
+-- landing on a few spots, and the sequence is the same every run.
+--
+-- The per-cell offset is the part that matters for what this looks like. With
+-- one offset for the whole cube, every cell samples the same relative point at
+-- the same time and their errors line up: a sweep whose offset happens to lean
+-- towards the sky brightens every cell that straddles an opening at once, so
+-- the reflections in the whole scene move together rather than each surface
+-- wobbling on its own. Coherent like that it reads as the scene pulsing, which
+-- is far more visible than the same amount of noise spread over cells, and
+-- since the step is a fixed sequence the pulsing is periodic. More rays does
+-- not help: it is not a shortage of samples, it is 216 cells making the same
+-- error at the same moment.
+--
+-- The offsets are the R2 low discrepancy sequence over the cells, which spreads
+-- them evenly in the square rather than clumping the way independent random
+-- ones would. The sweep step is the golden ratio and root two, unrelated to R2
+-- so the two do not come back into step with each other.
+local CELL_JITTER_U = {}
+local CELL_JITTER_V = {}
+for i = 1, CELL_COUNT do
+	CELL_JITTER_U[i] = (i * 0.7548776662) % 1.0
+	CELL_JITTER_V[i] = (i * 0.5698402909) % 1.0
+end
+local SWEEP_STEP_U = 0.6180339887
+local SWEEP_STEP_V = 0.4142135624
+
 local function aim_dirs(index)
-	local ju = (index * 0.7548776662) % 1.0 - 0.5
-	local jv = (index * 0.5698402909) % 1.0 - 0.5
+	local su = (index * SWEEP_STEP_U) % 1.0
+	local sv = (index * SWEEP_STEP_V) % 1.0
 	local i = 1
 	for face = 1, FACES do
 		local a = FACE_AXES[face]
 		for row = 0, CELLS - 1 do
 			for col = 0, CELLS - 1 do
 				local d = DIRS[i]
+				local ju = (CELL_JITTER_U[i] + su) % 1.0 - 0.5
+				local jv = (CELL_JITTER_V[i] + sv) % 1.0 - 0.5
 				d[a.major] = a.sign
 				d[a.u] = (col + 0.5 + ju) * CELL_SIZE - 1.0
 				d[a.v] = (row + 0.5 + jv) * CELL_SIZE - 1.0

--- a/builtin/voxel_shading/client_lua/module.lua
+++ b/builtin/voxel_shading/client_lua/module.lua
@@ -62,7 +62,7 @@ local TECHNIQUE = magic.cache:GetResource("Technique",
 -- and differently each sweep, and each cell keeps an average of its own rays,
 -- so a cell settles at the fraction of its directions that see sky.
 local FACES = 6
-local CELLS = 12                -- Per face, per axis
+local CELLS = 6                -- Per face, per axis
 local CELL_COUNT = FACES * CELLS * CELLS
 -- Rays cast into each cell per sweep, averaged into that cell's value. This is
 -- the knob for how noisy one sweep's answer is: a cell's rays are yes or no,
@@ -70,7 +70,7 @@ local CELL_COUNT = FACES * CELLS * CELLS
 -- the average of K of them has a K-th of the variance. They are stratified
 -- within the cell rather than independent, so they cover it evenly instead of
 -- clumping the way K independent samples would.
-local RAYS_PER_CELL = 16
+local RAYS_PER_CELL = 4
 -- Cells refreshed per frame. A sweep is every cell once, so this is how often
 -- the whole cube is renewed: 36 cells of a 12x12x6 cube is a sweep every 24
 -- frames. Rays per frame is this times RAYS_PER_CELL.

--- a/builtin/voxel_shading/client_lua/module.lua
+++ b/builtin/voxel_shading/client_lua/module.lua
@@ -56,8 +56,8 @@ local TECHNIQUE = magic.cache:GetResource("Technique",
 -- what stops a ray by the voxel registry's own physically_solid, so glass and
 -- water are whatever the world says they are.
 --
--- A ray answers yes if it gets its whole length without meeting anything and
--- no if something solid stops it. Partial values come from sampling rather
+-- A ray answers no if something solid stops it, and otherwise the skylight of
+-- the air it ended in. Partial values come from sampling rather
 -- than from any softening of that: the rays are jittered within their cells
 -- and differently each sweep, and each cell keeps an average of its own rays,
 -- so a cell settles at the fraction of its directions that see sky.
@@ -203,18 +203,24 @@ end
 -- however brightly lit the air in between happens to be. Partial values come
 -- from the sampling, not from softening this.
 --
--- "Nothing stopped it" means the ray got RAY_VOXELS of the way without
--- meeting anything, which is as much as this asks. Note what is not used
--- here: a voxel's skylight says the sky is open straight up from it, which is
--- nothing to do with whether the sky lies along the ray. Stopping a ray at
--- full skylight looked right and was badly wrong -- at the mouth of digger's
--- tunnel the air is fully lit, so every direction, the tunnel included, came
--- back at 1 and the tunnel got full outdoor reflections.
+-- Where the ray got to without being stopped, the skylight of the air it
+-- ended in is the answer: skylight says the sky is open straight up from
+-- there, and a ray that has travelled its whole length has put that point
+-- where the reflection is looking. Fully lit air at the far end is sky, dark
+-- air deep inside a cavern is not, which is the case a fixed length gets
+-- wrong on its own -- a ray crossing sixty-four voxels of unlit cavern has
+-- met nothing and seen no sky either.
 --
--- Skylight is still what answers for a ray that runs out of loaded chunks
--- part way: the skylight where it stopped is how far along the way out it had
--- got, and believing that is better than calling the edge of the loaded world
--- sky. A ray that never got into voxel data at all is outdoors, which is a
+-- Note where skylight is not used: not as something that stops a ray. It
+-- says the sky is open above a point, which is nothing to do with whether the
+-- sky lies along the ray, and stopping rays at full skylight looked right and
+-- was badly wrong -- at the mouth of digger's tunnel the air is fully lit, so
+-- every direction, the tunnel included, came back at 1 and the tunnel got
+-- full outdoor reflections. At the far end of a ray it answers a question it
+-- can answer, about the place the ray reached.
+--
+-- Running out of loaded chunks part way is the same answer for the same
+-- reason. A ray that never got into voxel data at all is outdoors, which is a
 -- camera above the world.
 local SKYLIGHT_MAX = 15
 local RAY = buildat.VOXEL_RAY
@@ -222,8 +228,6 @@ local RAY = buildat.VOXEL_RAY
 local function ray_visibility(status, skylight, steps)
 	if status == RAY.BLOCKED then
 		return 0.0
-	elseif status == RAY.RANGE then
-		return 1.0
 	elseif steps <= 1 then
 		return 1.0 -- Left the voxel data at once: nothing is around us
 	elseif skylight < 0 then

--- a/builtin/voxel_shading/client_lua/module.lua
+++ b/builtin/voxel_shading/client_lua/module.lua
@@ -156,6 +156,10 @@ local ray_args = {
 -- per frame
 local sky_vis_buffer = magic.VectorBuffer:new()
 local sky_vis_param = nil
+-- Multiplies the reflected sky in the shader. 1 is what a game renders; the
+-- benchmarks turn it up to look at the reflections themselves. See
+-- M.set_specular_emphasis().
+local spec_emphasis = 1.0
 
 local function each_material(node, cb)
 	local cg = node:GetComponent("CustomGeometry")
@@ -358,11 +362,29 @@ local function push_sky_vis()
 			local command = render_path:GetCommand(i)
 			if command ~= nil and command.type == magic.CMD_SCENEPASS then
 				command:SetShaderParameter("SkyVis", sky_vis_param)
+				command:SetShaderParameter("SpecEmphasis", spec_emphasis)
 			end
 		end
 		return
 	end
 	render_path:SetShaderParameter("SkyVis", sky_vis_param)
+	render_path:SetShaderParameter("SpecEmphasis", spec_emphasis)
+end
+
+-- How much to multiply the reflected sky by, 1 being what a game renders.
+--
+-- For looking at what this module does rather than at the scene. Most of a
+-- cave is rock reflecting almost nothing, so a change to the sampling that is
+-- worth arguing about moves a wall by a fraction of a value out of 255 -- less
+-- than PNG rounding, which makes screenshots useless as a way to tell whether
+-- a change did anything. Turned up, the same change is tens of values and can
+-- be measured. It scales the reflection alone, so what it exaggerates is
+-- exactly what this module decides and nothing else.
+function M.set_specular_emphasis(v)
+	spec_emphasis = v
+	-- Straight away rather than at the next declaring walk, so a key that
+	-- changes it takes effect on the next frame
+	declare_countdown = 0
 end
 
 -- dt of nil snaps, for when the camera has been moved rather than has moved

--- a/builtin/voxel_shading/client_lua/module.lua
+++ b/builtin/voxel_shading/client_lua/module.lua
@@ -62,11 +62,19 @@ local TECHNIQUE = magic.cache:GetResource("Technique",
 -- and differently each sweep, and each cell keeps an average of its own rays,
 -- so a cell settles at the fraction of its directions that see sky.
 local FACES = 6
-local CELLS = 6                 -- Per face, per axis: 6x6
+local CELLS = 12                -- Per face, per axis
 local CELL_COUNT = FACES * CELLS * CELLS
--- Rays per frame. A sweep is one ray per cell, so this is also how often the
--- whole set is renewed: 36 gives a sweep every sixth frame.
-local RAYS_PER_UPDATE = 36
+-- Rays cast into each cell per sweep, averaged into that cell's value. This is
+-- the knob for how noisy one sweep's answer is: a cell's rays are yes or no,
+-- so one of them is a coin flip weighted by how much of the cell sees sky, and
+-- the average of K of them has a K-th of the variance. They are stratified
+-- within the cell rather than independent, so they cover it evenly instead of
+-- clumping the way K independent samples would.
+local RAYS_PER_CELL = 16
+-- Cells refreshed per frame. A sweep is every cell once, so this is how often
+-- the whole cube is renewed: 36 cells of a 12x12x6 cube is a sweep every 24
+-- frames. Rays per frame is this times RAYS_PER_CELL.
+local CELLS_PER_UPDATE = 36
 -- How far a ray looks. Long, because the length is what makes the answer
 -- strict: a ray down digger's tunnel has to reach the end of it to find out
 -- that the tunnel is not a way to the sky, and the tunnel is tens of voxels
@@ -78,12 +86,12 @@ local RAY_VOXELS = 64
 -- under a second and the reflections trail the camera by about that. Taking
 -- more of each ray puts their own noise on the screen, which reads as the
 -- speculars flickering several times a second.
-local SKY_VIS_BLEND = 0.15
+local SKY_VIS_BLEND = 0.10
 -- Sweeps averaged when snapping, for a camera that has been moved rather than
 -- has moved: the same averaging done at once, so a screenshot taken right
 -- after a teleport is as settled as one taken later. This is some thousands of
 -- rays in one frame and drops one, which is what a teleport does anyway.
-local SNAP_SWEEPS = 8
+local SNAP_SWEEPS = 2
 -- Chunks are collected around the camera out to the reach of a ray, and the
 -- list is kept until the camera crosses into another chunk: which chunks are
 -- within reach does not change until then. Rebuilt every so many sweeps as
@@ -113,10 +121,11 @@ local FACE_AXES = {
 
 local CELL_SIZE = 2.0 / CELLS
 
--- One table per cell, reused: the sweep rewrites their components rather than
--- building 216 tables of three numbers every time
+-- One table per ray, reused: the sweep rewrites their components rather than
+-- building thousands of tables of three numbers every time. RAYS_PER_CELL of
+-- them per cell, in cell order, so a slice of cells is a run of directions.
 local DIRS = {}
-for i = 1, CELL_COUNT do
+for i = 1, CELL_COUNT * RAYS_PER_CELL do
 	DIRS[i] = {x = 0, y = 0, z = 0}
 end
 
@@ -148,7 +157,7 @@ local ray_args = {
 	-- do want that.
 	stop_skylight = 0,
 	first = 1,
-	count = RAYS_PER_UPDATE,
+	count = 1,
 	origin = {x = 0, y = 0, z = 0},
 	volumes = {},
 }
@@ -209,6 +218,28 @@ end
 local SWEEP_STEP_U = 0.6180339887
 local SWEEP_STEP_V = 0.4142135624
 
+-- Where a cell's rays sit relative to each other: a Hammersley set, which
+-- covers the cell evenly. The set is then shifted as a whole by the cell's own
+-- offset and by the sweep's step, which keeps the even coverage while moving
+-- it, so no two cells sample the same relative points and no cell samples the
+-- same points twice.
+local function radical_inverse_2(n)
+	local r, f = 0.0, 0.5
+	while n > 0 do
+		r = r + (n % 2) * f
+		n = math.floor(n / 2)
+		f = f * 0.5
+	end
+	return r
+end
+
+local STRAT_U = {}
+local STRAT_V = {}
+for k = 1, RAYS_PER_CELL do
+	STRAT_U[k] = (k - 0.5) / RAYS_PER_CELL
+	STRAT_V[k] = radical_inverse_2(k - 1)
+end
+
 local function aim_dirs(index)
 	local su = (index * SWEEP_STEP_U) % 1.0
 	local sv = (index * SWEEP_STEP_V) % 1.0
@@ -217,12 +248,17 @@ local function aim_dirs(index)
 		local a = FACE_AXES[face]
 		for row = 0, CELLS - 1 do
 			for col = 0, CELLS - 1 do
-				local d = DIRS[i]
-				local ju = (CELL_JITTER_U[i] + su) % 1.0 - 0.5
-				local jv = (CELL_JITTER_V[i] + sv) % 1.0 - 0.5
-				d[a.major] = a.sign
-				d[a.u] = (col + 0.5 + ju) * CELL_SIZE - 1.0
-				d[a.v] = (row + 0.5 + jv) * CELL_SIZE - 1.0
+				local bu = CELL_JITTER_U[i] + su
+				local bv = CELL_JITTER_V[i] + sv
+				local base = (i - 1) * RAYS_PER_CELL
+				for k = 1, RAYS_PER_CELL do
+					local d = DIRS[base + k]
+					local ju = (bu + STRAT_U[k]) % 1.0 - 0.5
+					local jv = (bv + STRAT_V[k]) % 1.0 - 0.5
+					d[a.major] = a.sign
+					d[a.u] = (col + 0.5 + ju) * CELL_SIZE - 1.0
+					d[a.v] = (row + 0.5 + jv) * CELL_SIZE - 1.0
+				end
 				i = i + 1
 			end
 		end
@@ -318,22 +354,32 @@ local function collect_volumes(origin)
 	return n > 0
 end
 
--- What a finished slice's rays found, into the sweep
-local function keep_slice(first, out)
+-- What a finished slice's rays found, into the sweep: a cell's RAYS_PER_CELL
+-- rays are consecutive, and the cell keeps their average
+local function keep_slice(first_cell, count_cells, out)
 	local status, skylight, steps = out.status, out.skylight, out.steps
-	for i = 1, out.count do
-		sweep_vis[first + i - 1] =
-				ray_visibility(status[i], skylight[i], steps[i])
+	local n = 0
+	for c = 1, count_cells do
+		local sum = 0.0
+		for k = 1, RAYS_PER_CELL do
+			n = n + 1
+			sum = sum + ray_visibility(status[n], skylight[n], steps[n])
+		end
+		sweep_vis[first_cell + c - 1] = sum / RAYS_PER_CELL
 	end
+end
+
+local function aim_args(first_cell, count_cells)
+	ray_args.first = (first_cell - 1) * RAYS_PER_CELL + 1
+	ray_args.count = count_cells * RAYS_PER_CELL
 end
 
 -- One slice of a sweep, marched here and now. Only the snap uses this: it is
 -- thousands of rays wanted before the next frame is drawn, which is what
 -- blocking is for.
-local function cast_slice(first, count)
-	ray_args.first = first
-	ray_args.count = count
-	keep_slice(first, buildat.cast_voxel_rays(ray_args))
+local function cast_slice(first_cell, count_cells)
+	aim_args(first_cell, count_cells)
+	keep_slice(first_cell, count_cells, buildat.cast_voxel_rays(ray_args))
 end
 
 -- f is how much of the sweep's rays to take; 1.0 replaces the values outright
@@ -362,10 +408,9 @@ end
 local MAX_IN_FLIGHT = 2
 local in_flight = {}
 
-local function submit_slice(first, count)
-	ray_args.first = first
-	ray_args.count = count
-	in_flight[#in_flight + 1] = {first = first, count = count,
+local function submit_slice(first_cell, count_cells)
+	aim_args(first_cell, count_cells)
+	in_flight[#in_flight + 1] = {first = first_cell, count = count_cells,
 			job = buildat.cast_voxel_rays_start(ray_args)}
 end
 
@@ -379,7 +424,7 @@ local function collect_slices(f)
 			return
 		end
 		table.remove(in_flight, 1)
-		keep_slice(slice.first, out)
+		keep_slice(slice.first, slice.count, out)
 		blend_cells(slice.first, slice.count, f)
 	end
 end
@@ -510,7 +555,7 @@ function M.update(dt)
 			break
 		end
 		local first = sweep_next
-		local count = math.min(RAYS_PER_UPDATE, CELL_COUNT - sweep_next + 1)
+		local count = math.min(CELLS_PER_UPDATE, CELL_COUNT - sweep_next + 1)
 		submit_slice(first, count)
 		sweep_next = sweep_next + count
 		if sweep_next > CELL_COUNT then

--- a/builtin/voxel_shading/client_lua/sky_visibility_test.lua
+++ b/builtin/voxel_shading/client_lua/sky_visibility_test.lua
@@ -32,21 +32,38 @@ local RAY = {BLOCKED = 0, NO_DATA = 1, RANGE = 2, SKYLIGHT = 3}
 
 -- Stands in for buildat.cast_voxel_rays. Steps voxel by voxel rather than by
 -- the binding's DDA, which is close enough for a world made of slabs.
+--
+-- Directions arrive as a flat array, three numbers to a ray, and consecutive
+-- rays belong to one cell: what comes back is their average, one value per
+-- cell. The rule turning a ray into a value lives in the engine now, so the
+-- copy here mirrors what src/lua_bindings/voxel_volume.cpp documents -- which
+-- means these checks pin the module's own part, the cell directions and the
+-- shader agreeing with them, and not the engine's arithmetic.
+local function stub_ray_visibility(status, skylight, steps)
+	if status == RAY.BLOCKED then return 0.0 end
+	if steps <= 1 then return 1.0 end
+	if skylight < 0 then return 0.0 end
+	return skylight / 15
+end
+
 local function cast_voxel_rays(args)
-	local status, skylight_out, steps_out = {}, {}, {}
+	local per_cell = args.rays_per_cell or 0
+	local vis = {}
 	local n = 0
-	for di = args.first, args.first + args.count - 1 do
-		local dir = args.directions[di]
-		if dir == nil then break end
+	for ri = args.first, args.first + args.count - 1 do
+		local base = (ri - 1) * 3
+		local dx, dy, dz = args.directions[base + 1], args.directions[base + 2],
+				args.directions[base + 3]
+		if dx == nil then break end
 		n = n + 1
-		local len = math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z)
+		local len = math.sqrt(dx * dx + dy * dy + dz * dz)
 		local st, sky, steps = RAY.RANGE, -1, 0
 		for i = 1, args.max_steps do
 			steps = i
 			local v = world({
-				x = args.origin.x + dir.x / len * i,
-				y = args.origin.y + dir.y / len * i,
-				z = args.origin.z + dir.z / len * i,
+				x = args.origin.x + dx / len * i,
+				y = args.origin.y + dy / len * i,
+				z = args.origin.z + dz / len * i,
 			})
 			if v == nil then
 				st = RAY.NO_DATA
@@ -62,10 +79,19 @@ local function cast_voxel_rays(args)
 				break
 			end
 		end
-		status[n], skylight_out[n], steps_out[n] = st, sky, steps
+		vis[n] = stub_ray_visibility(st, sky, steps)
 	end
-	return {count = n, status = status, skylight = skylight_out,
-			steps = steps_out, hit_id = {}}
+	assert(per_cell > 0, "the module is expected to ask for values per cell")
+	assert(n % per_cell == 0, "rays are not a whole number of cells")
+	local cells = {}
+	for c = 1, n / per_cell do
+		local sum = 0.0
+		for k = 1, per_cell do
+			sum = sum + vis[(c - 1) * per_cell + k]
+		end
+		cells[c] = sum / per_cell
+	end
+	return {count = #cells, visibility = cells}
 end
 
 local voxelworld_stub

--- a/builtin/voxel_shading/client_lua/sky_visibility_test.lua
+++ b/builtin/voxel_shading/client_lua/sky_visibility_test.lua
@@ -178,7 +178,7 @@ local M = chunk()
 M.set_camera(camera_node)
 
 -- GetSkyVisibility() from PBRVoxel.glsl, in Lua
-local CELLS = 12
+local CELLS = 6
 
 local function vis_at(vals, x, y, z)
 	local ax, ay, az = math.abs(x), math.abs(y), math.abs(z)
@@ -210,8 +210,8 @@ end
 local function sweep(w)
 	world = w
 	M.update(nil) -- nil snaps: a full sweep, no easing
-	assert(#params.SkyVis == 864,
-			"expected 864 values, got "..#params.SkyVis)
+	assert(#params.SkyVis == 216,
+			"expected 216 values, got "..#params.SkyVis)
 	return params.SkyVis
 end
 

--- a/builtin/voxel_shading/client_lua/sky_visibility_test.lua
+++ b/builtin/voxel_shading/client_lua/sky_visibility_test.lua
@@ -268,6 +268,13 @@ assert(out > 0.3, "tunnel +x: the mouth of the tunnel is dark: "..out)
 local off = vis_at(tunnel, 1, 1, 0)
 assert(off < out * 0.7, "tunnel +x: rock beside the mouth is lit: "..off)
 
+-- A cavern wider than a ray is long, unlit: every ray runs its whole length
+-- through air and meets nothing, so being stopped by rock is not what tells
+-- us there is no sky here. The air the rays end in is dark, and that does.
+check("dark cavern", sweep(function(p) return fake_voxel(AIR, 0) end),
+		{["+x"] = 0, ["-x"] = 0, ["+y"] = 0, ["-y"] = 0, ["+z"] = 0,
+			["-z"] = 0})
+
 -- Deep in a cave, dt-driven updates ease rather than snap
 world = function(p) return fake_voxel(ROCK, 0) end
 for i = 1, 400 do M.update(1 / 60) end

--- a/builtin/voxel_shading/client_lua/sky_visibility_test.lua
+++ b/builtin/voxel_shading/client_lua/sky_visibility_test.lua
@@ -130,6 +130,18 @@ local env = setmetatable({
 		write_floats = fake_write_floats,
 		get_time_us = function() return 0 end,
 		cast_voxel_rays = cast_voxel_rays,
+		-- The threaded pair, as the engine's contract describes it: start
+		-- takes what the blocking call takes, collect answers nil until the
+		-- marching is done. Ready on the second ask rather than the first, so
+		-- the module's waiting path is exercised and not just the lucky one.
+		cast_voxel_rays_start = function(args)
+			return {out = cast_voxel_rays(args), polls = 0}
+		end,
+		cast_voxel_rays_collect = function(job)
+			job.polls = job.polls + 1
+			if job.polls < 2 then return nil end
+			return job.out
+		end,
 		Logger = function()
 			return setmetatable({},
 					{__index = function() return function() end end})

--- a/builtin/voxel_shading/client_lua/sky_visibility_test.lua
+++ b/builtin/voxel_shading/client_lua/sky_visibility_test.lua
@@ -178,7 +178,7 @@ local M = chunk()
 M.set_camera(camera_node)
 
 -- GetSkyVisibility() from PBRVoxel.glsl, in Lua
-local CELLS = 6
+local CELLS = 12
 
 local function vis_at(vals, x, y, z)
 	local ax, ay, az = math.abs(x), math.abs(y), math.abs(z)
@@ -210,8 +210,8 @@ end
 local function sweep(w)
 	world = w
 	M.update(nil) -- nil snaps: a full sweep, no easing
-	assert(#params.SkyVis == 216,
-			"expected 216 values, got "..#params.SkyVis)
+	assert(#params.SkyVis == 864,
+			"expected 864 values, got "..#params.SkyVis)
 	return params.SkyVis
 end
 

--- a/client/api.lua
+++ b/client/api.lua
@@ -38,6 +38,11 @@ buildat.safe.Volume        = __buildat_Volume
 buildat.safe.deserialize_volume       = __buildat_deserialize_volume
 buildat.safe.deserialize_volume_int32 = __buildat_deserialize_volume_int32
 buildat.safe.deserialize_volume_8bit  = __buildat_deserialize_volume_8bit
+-- cast_voxel_rays(args): marches rays through voxel data. args.directions is a
+-- flat array of numbers, three to a ray. With args.rays_per_cell set,
+-- consecutive rays are one cell's and what comes back is their average
+-- visibility per cell; without it, what every ray ran into. See the comments
+-- in src/lua_bindings/voxel_volume.cpp.
 buildat.safe.cast_voxel_rays          = __buildat_cast_voxel_rays
 -- cast_voxel_rays_start(args) takes what cast_voxel_rays() takes and returns a
 -- handle; cast_voxel_rays_collect(handle) returns nil until the marching has

--- a/client/api.lua
+++ b/client/api.lua
@@ -39,6 +39,13 @@ buildat.safe.deserialize_volume       = __buildat_deserialize_volume
 buildat.safe.deserialize_volume_int32 = __buildat_deserialize_volume_int32
 buildat.safe.deserialize_volume_8bit  = __buildat_deserialize_volume_8bit
 buildat.safe.cast_voxel_rays          = __buildat_cast_voxel_rays
+-- cast_voxel_rays_start(args) takes what cast_voxel_rays() takes and returns a
+-- handle; cast_voxel_rays_collect(handle) returns nil until the marching has
+-- finished on a worker thread, and then what cast_voxel_rays() would have
+-- returned. The volumes and the registry are held for the job's lifetime, so a
+-- chunk arriving meanwhile does not pull data out from under it.
+buildat.safe.cast_voxel_rays_start    = __buildat_cast_voxel_rays_start
+buildat.safe.cast_voxel_rays_collect  = __buildat_cast_voxel_rays_collect
 -- write_floats(vector_buffer, values): the values into the buffer as floats,
 -- replacing what was in it
 buildat.safe.write_floats             = __buildat_write_floats

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -263,22 +263,33 @@ reads as fine.
 What that costs, measured at benchmark 3 over 4800 frames -- marching on its
 worker with thread CPU time, the rest on the main thread:
 
-    marching                    0.085 ms/frame   0.29 us/ray, 7.8 steps/ray
-    submitting (Lua -> C++)     0.223 ms/frame
-    collecting (C++ -> Lua)     0.256 ms/frame
-    aiming the directions       0.114 ms/frame
+    marching                    0.090 ms/frame   0.31 us/ray, 7.8 steps/ray
+    submitting (Lua -> C++)     0.183 ms/frame
+    collecting (C++ -> Lua)     0.042 ms/frame
+    aiming the directions       0.112 ms/frame
                                 -----
-                                0.678 ms/frame
+                                0.427 ms/frame
 
-The marching is an eighth of it. The rest is 288 direction tables built in Lua
-and read by luabind every frame, and a result table per ray read back, which is
-about eight table operations a ray against the eight voxels a ray actually
-walks. Rays are not what this costs; handing them over is.
+The marching is a fifth of it, and the rest is the price of 288 rays crossing
+between Lua and C++ every frame: 864 numbers written in Lua to aim them and 864
+read back by luabind to cast them. Rays are not what this costs; handing them
+over is. It was 0.678 ms before the engine started averaging each cell's rays
+itself and before the shader's copy of the cube was repacked once a frame
+rather than once per slice -- the second of those was worth more than the
+first, since repacking read every cell out of Lua twice a frame to publish a
+cube the shader reads once.
 
 Two things follow. Making the marching itself faster -- skipping empty space
-with a coarse occupancy mip, say -- would be optimising the eighth. And putting
-the rays on a worker thread, which is what happens now, moves that same eighth
-off the frame and leaves the rest of it there.
+with a coarse occupancy mip, say -- would be optimising the fifth, and rays
+that die after eight voxels have little empty space to skip. And putting the
+rays on a worker thread, which is what happens now, moves that same fifth off
+the frame and leaves the rest of it there.
+
+What is left is the direction crossing, and the only way past it is for the
+directions not to cross: the engine would have to work them out from the cell
+layout rather than being told each one. That is the part a game defines for
+itself, so it would have to become something a game opts into rather than
+something done to it.
 
 Note also that two slices are kept in flight, so the rays cast per frame are
 twice CELLS_PER_UPDATE times RAYS_PER_CELL: 288 here, where the constants read

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -182,12 +182,14 @@ camera can see is kept as 6x6 values per cube face, 216 in all; the shader
 looks the value up along each pixel's reflection direction, bilinear between
 cell centers, and multiplies the sky by it. A cell is about 15 degrees across.
 
-The client fills those by marching a ray per cell through the voxel data from
-the camera, 36 rays a frame, so every cell is renewed every sixth frame.
-buildat.cast_voxel_rays() does the marching -- see its comment in
-src/lua_bindings/voxel_volume.cpp -- because the same loop written in Lua cost
-half a millisecond a frame for four rays of twenty voxels, and this wants
-hundreds of sixty-four.
+The client fills those by marching rays through the voxel data from the camera:
+four per cell, thirty-six cells a frame, and two slices kept in flight at once,
+so 288 rays a frame and every cell renewed every third. A cell keeps the
+average of its four, and that average is eased into what the shader sees.
+buildat.cast_voxel_rays() does the marching, on a worker thread -- see its
+comment in src/lua_bindings/voxel_volume.cpp -- because the same loop written
+in Lua cost half a millisecond a frame for four rays of twenty voxels, and this
+wants hundreds of sixty-four.
 
 The values do not go on materials. They go on the render path's scene pass
 commands, whose shader parameters Urho hands to every batch the command draws,

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -328,6 +328,35 @@ rather than something the benchmark cameras do by themselves: moving between
 cameras should not stop the scene animating, and a frozen scene that nothing
 said it had frozen is a confusing thing to land in.
 
+R (or the HUD button beside the wind one) cycles the specular emphasis
+through 1, 4, 16 and 64, multiplying the reflected sky and nothing else.
+
+This exists because the reflections are too faint to measure at 1. A change to
+voxel_shading's sky visibility sampling moves a cave wall by a fraction of a
+value out of 255 -- below what a PNG rounds to -- so bursts of screenshots come
+back byte-identical whatever the sampling does, and comparing two approaches by
+eye or by ImageMagick says nothing. Turned up, the same change is tens of
+values and can be measured.
+
+The pulsation the sampling produces is what this was built to see. At benchmark
+3, with the wind frozen and the camera left alone, sampling one frame per sweep
+off the brightest patch of the cave mouth's rim:
+
+    16x:  84.8 82.7 83.2 81.9 84.9 84.7 83.0 88.3 86.9 ... 91.0 88.1 87.3
+          per-sweep |diff| mean 2.32, max 8.15, on a level of 86
+    1x:   per-sweep |diff| mean 0.16, max 0.54
+
+The rim is the whole of it: a per-pixel map of temporal range over the mouth
+traces the dirt and rock edges and is black everywhere else. Cells looking at
+solid rock sit at 0 and cells looking out of the mouth sit at 1, and neither
+varies; the variance is entirely in the cells straddling the rim, where a
+cell's rays are a coin flip weighted by how much of it the opening covers.
+
+Emphasis scales the reflection alone, so what it exaggerates is exactly what
+that sampling decides. It does also make the VOXELSPOTS sparkle plain, since
+those spots reflect the sky too -- worth knowing before reading a screenshot
+taken at 64.
+
 The pond is dug rather than found. This terrain is one slope, so a water line
 drawn across it fills the low ground at the edge of the volume and reads as a
 sea the world runs out of; a basin dug into the flattest ground away from the

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -210,13 +210,22 @@ ms in all. In voxel_lighting, whose world is one section, 0.10 ms. Collecting
 the chunks was 0.5 ms until it stopped happening every sweep: the set within
 reach of a ray does not change until the camera crosses into another chunk.
 
-A ray answers yes if it gets its whole length, 64 voxels, without meeting
-anything, and no if something solid stops it. Nothing in between, and nothing
-to do with skylight: a voxel's skylight says the sky is open straight up from
-it, which is no answer to whether the sky lies along the ray. The length is
-what makes the answer strict -- a ray down digger's tunnel has to reach the far
-end to find out that the tunnel is not a way out -- so it is not the thing to
-economise on.
+A ray answers no if something solid stops it. If nothing does, the answer is
+the skylight of the air it ended in, which is 1 for fully lit air and 0 for
+dark. Getting its whole length, 64 voxels, is not itself a yes: a ray crossing
+sixty-four voxels of unlit cavern has met nothing and seen no sky either, and
+calling that sky is how a fixed length goes wrong on its own. The length still
+matters -- a ray down digger's tunnel has to reach the far end to find out that
+the tunnel is not a way out -- so it is not the thing to economise on.
+
+Skylight is used there and nowhere else along the ray. It says the sky is open
+straight up from a point, which is no answer to whether the sky lies along the
+ray, and stopping rays wherever they met full skylight looked right and was
+badly wrong: at the mouth of digger's tunnel the air is fully lit, so every
+direction including the tunnel came back at 1. At the far end of a ray it is
+answering about the place the ray reached, which is a question it can answer.
+A ray that runs out of loaded chunks part way is read the same way, for the
+same reason, and that beats calling the edge of the loaded world sky.
 
 Partial values come from the sampling instead. The rays are jittered inside
 their cells and differently each sweep, and each cell keeps an average of its
@@ -235,10 +244,6 @@ the runs that were supposed to compare the two turned out to differ in whether
 the wind was frozen and whether the camera had reached the benchmark at all, so
 the numbers that looked like a verdict were not one. Worth measuring properly
 before anyone leans on it.
-
-Skylight does answer for a ray that runs out of loaded chunks part way: the
-skylight where it stopped is how far along the way out it had got, and
-believing that beats calling the edge of the loaded world sky.
 
 Resolution is what decides how narrowly this can be aimed. The sky over
 digger's spawn tunnel is a few degrees off the tunnel's own direction, and a

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -243,7 +243,8 @@ sweep steps by a fixed sequence the pulsing is periodic. Casting more rays does
 not help with any of that: it was never a shortage of samples, it was 216 cells
 making the same error at the same moment.
 
-Measured at benchmark 3 with the emphasis at 16, over the mouth region:
+Measured at benchmark 3 with the emphasis at 16, over the mouth region, with
+6x6 cells and one ray each:
 
                                     one offset   per cell
     coherent std of the region       0.2049       0.0923
@@ -251,9 +252,21 @@ Measured at benchmark 3 with the emphasis at 16, over the mouth region:
     the same on the worst patch      2.32         0.99
 
 Noise falling by 2.8 is what casting eight times the rays would have bought,
-for no rays at all. The region also sits about a value lower afterwards, at
-16x: large coherent excursions through the tonemap do not average to the same
-place as the steady signal they were swinging around.
+for no rays at all. Brightness is unchanged by it: the rim region reads 77.5660
+before and 77.5657 after at emphasis 1, over thirty frames each.
+
+The settings now are 12x12 cells and sixteen rays each, which is what the same
+measurement makes of them:
+
+    coherent std of the region       0.0097
+    per-pixel per-sweep |diff|       0.0028
+    the same on the worst patch      0.05
+
+That is a ceiling rather than a considered choice: 576 rays a frame against the
+36 this started at, picked to find out what the sampling can do before deciding
+what it should cost. Walking back down from it is the open question -- the two
+knobs are RAYS_PER_CELL, which divides a sweep's variance, and CELLS, which
+decides how narrowly the cube can be aimed and costs rays for nothing else.
 
  That average is also what keeps the speculars still: taking a ray whole
 put its own yes-or-no on the screen, which flickered several times a second --

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -230,7 +230,32 @@ same reason, and that beats calling the edge of the loaded world sky.
 Partial values come from the sampling instead. The rays are jittered inside
 their cells and differently each sweep, and each cell keeps an average of its
 own rays at 0.15, so a cell settles at the fraction of its directions that see
-sky. That average is also what keeps the speculars still: taking a ray whole
+sky.
+
+Each cell is jittered by an offset of its own, and this matters more than the
+number of rays does. With one offset for the whole cube -- which is what it was
+at first -- every cell samples the same relative point at the same time and
+their errors line up, so a sweep whose offset leans towards the sky brightens
+every cell straddling an opening at once and the reflections in the whole scene
+move together. Coherent like that it reads as the scene pulsing, which is far
+more visible than the same amount of noise spread over cells, and since the
+sweep steps by a fixed sequence the pulsing is periodic. Casting more rays does
+not help with any of that: it was never a shortage of samples, it was 216 cells
+making the same error at the same moment.
+
+Measured at benchmark 3 with the emphasis at 16, over the mouth region:
+
+                                    one offset   per cell
+    coherent std of the region       0.2049       0.0923
+    per-pixel per-sweep |diff|       0.2964       0.1058
+    the same on the worst patch      2.32         0.99
+
+Noise falling by 2.8 is what casting eight times the rays would have bought,
+for no rays at all. The region also sits about a value lower afterwards, at
+16x: large coherent excursions through the tonemap do not average to the same
+place as the steady signal they were swinging around.
+
+ That average is also what keeps the speculars still: taking a ray whole
 put its own yes-or-no on the screen, which flickered several times a second --
 measured over bursts of twelve frames of digger's tunnel wall as the mean
 absolute difference between consecutive frames, 1.05 taking rays whole against

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -255,18 +255,34 @@ Noise falling by 2.8 is what casting eight times the rays would have bought,
 for no rays at all. Brightness is unchanged by it: the rim region reads 77.5660
 before and 77.5657 after at emphasis 1, over thirty frames each.
 
-The settings now are 12x12 cells and sixteen rays each, which is what the same
-measurement makes of them:
+Twelve by twelve cells with sixteen rays each measures 0.0097, 0.0028 and 0.05
+on those three, which is as still as it gets and far past what is needed. The
+settings are 6x6 cells with four rays each, which leaves a slight shimmer that
+reads as fine.
 
-    coherent std of the region       0.0097
-    per-pixel per-sweep |diff|       0.0028
-    the same on the worst patch      0.05
+What that costs, measured at benchmark 3 over 4800 frames -- marching on its
+worker with thread CPU time, the rest on the main thread:
 
-That is a ceiling rather than a considered choice: 576 rays a frame against the
-36 this started at, picked to find out what the sampling can do before deciding
-what it should cost. Walking back down from it is the open question -- the two
-knobs are RAYS_PER_CELL, which divides a sweep's variance, and CELLS, which
-decides how narrowly the cube can be aimed and costs rays for nothing else.
+    marching                    0.085 ms/frame   0.29 us/ray, 7.8 steps/ray
+    submitting (Lua -> C++)     0.223 ms/frame
+    collecting (C++ -> Lua)     0.256 ms/frame
+    aiming the directions       0.114 ms/frame
+                                -----
+                                0.678 ms/frame
+
+The marching is an eighth of it. The rest is 288 direction tables built in Lua
+and read by luabind every frame, and a result table per ray read back, which is
+about eight table operations a ray against the eight voxels a ray actually
+walks. Rays are not what this costs; handing them over is.
+
+Two things follow. Making the marching itself faster -- skipping empty space
+with a coarse occupancy mip, say -- would be optimising the eighth. And putting
+the rays on a worker thread, which is what happens now, moves that same eighth
+off the frame and leaves the rest of it there.
+
+Note also that two slices are kept in flight, so the rays cast per frame are
+twice CELLS_PER_UPDATE times RAYS_PER_CELL: 288 here, where the constants read
+144.
 
  That average is also what keeps the speculars still: taking a ray whole
 put its own yes-or-no on the screen, which flickered several times a second --

--- a/games/voxel_lighting/main/client_lua/init.lua
+++ b/games/voxel_lighting/main/client_lua/init.lua
@@ -166,6 +166,23 @@ voxel_shading.set_camera(camera_node)
 
 magic.input:SetMouseVisible(true)
 
+-- Multiplies the reflected sky, for looking at what voxel_shading's sky
+-- visibility sampling does rather than at the scene. At 1, which is how the
+-- game renders, a change to the sampling worth arguing about moves a cave wall
+-- by a fraction of a value out of 255 -- below PNG rounding, so screenshots
+-- cannot tell whether it did anything. At 16 the same change is tens of values.
+-- Only the reflection is scaled, so nothing but what that sampling decides is
+-- exaggerated. See the note in the README.
+local SPECULAR_EMPHASIS = {1, 4, 16, 64}
+local specular_emphasis_i = 1
+
+local function cycle_specular_emphasis()
+	specular_emphasis_i = specular_emphasis_i % #SPECULAR_EMPHASIS + 1
+	local v = SPECULAR_EMPHASIS[specular_emphasis_i]
+	voxel_shading.set_specular_emphasis(v)
+	log:info("specular emphasis: "..v.."x")
+end
+
 local function set_time_frozen(enable)
 	time_frozen = enable
 	if time_frozen then
@@ -487,6 +504,7 @@ do
 	add_button("Freeze wind (F)", function()
 		set_time_frozen(not time_frozen)
 	end)
+	add_button("Emphasis (R)", cycle_specular_emphasis)
 
 	magic.ui:SetFocusElement(nil)
 end
@@ -517,6 +535,8 @@ magic.SubscribeToEvent("KeyDown", function(event_type, event_data)
 		buildat.send_packet("main:verify_skylight", "")
 	elseif key == magic.KEY_F then
 		set_time_frozen(not time_frozen)
+	elseif key == magic.KEY_R then
+		cycle_specular_emphasis()
 	elseif key == magic.KEY_ESCAPE then
 		if free_look then
 			set_free_look(false)

--- a/src/lua_bindings/voxel_volume.cpp
+++ b/src/lua_bindings/voxel_volume.cpp
@@ -199,9 +199,16 @@ struct RayJob
 	sv_<double> dirs;   // Three per ray, not normalized
 	int max_steps = 32;
 	int stop_skylight = 0;
+	// Rays per cell. Zero hands back what every ray found and leaves the
+	// caller to make of it what it likes; above zero, consecutive rays are one
+	// cell's and the job hands back a value per cell instead. See
+	// ray_visibility() on what that costs the caller in freedom, and
+	// cast_voxel_rays() on why it is worth it.
+	int rays_per_cell = 0;
 
-	// Outputs, one per ray
+	// Outputs. Per ray, or per cell when rays_per_cell is set.
 	sv_<int> status, hit_id, skylight, steps;
+	sv_<double> visibility;
 
 	// Set by the task's post(), which the pool runs on the main thread after
 	// thread() has finished; read by cast_voxel_rays_collect(). Both on the
@@ -265,6 +272,26 @@ static pv::Vector3DInt32 table_vector3_int(const luabind::object &t,
 			(int)table_number(v, "x", 0),
 			(int)table_number(v, "y", 0),
 			(int)table_number(v, "z", 0));
+}
+
+// What one ray is worth, as a fraction of sky along it: nothing if something
+// solid stopped it, and otherwise the skylight of the air it ended in, which
+// says how open the sky is above the point the ray reached. A ray that left
+// the voxel data immediately had nothing around it to see.
+//
+// This is the one piece of policy in here, and it is here only because
+// averaging rays into a cell means deciding what a ray is worth. A caller that
+// wants a different rule leaves rays_per_cell unset and gets what every ray
+// found, which is what this is computed from.
+static double ray_visibility(int status, int skylight, int steps)
+{
+	if(status == VOXEL_RAY_BLOCKED)
+		return 0.0;
+	if(steps <= 1)
+		return 1.0;
+	if(skylight < 0)
+		return 0.0;
+	return (double)skylight / (double)interface::VoxelInstance::SKYLIGHT_MAX;
 }
 
 // Marches the job's rays. Touches nothing that belongs to a thread -- no Lua,
@@ -387,6 +414,20 @@ static void march_rays(RayJob &job)
 		job.skylight[ri] = skylight;
 		job.steps[ri] = steps;
 	}
+
+	// One value per cell, if that is what was asked for
+	if(job.rays_per_cell > 0){
+		const size_t cells = n / (size_t)job.rays_per_cell;
+		job.visibility.assign(cells, 0.0);
+		size_t ri = 0;
+		for(size_t c = 0; c < cells; c++){
+			double sum = 0.0;
+			for(int k = 0; k < job.rays_per_cell; k++, ri++)
+				sum += ray_visibility(job.status[ri], job.skylight[ri],
+						job.steps[ri]);
+			job.visibility[c] = sum / (double)job.rays_per_cell;
+		}
+	}
 }
 
 // Reads the argument table into a job. Everything Lua-side happens here, so
@@ -448,6 +489,14 @@ static void ray_job_from_lua(RayJob &job, const luabind::object &args)
 
 	job.stop_skylight = (int)table_number(args, "stop_skylight", 0);
 
+	job.rays_per_cell = (int)table_number(args, "rays_per_cell", 0);
+	if(job.rays_per_cell < 0)
+		job.rays_per_cell = 0;
+
+	// A flat array of numbers, three to a ray, rather than a table per ray:
+	// this is read once a frame for every ray and a table each was most of
+	// what the sampling cost. Three array reads a ray, and the caller still
+	// says where every one of them points.
 	luabind::object directions_o = args["directions"];
 	if(!directions_o || luabind::type(directions_o) != LUA_TTABLE)
 		throw Exception("cast_voxel_rays(): args.directions is not a table");
@@ -457,20 +506,42 @@ static void ray_job_from_lua(RayJob &job, const luabind::object &args)
 		first = 1;
 	int count = (int)table_number(args, "count", -1);
 
-	for(int di = first; count < 0 || di < first + count; di++){
-		luabind::object dir_o = directions_o[di];
-		if(!dir_o || luabind::type(dir_o) != LUA_TTABLE)
-			break; // End of the array, or the slice asked for runs past it
+	for(int ri = first; count < 0 || ri < first + count; ri++){
 		if(job.dirs.size() / 3 >= VOXEL_RAY_MAX_DIRECTIONS)
 			break;
-		job.dirs.push_back(table_number(dir_o, "x", 0.0));
-		job.dirs.push_back(table_number(dir_o, "y", 0.0));
-		job.dirs.push_back(table_number(dir_o, "z", 0.0));
+		luabind::object x_o = directions_o[(ri - 1) * 3 + 1];
+		if(!x_o || luabind::type(x_o) != LUA_TNUMBER)
+			break; // End of the array, or the slice asked for runs past it
+		luabind::object y_o = directions_o[(ri - 1) * 3 + 2];
+		luabind::object z_o = directions_o[(ri - 1) * 3 + 3];
+		job.dirs.push_back(luabind::object_cast<double>(x_o));
+		job.dirs.push_back(y_o && luabind::type(y_o) == LUA_TNUMBER ?
+				luabind::object_cast<double>(y_o) : 0.0);
+		job.dirs.push_back(z_o && luabind::type(z_o) == LUA_TNUMBER ?
+				luabind::object_cast<double>(z_o) : 0.0);
 	}
+
+	if(job.rays_per_cell > 0 &&
+			(job.dirs.size() / 3) % (size_t)job.rays_per_cell != 0)
+		throw Exception("cast_voxel_rays(): rays are not a whole number of "
+				"cells");
 }
 
 static luabind::object ray_job_to_lua(const RayJob &job, lua_State *L)
 {
+	// A value per cell is the whole point of asking for it: what the caller
+	// gets back is then a few hundred numbers instead of four per ray, and
+	// none of the per-ray tables are built at all
+	if(job.rays_per_cell > 0){
+		luabind::object visibility_t = luabind::newtable(L);
+		for(size_t i = 0; i < job.visibility.size(); i++)
+			visibility_t[i + 1] = job.visibility[i];
+		luabind::object result = luabind::newtable(L);
+		result["count"] = (int)job.visibility.size();
+		result["visibility"] = visibility_t;
+		return result;
+	}
+
 	luabind::object status_t = luabind::newtable(L);
 	luabind::object hit_id_t = luabind::newtable(L);
 	luabind::object skylight_t = luabind::newtable(L);

--- a/src/lua_bindings/voxel_volume.cpp
+++ b/src/lua_bindings/voxel_volume.cpp
@@ -176,7 +176,7 @@ enum VoxelRayStatus {
 };
 
 static const int VOXEL_RAY_MAX_STEPS = 4096;
-static const size_t VOXEL_RAY_MAX_DIRECTIONS = 8192;
+static const size_t VOXEL_RAY_MAX_DIRECTIONS = 65536;
 
 // One casting job: everything the marching reads and everything it produces,
 // with no Lua anywhere in it. Separate from the binding so that the same

--- a/src/lua_bindings/voxel_volume.cpp
+++ b/src/lua_bindings/voxel_volume.cpp
@@ -5,6 +5,7 @@
 #include "lua_bindings/sandbox_util.h"
 #include "client/app.h"
 #include "interface/voxel_volume.h"
+#include "interface/thread_pool.h"
 #include <c55/os.h>
 #include <tolua++.h>
 #include <luabind/luabind.hpp>
@@ -177,25 +178,59 @@ enum VoxelRayStatus {
 static const int VOXEL_RAY_MAX_STEPS = 4096;
 static const size_t VOXEL_RAY_MAX_DIRECTIONS = 8192;
 
-// Chunk position -> volume, for the duration of one call
+// One casting job: everything the marching reads and everything it produces,
+// with no Lua anywhere in it. Separate from the binding so that the same
+// marching can run on a thread pool worker, where a lua_State must not be
+// touched.
+struct RayJob
+{
+	// Inputs
+	pv::Vector3DInt32 chunk_size = pv::Vector3DInt32(1, 1, 1);
+	// The volumes are held rather than borrowed. A chunk that arrives while a
+	// job is in flight replaces the entry in voxelworld's cache and drops its
+	// reference, and the volume this job is part way through reading has to
+	// outlive that. Holding them is a refcount each and no copying: the voxel
+	// data itself is never written after it is deserialized.
+	sv_<std::pair<pv::Vector3DInt32, sp_<CommonVolume>>> volumes;
+	// Held for the same reason. The mesher's tasks already read the registry
+	// from worker threads; get() is a lookup and does not write.
+	sp_<VoxelRegistry> voxel_reg;
+	double origin_x = 0.0, origin_y = 0.0, origin_z = 0.0;
+	sv_<double> dirs;   // Three per ray, not normalized
+	int max_steps = 32;
+	int stop_skylight = 0;
+
+	// Outputs, one per ray
+	sv_<int> status, hit_id, skylight, steps;
+
+	// Set by the task's post(), which the pool runs on the main thread after
+	// thread() has finished; read by cast_voxel_rays_collect(). Both on the
+	// main thread, so this needs no atomic of its own.
+	bool done = false;
+};
+
+// Chunk position -> volume, for the duration of one job
 struct RayVolumeSet
 {
+	const sv_<std::pair<pv::Vector3DInt32, sp_<CommonVolume>>> *volumes;
 	pv::Vector3DInt32 chunk_size;
 	// A flat vector rather than a hash: a ray crosses a chunk boundary once
 	// every chunk_size voxels and asks again only then, and the one it asked
 	// for last is nearly always the one it wants, so the scan behind that is
 	// rare enough that its length does not matter
-	sv_<std::pair<pv::Vector3DInt32, CommonVolume*>> volumes;
 	int last_hit = -1;
+
+	RayVolumeSet(const RayJob &job):
+		volumes(&job.volumes), chunk_size(job.chunk_size){}
 
 	CommonVolume* find(const pv::Vector3DInt32 &chunk_p)
 	{
-		if(last_hit >= 0 && volumes[last_hit].first == chunk_p)
-			return volumes[last_hit].second;
-		for(size_t i = 0; i < volumes.size(); i++){
-			if(volumes[i].first == chunk_p){
+		if(last_hit >= 0 && (*volumes)[last_hit].first == chunk_p)
+			return (*volumes)[last_hit].second.get();
+		for(size_t i = 0; i < volumes->size(); i++){
+			if((*volumes)[i].first == chunk_p){
 				last_hit = i;
-				return volumes[i].second;
+				return (*volumes)[i].second.get();
 			}
 		}
 		return nullptr;
@@ -232,117 +267,42 @@ static pv::Vector3DInt32 table_vector3_int(const luabind::object &t,
 			(int)table_number(v, "z", 0));
 }
 
-luabind::object cast_voxel_rays(const luabind::object &args, lua_State *L)
+// Marches the job's rays. Touches nothing that belongs to a thread -- no Lua,
+// no Urho -- which is what lets a worker run it.
+static void march_rays(RayJob &job)
 {
-	if(!args || luabind::type(args) != LUA_TTABLE)
-		throw Exception("cast_voxel_rays(): args is not a table");
+	const size_t n = job.dirs.size() / 3;
+	job.status.assign(n, VOXEL_RAY_RANGE);
+	job.hit_id.assign(n, 0);
+	job.skylight.assign(n, -1);
+	job.steps.assign(n, 0);
 
-	VoxelRegistry *voxel_reg = nullptr;
-	{
-		luabind::object o = args["registry"];
-		if(o)
-			voxel_reg = luabind::object_cast<VoxelRegistry*>(o);
-	}
-	if(voxel_reg == nullptr)
-		throw Exception("cast_voxel_rays(): args.registry is not a registry");
-
-	RayVolumeSet volume_set;
-	volume_set.chunk_size = table_vector3_int(args, "chunk_size");
-	if(volume_set.chunk_size.getX() <= 0 || volume_set.chunk_size.getY() <= 0 ||
-			volume_set.chunk_size.getZ() <= 0)
-		throw Exception("cast_voxel_rays(): args.chunk_size is not positive");
-
-	{
-		luabind::object volumes_o = args["volumes"];
-		if(!volumes_o || luabind::type(volumes_o) != LUA_TTABLE)
-			throw Exception("cast_voxel_rays(): args.volumes is not a table");
-		for(luabind::iterator it(volumes_o), end; it != end; ++it){
-			luabind::object entry = *it;
-			if(luabind::type(entry) != LUA_TTABLE)
-				continue;
-			luabind::object volume_o = entry["volume"];
-			if(!volume_o)
-				continue;
-			sp_<CommonVolume> volume =
-					luabind::object_cast<sp_<CommonVolume>>(volume_o);
-			if(volume == nullptr)
-				continue;
-			volume_set.volumes.push_back(std::make_pair(pv::Vector3DInt32(
-					(int)table_number(entry, "x", 0),
-					(int)table_number(entry, "y", 0),
-					(int)table_number(entry, "z", 0)), volume.get()));
-		}
-	}
-
-	double origin_x = 0.0, origin_y = 0.0, origin_z = 0.0;
-	{
-		luabind::object o = args["origin"];
-		if(!o || luabind::type(o) != LUA_TTABLE)
-			throw Exception("cast_voxel_rays(): args.origin is not a table");
-		origin_x = table_number(o, "x", 0.0);
-		origin_y = table_number(o, "y", 0.0);
-		origin_z = table_number(o, "z", 0.0);
-	}
-
-	luabind::object directions_o = args["directions"];
-	if(!directions_o || luabind::type(directions_o) != LUA_TTABLE)
-		throw Exception("cast_voxel_rays(): args.directions is not a table");
-
-	int max_steps = (int)table_number(args, "max_steps", 32);
-	if(max_steps < 1)
-		max_steps = 1;
-	if(max_steps > VOXEL_RAY_MAX_STEPS)
-		max_steps = VOXEL_RAY_MAX_STEPS;
-
-	int stop_skylight = (int)table_number(args, "stop_skylight", 0);
-
-	int first = (int)table_number(args, "first", 1);
-	if(first < 1)
-		first = 1;
-	int count = (int)table_number(args, "count", -1);
+	RayVolumeSet volume_set(job);
 
 	// physically_solid per voxel id, filled as ids turn up. Unknown ids stop a
 	// ray: an id with no definition is not something to see the sky through.
 	sv_<int8_t> solid_cache;
 
-	luabind::object status_t = luabind::newtable(L);
-	luabind::object hit_id_t = luabind::newtable(L);
-	luabind::object skylight_t = luabind::newtable(L);
-	luabind::object steps_t = luabind::newtable(L);
-
-	int out_i = 0;
-	for(int di = first; count < 0 || di < first + count; di++){
-		luabind::object dir_o = directions_o[di];
-		if(!dir_o || luabind::type(dir_o) != LUA_TTABLE)
-			break; // End of the array, or the slice asked for runs past it
-		if((size_t)out_i >= VOXEL_RAY_MAX_DIRECTIONS)
-			break;
-		out_i++;
-
-		double dx = table_number(dir_o, "x", 0.0);
-		double dy = table_number(dir_o, "y", 0.0);
-		double dz = table_number(dir_o, "z", 0.0);
+	for(size_t ri = 0; ri < n; ri++){
+		double dx = job.dirs[ri * 3 + 0];
+		double dy = job.dirs[ri * 3 + 1];
+		double dz = job.dirs[ri * 3 + 2];
 		double len = sqrt(dx * dx + dy * dy + dz * dz);
+		if(!(len > 1e-9))
+			continue; // A zero or broken direction goes nowhere, not forever
+		dx /= len; dy /= len; dz /= len;
 
 		int status = VOXEL_RAY_RANGE;
 		int hit_id = 0;
 		int skylight = -1;
 		int steps = 0;
 
-		if(!(len > 1e-9)){
-			// A zero or broken direction goes nowhere rather than looping
-			status_t[out_i] = VOXEL_RAY_RANGE;
-			hit_id_t[out_i] = 0;
-			skylight_t[out_i] = -1;
-			steps_t[out_i] = 0;
-			continue;
-		}
-		dx /= len; dy /= len; dz /= len;
-
 		// Voxel coordinates are voxel centers, so the boundaries are at half
 		// integers; shifting by a half puts them on integers, where a DDA
 		// wants them.
-		double px = origin_x + 0.5, py = origin_y + 0.5, pz = origin_z + 0.5;
+		double px = job.origin_x + 0.5;
+		double py = job.origin_y + 0.5;
+		double pz = job.origin_z + 0.5;
 		int vx = (int)floor(px), vy = (int)floor(py), vz = (int)floor(pz);
 
 		int step_x = dx > 0.0 ? 1 : -1;
@@ -366,7 +326,7 @@ luabind::object cast_voxel_rays(const luabind::object &args, lua_State *L)
 		pv::Vector3DInt32 volume_chunk_p(0, 0, 0);
 		bool have_volume = false;
 
-		for(int step = 0; step < max_steps; step++){
+		for(int step = 0; step < job.max_steps; step++){
 			// Step into the next voxel first: the one the origin is in is the
 			// caller's own and is not what it is asking about
 			if(t_max_x < t_max_y && t_max_x < t_max_z){
@@ -405,7 +365,7 @@ luabind::object cast_voxel_rays(const luabind::object &args, lua_State *L)
 				solid_cache.resize((size_t)id + 1, -1);
 			int8_t solid = solid_cache[id];
 			if(solid < 0){
-				const interface::VoxelDefinition *def = voxel_reg->get(id);
+				const interface::VoxelDefinition *def = job.voxel_reg->get(id);
 				solid = (def == nullptr || def->physically_solid) ? 1 : 0;
 				solid_cache[id] = solid;
 			}
@@ -416,25 +376,174 @@ luabind::object cast_voxel_rays(const luabind::object &args, lua_State *L)
 			}
 
 			skylight = v.get_skylight();
-			if(stop_skylight > 0 && skylight >= stop_skylight){
+			if(job.stop_skylight > 0 && skylight >= job.stop_skylight){
 				status = VOXEL_RAY_SKYLIGHT;
 				break;
 			}
 		}
 
-		status_t[out_i] = status;
-		hit_id_t[out_i] = hit_id;
-		skylight_t[out_i] = skylight;
-		steps_t[out_i] = steps;
+		job.status[ri] = status;
+		job.hit_id[ri] = hit_id;
+		job.skylight[ri] = skylight;
+		job.steps[ri] = steps;
+	}
+}
+
+// Reads the argument table into a job. Everything Lua-side happens here, so
+// that what is handed to a worker is plain C++ that owns what it reads.
+static void ray_job_from_lua(RayJob &job, const luabind::object &args)
+{
+	if(!args || luabind::type(args) != LUA_TTABLE)
+		throw Exception("cast_voxel_rays(): args is not a table");
+
+	{
+		luabind::object o = args["registry"];
+		if(o)
+			job.voxel_reg = luabind::object_cast<sp_<VoxelRegistry>>(o);
+	}
+	if(job.voxel_reg == nullptr)
+		throw Exception("cast_voxel_rays(): args.registry is not a registry");
+
+	job.chunk_size = table_vector3_int(args, "chunk_size");
+	if(job.chunk_size.getX() <= 0 || job.chunk_size.getY() <= 0 ||
+			job.chunk_size.getZ() <= 0)
+		throw Exception("cast_voxel_rays(): args.chunk_size is not positive");
+
+	{
+		luabind::object volumes_o = args["volumes"];
+		if(!volumes_o || luabind::type(volumes_o) != LUA_TTABLE)
+			throw Exception("cast_voxel_rays(): args.volumes is not a table");
+		for(luabind::iterator it(volumes_o), end; it != end; ++it){
+			luabind::object entry = *it;
+			if(luabind::type(entry) != LUA_TTABLE)
+				continue;
+			luabind::object volume_o = entry["volume"];
+			if(!volume_o)
+				continue;
+			sp_<CommonVolume> volume =
+					luabind::object_cast<sp_<CommonVolume>>(volume_o);
+			if(volume == nullptr)
+				continue;
+			job.volumes.push_back(std::make_pair(pv::Vector3DInt32(
+					(int)table_number(entry, "x", 0),
+					(int)table_number(entry, "y", 0),
+					(int)table_number(entry, "z", 0)), volume));
+		}
 	}
 
+	{
+		luabind::object o = args["origin"];
+		if(!o || luabind::type(o) != LUA_TTABLE)
+			throw Exception("cast_voxel_rays(): args.origin is not a table");
+		job.origin_x = table_number(o, "x", 0.0);
+		job.origin_y = table_number(o, "y", 0.0);
+		job.origin_z = table_number(o, "z", 0.0);
+	}
+
+	job.max_steps = (int)table_number(args, "max_steps", 32);
+	if(job.max_steps < 1)
+		job.max_steps = 1;
+	if(job.max_steps > VOXEL_RAY_MAX_STEPS)
+		job.max_steps = VOXEL_RAY_MAX_STEPS;
+
+	job.stop_skylight = (int)table_number(args, "stop_skylight", 0);
+
+	luabind::object directions_o = args["directions"];
+	if(!directions_o || luabind::type(directions_o) != LUA_TTABLE)
+		throw Exception("cast_voxel_rays(): args.directions is not a table");
+
+	int first = (int)table_number(args, "first", 1);
+	if(first < 1)
+		first = 1;
+	int count = (int)table_number(args, "count", -1);
+
+	for(int di = first; count < 0 || di < first + count; di++){
+		luabind::object dir_o = directions_o[di];
+		if(!dir_o || luabind::type(dir_o) != LUA_TTABLE)
+			break; // End of the array, or the slice asked for runs past it
+		if(job.dirs.size() / 3 >= VOXEL_RAY_MAX_DIRECTIONS)
+			break;
+		job.dirs.push_back(table_number(dir_o, "x", 0.0));
+		job.dirs.push_back(table_number(dir_o, "y", 0.0));
+		job.dirs.push_back(table_number(dir_o, "z", 0.0));
+	}
+}
+
+static luabind::object ray_job_to_lua(const RayJob &job, lua_State *L)
+{
+	luabind::object status_t = luabind::newtable(L);
+	luabind::object hit_id_t = luabind::newtable(L);
+	luabind::object skylight_t = luabind::newtable(L);
+	luabind::object steps_t = luabind::newtable(L);
+	for(size_t i = 0; i < job.status.size(); i++){
+		status_t[i + 1] = job.status[i];
+		hit_id_t[i + 1] = job.hit_id[i];
+		skylight_t[i + 1] = job.skylight[i];
+		steps_t[i + 1] = job.steps[i];
+	}
 	luabind::object result = luabind::newtable(L);
-	result["count"] = out_i;
+	result["count"] = (int)job.status.size();
 	result["status"] = status_t;
 	result["hit_id"] = hit_id_t;
 	result["skylight"] = skylight_t;
 	result["steps"] = steps_t;
 	return result;
+}
+
+luabind::object cast_voxel_rays(const luabind::object &args, lua_State *L)
+{
+	RayJob job;
+	ray_job_from_lua(job, args);
+	march_rays(job);
+	return ray_job_to_lua(job, L);
+}
+
+// The same marching on a thread pool worker. The point is not that marching is
+// slow -- it is a third of a millisecond -- but that sampling wants several
+// times more rays than that, and the frame has better uses for the time. The
+// work itself is identical, so this should cost the machine the same and the
+// frame much less; that it does is worth re-checking rather than assuming,
+// since two threads walking voxel data at once share a cache.
+//
+// The pool is the client's own, four workers, already started and idle, and
+// already used this way by the mesher.
+struct CastVoxelRaysTask: public interface::thread_pool::Task
+{
+	sp_<RayJob> job;
+
+	CastVoxelRaysTask(sp_<RayJob> job): job(job){}
+
+	bool pre(){ return true; }
+	bool thread(){ march_rays(*job); return true; }
+	bool post(){ job->done = true; return true; }
+};
+
+// Starts a job and hands back a handle to ask about later. Takes what
+// cast_voxel_rays() takes.
+sp_<RayJob> cast_voxel_rays_start(const luabind::object &args, lua_State *L)
+{
+	sp_<RayJob> job(new RayJob());
+	ray_job_from_lua(*job, args);
+
+	lua_getfield(L, LUA_REGISTRYINDEX, "__buildat_app");
+	app::App *buildat_app = (app::App*)lua_touserdata(L, -1);
+	lua_pop(L, 1);
+	if(buildat_app == nullptr)
+		throw Exception("cast_voxel_rays_start(): no app");
+
+	up_<CastVoxelRaysTask> task(new CastVoxelRaysTask(job));
+	buildat_app->get_thread_pool()->add_task(std::move(task));
+	return job;
+}
+
+// Nil until the job has finished, then what cast_voxel_rays() would have
+// returned. Asking again after that returns it again: the job holds its
+// results until it is dropped.
+luabind::object cast_voxel_rays_collect(sp_<RayJob> job, lua_State *L)
+{
+	if(job == nullptr || !job->done)
+		return luabind::object();
+	return ray_job_to_lua(*job, L);
 }
 
 // Writes an array of numbers into a VectorBuffer as floats, replacing what was
@@ -497,7 +606,13 @@ void init_voxel_volume(lua_State *L)
 		LUABIND_FUNC(deserialize_volume),
 		LUABIND_FUNC(deserialize_volume_int32),
 		LUABIND_FUNC(deserialize_volume_8bit),
+		// An opaque handle: a job in flight, with nothing to call on it.
+		// cast_voxel_rays_collect() is what asks whether it has finished.
+		class_<RayJob, bases<>, sp_<RayJob>>("__buildat_VoxelRayJob")
+		,
 		LUABIND_FUNC(cast_voxel_rays),
+		LUABIND_FUNC(cast_voxel_rays_start),
+		LUABIND_FUNC(cast_voxel_rays_collect),
 		LUABIND_FUNC(write_floats)
 	];
 }

--- a/src/lua_bindings/voxel_volume.cpp
+++ b/src/lua_bindings/voxel_volume.cpp
@@ -153,11 +153,15 @@ sp_<CommonVolume> deserialize_volume_8bit(
 //                  volumes; a ray entering a chunk that is not in here stops
 //                  with status "no data"
 //   origin         {x=,y=,z=} in voxels; the voxel it is in is not sampled
-//   directions     array of {x=,y=,z=}, need not be unit vectors
-//   first, count   which of the directions to cast, 1-based (default: all)
+//   directions     flat array of numbers, three to a ray, need not be unit
+//                  vectors. Flat rather than a table per ray because this is
+//                  read for every ray every frame and a table each cost more
+//                  than the marching did.
+//   first, count   which rays to cast, 1-based (default: all)
 //   max_steps      voxels a ray may enter before giving up
 //   stop_skylight  optional 1..15; a passable voxel at or above this stops the
 //                  ray with status "skylight"
+//   rays_per_cell  optional; see below
 //
 // Returns a table of four arrays, each indexed 1..count:
 //   status    one of the VoxelRayStatus values below, which the client Lua
@@ -165,6 +169,15 @@ sp_<CommonVolume> deserialize_volume_8bit(
 //   hit_id    the voxel id that stopped the ray, or 0
 //   skylight  skylight of the last passable voxel entered, or -1 for none
 //   steps     voxels entered
+//
+// With rays_per_cell set, consecutive rays are taken to be one cell's and what
+// comes back instead is
+//   count       cells
+//   visibility  their mean ray_visibility(), one per cell
+// which is a few hundred numbers a frame rather than four arrays per ray, and
+// is most of what this call costs at any real ray count. The price is that the
+// rule turning a ray into a number is then this file's rather than the
+// caller's; a caller that wants its own leaves rays_per_cell unset.
 //
 // The march is a DDA over voxel centers, so it enters every voxel the ray
 // passes through and cannot step over a wall one voxel thick.


### PR DESCRIPTION
Eight commits on voxel_shading's directional sky visibility. The reflections
around a cave mouth pulsed visibly; they no longer do, and the sampling costs
less than it did before.

## Read a ray's answer from the skylight where it ended

A ray that nothing stopped counted as seeing sky, on the strength of having
travelled its whole 64 voxels. Inside a space wider than that, every ray
travels its full length through air and meets nothing, so an unlit cavern read
as full sky in every direction.

The answer now comes from the skylight of the air the ray ended in. That is
where a voxel's skylight can answer something -- about the point the ray
reached -- rather than along the way, where it says only that the sky is open
above some voxel the ray passed through. Rays that run out of loaded chunks
were already read this way, so this removes a rule rather than adding one.

## Specular emphasis, for measuring any of this

The reflections were too faint to measure: a change to the sampling moved a
cave wall by a fraction of a value out of 255, below PNG rounding, so bursts of
screenshots came back byte-identical whatever the sampling did. R in
voxel_lighting cycles a multiplier on the reflected sky through 1, 4, 16, 64.
Everything measured below depends on it.

## Give each cell its own jitter offset

The jitter was worked out once per sweep and applied to every cell, so all of
them sampled the same relative point at the same time and their errors lined
up. A sweep leaning skyward brightened every cell straddling an opening at
once -- the whole scene's reflections moving together rather than each surface
wobbling on its own. Coherent like that it reads as pulsing, far more visible
than the same noise spread over cells, and periodic because the sweep steps by
a fixed sequence. Casting more rays cannot fix it; it was never a shortage of
samples.

Each cell now has a fixed offset from the R2 sequence, and the sweep steps by
constants unrelated to it. Noise fell by 2.8, which is what eight times the
rays would have bought, for no rays at all.

## Several rays per cell

RAYS_PER_CELL casts a stratified set into each cell per sweep and keeps their
average, dividing a sweep's variance by their number. Twelve by twelve cells
with sixteen rays each was measured as a ceiling; the settings are 6x6 with
four, which leaves a slight shimmer that reads as fine.

At benchmark 3, emphasis 16, over the cave mouth:

                                   at the start   shipped    ceiling
    coherent std of the region       0.2049       0.0941      0.0097
    per-pixel per-sweep |diff|       0.2964       0.0652      0.0028

## Marching on a worker, and a cheaper way to hand rays over

cast_voxel_rays_start()/collect() run the marching on the client's existing
four-worker pool, the one the mesher already uses. The job holds the volumes
and the registry rather than borrowing them, so a chunk arriving mid-flight
cannot pull data out from under a worker; client-side voxel data is never
written after deserialization, so there are no locks on it.

Measuring that turned up where the time actually goes. A ray marches in 0.31 us
and dies after eight voxels; handing 288 of them across the Lua boundary each
frame cost several times more. So directions now arrive as a flat array of
numbers rather than a table per ray, cast_voxel_rays() can average each cell's
rays itself and hand back one value per cell, and voxel_shading repacks the
shader's copy of the cube once a frame rather than once per collected slice.
The caller still says where every ray points, and a caller wanting its own rule
for what a ray is worth leaves rays_per_cell unset and reads the rays as
before.

                            before      after
    marching                0.085 ms    0.090 ms
    submitting              0.223 ms    0.183 ms
    collecting              0.256 ms    0.042 ms
    aiming                  0.114 ms    0.112 ms
                            0.678 ms    0.427 ms

What is left is the directions crossing the boundary. Getting past that would
mean the engine working them out from the cell layout instead of being told
each one, which is the part a game defines for itself, so it would have to be
something a game opts into. Not done here.

## Checks

`lua builtin/voxel_shading/client_lua/sky_visibility_test.lua` -- direction
placement, the shader agreeing with it, and a dark cavern that reads 1.00 in
every direction before the range fix and 0.00 after.

voxel_lighting benchmarks 1 to 3 at emphasis 1 are unchanged within 0.01 of a
value throughout: all of this is about what the reflections do over time, not
what they read in a still frame.