### PR TITLE
Worldgen, streaming and LOD performance

### DIFF
--- a/3rdparty/Urho3D/Source/Urho3D/LuaScript/LuaScript.cpp
+++ b/3rdparty/Urho3D/Source/Urho3D/LuaScript/LuaScript.cpp
@@ -473,10 +473,13 @@ void LuaScript::HandlePostUpdate(StringHash eventType, VariantMap& eventData)
         coroutineUpdate_->EndCall();
     }
 
-    // Collect garbage
+    // Collect garbage. A full collect here walks the whole heap every frame,
+    // which with a large bound heap (voxel geometry, the Urho3D bindings) costs
+    // more than everything else the frame does. An incremental step keeps the
+    // heap bounded at a cost proportional to what was allocated.
     {
         URHO3D_PROFILE(LuaCollectGarbage);
-        lua_gc(luaState_, LUA_GCCOLLECT, 0);
+        lua_gc(luaState_, LUA_GCSTEP, 0);
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Play
 
 Local game or connect to a server.
 
+Debug keys, in any game:
+
+* F8: draw debug geometry
+* F9: on-screen profiler, render and resource stats
+* F10: sandbox test extension
+
 Server and client
 -----------------
 

--- a/builtin/voxelworld/api.h
+++ b/builtin/voxelworld/api.h
@@ -151,8 +151,16 @@ namespace voxelworld
 
 	struct Interface
 	{
+		// physics_enabled gives the chunk nodes server-side Bullet collision
+		// shapes. Off by default: they cost more than the world generation
+		// they are built alongside, and only a game that has the server
+		// simulate something against the terrain queries them at all. A game
+		// that reads terrain hits out of the voxel volumes does not need them.
+		// It is a parameter and not a setting because the initial sections are
+		// created here. The client has its own switch; see physics_distance in
+		// voxelworld's client_lua.
 		virtual void create_instance(SceneReference scene_ref,
-				const pv::Region &region) = 0;
+				const pv::Region &region, bool physics_enabled = false) = 0;
 		virtual void delete_instance(SceneReference scene_ref) = 0;
 
 		virtual Instance* get_instance(SceneReference scene_ref) = 0;

--- a/builtin/voxelworld/voxelworld.cpp
+++ b/builtin/voxelworld/voxelworld.cpp
@@ -263,6 +263,7 @@ struct CInstance: public voxelworld::Instance
 
 	// Skylight. Off unless the world asks for it; see api.h.
 	bool m_skylight_enabled = false;
+	bool m_physics_enabled;
 	// The world region in sections, so that the top of it can be found. Light
 	// enters from above that; everything outside is a barrier.
 	pv::Region m_section_region;
@@ -278,10 +279,11 @@ struct CInstance: public voxelworld::Instance
 	std::vector<SkylightSeed> m_skylight_seeds;
 
 	CInstance(interface::Server *server, SceneReference scene_ref,
-			const pv::Region &region):
+			const pv::Region &region, bool physics_enabled):
 		m_server(server),
 		m_scene_ref(scene_ref),
-		m_section_region(region)
+		m_section_region(region),
+		m_physics_enabled(physics_enabled)
 	{
 		m_voxel_reg.reset(interface::createVoxelRegistry());
 		m_block_reg.reset(interface::createBlockRegistry(m_voxel_reg.get()));
@@ -589,8 +591,10 @@ struct CInstance: public voxelworld::Instance
 				new NodeVolumeUpdated(m_scene_ref, n->GetID(), true, chunk_p));
 
 		// There are no collision shapes initially, but add the rigid body now
-		RigidBody *body = n->CreateComponent<RigidBody>(LOCAL);
-		body->SetFriction(0.75f);
+		if(m_physics_enabled){
+			RigidBody *body = n->CreateComponent<RigidBody>(LOCAL);
+			body->SetFriction(0.75f);
+		}
 	}
 
 	void create_section(Section &section)
@@ -640,6 +644,8 @@ struct CInstance: public voxelworld::Instance
 
 	void mark_node_for_physics_update(uint node_id)
 	{
+		if(!m_physics_enabled)
+			return;
 		QueuedNodePhysicsUpdate update(node_id);
 		auto it = std::lower_bound(m_nodes_needing_physics_update.begin(),
 				m_nodes_needing_physics_update.end(), update,
@@ -1831,7 +1837,8 @@ struct Module: public interface::Module, public voxelworld::Interface
 
 	// Interface
 
-	void create_instance(SceneReference scene_ref, const pv::Region &region)
+	void create_instance(SceneReference scene_ref, const pv::Region &region,
+			bool physics_enabled)
 	{
 		auto it = m_instances.find(scene_ref);
 		// TODO: Is an exception the best way to handle this?
@@ -1839,7 +1846,8 @@ struct Module: public interface::Module, public voxelworld::Interface
 			throw Exception("create_instance(): Scene already has a voxel"
 					" world instance");
 
-		up_<CInstance> instance(new CInstance(m_server, scene_ref, region));
+		up_<CInstance> instance(new CInstance(m_server, scene_ref, region,
+				physics_enabled));
 		m_instances[scene_ref] = std::move(instance);
 	}
 

--- a/doc/most_important_performance_issues.txt
+++ b/doc/most_important_performance_issues.txt
@@ -3,7 +3,49 @@ Buildat: Most important performance issues
 
 Issues are ordered by descending importance.
 
-1. Applying the physics box generation result for 32x32x32 voxels into the
+Measured by flying straight and level over infinite terrain in
+games/bomber_drone (turn the motor on with M, hold the runway until it is at
+flying speed, tap S to climb) with the on-screen profiler up (F9). Debug build,
+-O1, 2026-09-08. Numbers are per frame of the client or, where said, of one
+section on the server.
+
+Fixed, kept here for what the shape of the problem was:
+
+* The client's spatial update queue was a sorted std::list with a sorted
+  std::list as its index, so every put walked thousands of items several times.
+  21% of the client's CPU; the whole voxelworld Lua update was 45 ms of every
+  frame. A multimap and an unordered_map instead.
+
+* Urho3D's LuaScript ran a full lua_gc collect every frame, walking a heap that
+  is large and mostly live. 20 ms per frame. An incremental step instead.
+
+* voxelworld built Bullet collision shapes for every chunk on the server
+  whether or not anything simulated against them, and Bullet then kept their
+  AABBs up to date forever. 19% of the server's CPU, competing with world
+  generation for the module. set_physics_enabled(false) for a world that reads
+  its terrain out of the voxel volumes.
+
+Still open, in the order they showed up in a profile after those:
+
+1. update_skylight() and its voxel reads are about 25% of the server's CPU, and
+a freshly generated section costs 35-50 ms of it. The incremental unlight and
+spread machinery is right for an edit, but a whole new section hands it 262144
+seeds when nothing above it is loaded yet. A top-down column sweep for that
+case would cost a fraction of it.
+
+Chunk serialization and its zlib compression is another 14% of the server, and
+a section is serialized more than once on its way in.
+
+2. The client's software occlusion buffer is about 6.5% of its CPU. Every chunk
+is an occluder, LOD chunks included, and the terrain is not a shape that
+occludes much of itself from the air.
+
+3. The atlas rebuilds all three of its textures, with their mipmap chains, for
+every segment added to it. The segments are bounded per voxel registry, so this
+is a startup hitch rather than a steady cost, but batching the SetData of a
+whole registry's worth of segments would remove it.
+
+4. Applying the physics box generation result for 32x32x32 voxels into the
 physics world is too slow. It is currently split to only two parts; the creation
 of the Urho3D::CollisionShapes and constructing the physics stuff in Bullet.
 Both can take up to 20us in worst practical case, and cannot be threaded.
@@ -13,7 +55,7 @@ multiple child nodes (assuming the physics system handles that appropriately).
 
 Measured on Dell Precision M6800, release build, 2014-10-18.
 
-2. Creating the CustomGeometry for a 32x32x32 node is too slow. It can take up
+5. Creating the CustomGeometry for a 32x32x32 node is too slow. It can take up
 to 5000us in the worst practical case and cannot be threaded. It likely cannot
 be split into multiple steps (measuring needed).
 
@@ -23,4 +65,3 @@ creating child nodes out of them.
 It might not be worth solving because the time is relatively low.
 
 Measured on Dell Precision M6800, release build, 2014-10-18.
-

--- a/games/bomber_drone/README.txt
+++ b/games/bomber_drone/README.txt
@@ -14,8 +14,9 @@ Controls:
 The screen is split: the left view is a gimbal on an imaginary aircraft flying
 ahead of the drone, the right one is fixed to the drone's nose.
 
-Known limitation: at cruise speed the drone outruns terrain streaming, so the
-view ahead can be empty until the chunks arrive.
+At cruise speed the drone is close to outrunning terrain streaming: the
+generation queue sits at its soft maximum, so a turn into unseen terrain can
+still show the streaming edge for a moment before the chunks arrive.
 
 Licenses of textures and other media:
 ------------------------------------

--- a/games/digger/main/main.cpp
+++ b/games/digger/main/main.cpp
@@ -8,17 +8,12 @@
 #include "interface/module.h"
 #include "interface/server.h"
 #include "interface/event.h"
-#include "interface/mesh.h"
 #include "interface/voxel.h"
 #include "interface/noise.h"
 #include "interface/voxel_volume.h"
 #include <Scene.h>
-#include <RigidBody.h>
-#include <CollisionShape.h>
-#include <ResourceCache.h>
 #include <Context.h>
 #include <StaticModel.h>
-#include <Model.h>
 #include <Material.h>
 #include <Texture2D.h>
 #include <Technique.h>
@@ -209,7 +204,6 @@ struct Module: public interface::Module
 		m_server->sub_event(this, Event::t("core:start"));
 		m_server->sub_event(this, Event::t("core:unload"));
 		m_server->sub_event(this, Event::t("core:continue"));
-		m_server->sub_event(this, Event::t("core:tick"));
 		m_server->sub_event(this, Event::t("client_file:files_transmitted"));
 		m_server->sub_event(this, Event::t(
 				"network:packet_received/main:place_voxel"));
@@ -223,7 +217,6 @@ struct Module: public interface::Module
 		EVENT_VOIDN("core:start", on_start)
 		EVENT_VOIDN("core:unload", on_unload)
 		EVENT_VOIDN("core:continue", on_continue)
-		EVENT_TYPEN("core:tick", on_tick, interface::TickEvent)
 		EVENT_TYPEN("client_file:files_transmitted",
 				on_files_transmitted, client_file::FilesTransmitted)
 		EVENT_TYPEN("network:packet_received/main:place_voxel",
@@ -341,58 +334,6 @@ struct Module: public interface::Module
 		{
 			instance->enable();
 		});
-
-		voxelworld::access(m_server, m_main_scene,
-				[&](voxelworld::Instance *instance)
-		{
-			main_context::access(m_server, [&](main_context::Interface *imc)
-			{
-				Scene *scene = imc->check_scene(m_main_scene);
-				Context *context = imc->get_context();
-				ResourceCache *cache = context->GetSubsystem<ResourceCache>();
-
-				interface::VoxelRegistry *voxel_reg =
-						instance->get_voxel_reg();
-
-				Node *n = scene->CreateChild("Testbox");
-				n->SetPosition(Vector3(30.0f, 30.0f, 40.0f));
-				n->SetScale(Vector3(1.0f, 1.0f, 1.0f));
-
-				/*int w = 1, h = 1, d = 1;
-				ss_ data = "1";*/
-				int w = 2, h = 2, d = 1;
-				ss_ data = "1333";
-
-				// Convert data to the actually usable voxel type id namespace
-				// starting from VOXELTYPEID_UNDEFINED=0
-				for(size_t i = 0; i < data.size(); i++){
-					data[i] = data[i] - '0';
-				}
-
-				n->SetVar(StringHash("simple_voxel_data"), Variant(
-						PODVector<uint8_t>((const uint8_t*)data.c_str(),
-						data.size())));
-				n->SetVar(StringHash("simple_voxel_w"), Variant(w));
-				n->SetVar(StringHash("simple_voxel_h"), Variant(h));
-				n->SetVar(StringHash("simple_voxel_d"), Variant(d));
-
-
-				// Load the same model in here and give it to the physics
-				// subsystem so that it can be collided to
-				SharedPtr<Model> model(interface::mesh::
-						create_8bit_voxel_physics_model(context, w, h, d, data,
-						voxel_reg));
-
-				RigidBody *body = n->CreateComponent<RigidBody>(LOCAL);
-				body->SetFriction(0.75f);
-				body->SetMass(1.0);
-				CollisionShape *shape =
-						n->CreateComponent<CollisionShape>(LOCAL);
-				shape->SetConvexHull(model, 0, Vector3::ONE);
-				//shape->SetTriangleMesh(model, 0, Vector3::ONE);
-				//shape->SetBox(Vector3::ONE);
-			});
-		});
 	}
 
 	void on_unload()
@@ -409,29 +350,6 @@ struct Module: public interface::Module
 		// TODO: Restore main scene reference
 		// Just do this for now
 		on_start();
-	}
-
-	void on_tick(const interface::TickEvent &event)
-	{
-		/*main_context::access(m_server, [&](main_context::Interface *imc)
-		{
-			Scene *scene = imc->check_scene(m_main_scene);
-			Node *n = scene->GetChild("Testbox");
-			auto p = n->GetPosition();
-			log_v(MODULE, "Testbox: (%f, %f, %f)", p.x_, p.y_, p.z_);
-		});*/
-		static uint a = 0;
-		if(((a++) % 150) == 0){
-			main_context::access(m_server, [&](main_context::Interface *imc)
-			{
-				Scene *scene = imc->check_scene(m_main_scene);
-				Node *n = scene->GetChild("Testbox");
-				if(n){
-					n->SetRotation(Quaternion(30, 60, 90));
-					n->SetPosition(Vector3(30.0f, 30.0f, 40.0f));
-				}
-			});
-		}
 	}
 
 	// Standing-height air along -X (player facing). No path check; long enough

--- a/games/infidigger/main/main.cpp
+++ b/games/infidigger/main/main.cpp
@@ -8,7 +8,6 @@
 #include "interface/module.h"
 #include "interface/server.h"
 #include "interface/event.h"
-#include "interface/mesh.h"
 #include "interface/voxel.h"
 #include "interface/noise.h"
 #include "interface/voxel_volume.h"
@@ -16,10 +15,7 @@
 #include "interface/polyvox_cereal.h"
 #include "interface/polyvox_std.h"
 #include <Scene.h>
-#include <RigidBody.h>
-#include <CollisionShape.h>
 #include <Context.h>
-#include <Model.h>
 #include <cereal/archives/portable_binary.hpp>
 #include <sstream>
 #include <cmath>
@@ -329,58 +325,6 @@ struct Module: public interface::Module
 				interface::container_coord(spawn_p.getY(), SECTION_SIZE_VOXELS),
 				interface::container_coord(spawn_p.getZ(), SECTION_SIZE_VOXELS)));
 		stream_around(spawn_p);
-
-		voxelworld::access(m_server, m_main_scene,
-				[&](voxelworld::Instance *instance)
-		{
-			main_context::access(m_server, [&](main_context::Interface *imc)
-			{
-				Scene *scene = imc->check_scene(m_main_scene);
-				Context *context = imc->get_context();
-
-				interface::VoxelRegistry *voxel_reg =
-						instance->get_voxel_reg();
-
-				Node *n = scene->CreateChild("Testbox");
-				n->SetPosition(Vector3(
-						(float)SPAWN_X + 3.0f, 40.0f, (float)SPAWN_Z + 2.0f));
-				n->SetScale(Vector3(1.0f, 1.0f, 1.0f));
-
-				/*int w = 1, h = 1, d = 1;
-				ss_ data = "1";*/
-				int w = 2, h = 2, d = 1;
-				ss_ data = "1333";
-
-				// Convert data to the actually usable voxel type id namespace
-				// starting from VOXELTYPEID_UNDEFINED=0
-				for(size_t i = 0; i < data.size(); i++){
-					data[i] = data[i] - '0';
-				}
-
-				n->SetVar(StringHash("simple_voxel_data"), Variant(
-						PODVector<uint8_t>((const uint8_t*)data.c_str(),
-						data.size())));
-				n->SetVar(StringHash("simple_voxel_w"), Variant(w));
-				n->SetVar(StringHash("simple_voxel_h"), Variant(h));
-				n->SetVar(StringHash("simple_voxel_d"), Variant(d));
-
-
-				// Load the same model in here and give it to the physics
-				// subsystem so that it can be collided to
-				SharedPtr<Model> model(interface::mesh::
-						create_8bit_voxel_physics_model(context, w, h, d, data,
-						voxel_reg));
-
-				RigidBody *body = n->CreateComponent<RigidBody>(LOCAL);
-				body->SetFriction(0.75f);
-				body->SetMass(1.0);
-				CollisionShape *shape =
-						n->CreateComponent<CollisionShape>(LOCAL);
-				shape->SetConvexHull(model, 0, Vector3::ONE);
-				//shape->SetTriangleMesh(model, 0, Vector3::ONE);
-				//shape->SetBox(Vector3::ONE);
-			});
-		});
 	}
 
 	void on_unload()

--- a/src/impl/atlas.cpp
+++ b/src/impl/atlas.cpp
@@ -243,99 +243,37 @@ struct CAtlasRegistry: public AtlasRegistry
 				}
 			}
 		} else {
-			int lod = def.lod_simulation & 0x0f;
-			uint8_t flags = def.lod_simulation & 0xf0;
+			// One LOD voxel stands for lod voxels each way, so the segment has
+			// to carry the texture tiled lod times as densely to keep the
+			// texel density of LOD 1. The segment is not big enough to hold
+			// that at full resolution, so each texel is the average of the
+			// lod x lod source texels it stands for -- which is what those
+			// voxels look like from the distance this LOD is drawn at anyway.
+			// Picking one of them instead leaves a blotchy pattern that has
+			// nothing to do with the texture and shimmers as the camera moves.
+			//
+			// The shading is left to the scene's lighting; the LOD geometry
+			// keeps its real normals, so nothing is baked in here.
+			int lod = def.lod_simulation;
+			float inv = 1.0f / (lod * lod);
 			for(int y = 0; y<seg_size.y_ * 2; y++){
 				for(int x = 0; x<seg_size.x_ * 2; x++){
-					if(flags & ATLAS_LOD_TOP_FACE){
-						// Preserve original colors
-						magic::IntVector2 src_p = src_off + magic::IntVector2(
-								((x + seg_size.x_ / 2) * lod) % seg_size.x_,
-								((y + seg_size.y_ / 2) * lod) % seg_size.y_
-						);
-						magic::IntVector2 dst_p = dst_p00 + magic::IntVector2(x, y);
-						magic::Color c = seg_img->GetPixel(src_p.x_, src_p.y_);
-						if(flags & ATLAS_LOD_BAKE_SHADOWS){
-							c.r_ *= 0.8f;
-							c.g_ *= 0.8f;
-							c.b_ *= 0.8f;
-						} else {
-							c.r_ *= 1.0f;
-							c.g_ *= 1.0f;
-							c.b_ *= 0.875f;
+					int sx0 = (x + seg_size.x_ / 2) * lod;
+					int sy0 = (y + seg_size.y_ / 2) * lod;
+					magic::Color c(0.0f, 0.0f, 0.0f, 0.0f);
+					for(int sy = 0; sy < lod; sy++){
+						for(int sx = 0; sx < lod; sx++){
+							magic::Color sc = seg_img->GetPixel(
+									src_off.x_ + (sx0 + sx) % seg_size.x_,
+									src_off.y_ + (sy0 + sy) % seg_size.y_);
+							c.r_ += sc.r_ * inv;
+							c.g_ += sc.g_ * inv;
+							c.b_ += sc.b_ * inv;
+							c.a_ += sc.a_ * inv;
 						}
-						atlas.image->SetPixel(dst_p.x_, dst_p.y_, c);
-					} else {
-						// Simulate sides
-						magic::IntVector2 src_p = src_off + magic::IntVector2(
-								((x + seg_size.x_ / 2) * lod) % seg_size.x_,
-								((y + seg_size.y_ / 2) * lod) % seg_size.y_
-						);
-						magic::IntVector2 dst_p = dst_p00 + magic::IntVector2(x, y);
-						magic::Color c = seg_img->GetPixel(src_p.x_, src_p.y_);
-						// Leave horizontal edges look like they are bright
-						// topsides
-						// TODO: This should be variable according to the
-						// camera's height relative to the thing the atlas
-						// segment is representing
-						int edge_size = lod * seg_size.y_ / 16;
-						bool is_edge = (
-								src_p.y_ <= edge_size ||
-								src_p.y_ >= seg_size.y_ - edge_size
-						);
-						if(flags & ATLAS_LOD_BAKE_SHADOWS){
-							if(is_edge){
-								if(flags & ATLAS_LOD_SEMIBRIGHT1_FACE){
-									c.r_ *= 0.75f;
-									c.g_ *= 0.75f;
-									c.b_ *= 0.8f;
-								} else if(flags & ATLAS_LOD_SEMIBRIGHT2_FACE){
-									c.r_ *= 0.75f;
-									c.g_ *= 0.75f;
-									c.b_ *= 0.8f;
-								} else {
-									c.r_ *= 0.8f * 0.49f;
-									c.g_ *= 0.8f * 0.49f;
-									c.b_ *= 0.8f * 0.52f;
-								}
-							} else {
-								if(flags & ATLAS_LOD_SEMIBRIGHT1_FACE){
-									c.r_ *= 0.70f * 0.75f;
-									c.g_ *= 0.70f * 0.75f;
-									c.b_ *= 0.65f * 0.8f;
-								} else if(flags & ATLAS_LOD_SEMIBRIGHT2_FACE){
-									c.r_ *= 0.50f * 0.75f;
-									c.g_ *= 0.50f * 0.75f;
-									c.b_ *= 0.50f * 0.8f;
-								} else {
-									c.r_ *= 0.5f * 0.15f;
-									c.g_ *= 0.5f * 0.15f;
-									c.b_ *= 0.5f * 0.16f;
-								}
-							}
-						} else {
-							if(is_edge){
-								c.r_ *= 1.0f;
-								c.g_ *= 1.0f;
-								c.b_ *= 0.875f;
-							} else {
-								if(flags & ATLAS_LOD_SEMIBRIGHT1_FACE){
-									c.r_ *= 0.70f;
-									c.g_ *= 0.70f;
-									c.b_ *= 0.65f;
-								} else if(flags & ATLAS_LOD_SEMIBRIGHT2_FACE){
-									c.r_ *= 0.50f;
-									c.g_ *= 0.50f;
-									c.b_ *= 0.50f;
-								} else {
-									c.r_ *= 0.5f;
-									c.g_ *= 0.5f;
-									c.b_ *= 0.5f;
-								}
-							}
-						}
-						atlas.image->SetPixel(dst_p.x_, dst_p.y_, c);
 					}
+					magic::IntVector2 dst_p = dst_p00 + magic::IntVector2(x, y);
+					atlas.image->SetPixel(dst_p.x_, dst_p.y_, c);
 				}
 			}
 		}
@@ -379,7 +317,7 @@ struct CAtlasRegistry: public AtlasRegistry
 	{
 		// LOD segments sample the source at a stride; the same stride has to
 		// be used here or the maps would not line up with the diffuse texture
-		int step = def.lod_simulation & 0x0f;
+		int step = def.lod_simulation;
 		if(step == 0)
 			step = 1;
 		// The mean is what def.roughness names, so a texel is only made

--- a/src/impl/mesh.cpp
+++ b/src/impl/mesh.cpp
@@ -836,9 +836,6 @@ void generate_voxel_lod_geometry(int lod,
 		VoxelRegistry *voxel_reg, AtlasRegistry *atlas_reg,
 		bool use_skylight)
 {
-	// Far LODs are drawn unlit, and there is no unlit vertex-color technique
-	// without alpha blending, so skylight stops at the shadowed LODs.
-	use_skylight = use_skylight && lod <= interface::MAX_LOD_WITH_SHADOWS;
 	IsQuadNeededByRegistry<VoxelInstance> iqn(voxel_reg);
 	pv::SurfaceMesh<pv::PositionMaterialNormal> pv_mesh;
 	pv::CubicSurfaceExtractorWithNormals<pv::RawVolume<VoxelInstance>,
@@ -934,7 +931,6 @@ void generate_voxel_lod_geometry(int lod,
 					- h/2.0f - 0.5f - lod/2.0f;
 			tg_vert.position_.z_ = pv_vert.position.getZ() * lod
 					- d/2.0f - 0.5f - lod/2.0f;
-			// Set real normal temporarily for assign_txcoords().
 			tg_vert.normal_.x_ = pv_vert.normal.getX();
 			tg_vert.normal_.y_ = pv_vert.normal.getY();
 			tg_vert.normal_.z_ = pv_vert.normal.getZ();
@@ -942,18 +938,6 @@ void generate_voxel_lod_geometry(int lod,
 			size_t pv_vertex_i1 = pv_vertex_i - pv_vertex_i0;
 			assign_txcoords(pv_vertex_i1, aseg, tg_vert);
 			tg_vert.color_ = corner_colors[pv_vertex_i1];
-			// Don't use the real normal.
-			// Constant bright shading is needed so that the look of multiple
-			// shaded faces can be emulated by using textures. This normal
-			// should give it to us.
-			// Note that this normal isn't actually exactly correct: It should
-			// be the normal that points to the main light source of the scene;
-			// however, it is close enough.
-			// We can't turn off lighting for this geometry, because then we
-			// don't get shadows, which we do want.
-			tg_vert.normal_.x_ = 0;
-			tg_vert.normal_.y_ = 1;
-			tg_vert.normal_.z_ = 0;
 		}
 	}
 }
@@ -983,20 +967,19 @@ void set_voxel_lod_geometry(int lod, CustomGeometry *cg, Context *context,
 		PODVector<CustomGeometryVertex> &cg_vertices = cg_all_vertices[cg_i];
 		cg_vertices = tg.vertex_data;
 		Material *material = new Material(context);
-		if(lod <= interface::MAX_LOD_WITH_SHADOWS){
-			if(tg.has_colors){
-				// The game sets the technique; see set_voxel_geometry()
-				material->SetShaderParameter("Roughness", 0.0f);
-				material->SetShaderParameter("Metallic", 0.0f);
-				material->SetTexture(TU_NORMAL, atlas_cache->normal_texture);
-				material->SetTexture(TU_SPECULAR, atlas_cache->spec_texture);
-			} else {
-				material->SetTechnique(0,
-						cache->GetResource<Technique>("Techniques/Diff.xml"));
-			}
+		// Every LOD is lit the same way as the geometry next to it. An unlit
+		// technique cannot match a scene lit in HDR and tonemapped, whatever
+		// is baked into its texture, and a visible brightness step at the LOD
+		// boundary is worse than the coarseness of the LOD itself.
+		if(tg.has_colors){
+			// The game sets the technique; see set_voxel_geometry()
+			material->SetShaderParameter("Roughness", 0.0f);
+			material->SetShaderParameter("Metallic", 0.0f);
+			material->SetTexture(TU_NORMAL, atlas_cache->normal_texture);
+			material->SetTexture(TU_SPECULAR, atlas_cache->spec_texture);
 		} else {
 			material->SetTechnique(0,
-					cache->GetResource<Technique>("Techniques/DiffUnlit.xml"));
+					cache->GetResource<Technique>("Techniques/Diff.xml"));
 		}
 		material->SetTexture(TU_DIFFUSE, atlas_cache->texture);
 		cg->SetMaterial(cg_i, material);

--- a/src/impl/voxel.cpp
+++ b/src/impl/voxel.cpp
@@ -190,22 +190,6 @@ struct CVoxelRegistry: public VoxelRegistry
 					int lod = 2 + j;
 					AtlasSegmentDefinition lod_seg_def = seg_def;
 					lod_seg_def.lod_simulation = lod;
-					if(i == 0){
-						lod_seg_def.lod_simulation |=
-								interface::ATLAS_LOD_TOP_FACE;
-					}
-					if(i == 5 /*Z-*/){
-					lod_seg_def.lod_simulation |=
-							interface::ATLAS_LOD_SEMIBRIGHT1_FACE;
-					}
-					if(i == 2 /*X+*/){
-					lod_seg_def.lod_simulation |=
-							interface::ATLAS_LOD_SEMIBRIGHT2_FACE;
-					}
-					if(lod > MAX_LOD_WITH_SHADOWS){
-						lod_seg_def.lod_simulation |=
-								interface::ATLAS_LOD_BAKE_SHADOWS;
-					}
 					AtlasSegmentReference lod_seg_ref =
 							atlas_reg->find_or_add_segment(lod_seg_def);
 					cache.lod_textures[j][i] = lod_seg_ref;

--- a/src/interface/atlas.h
+++ b/src/interface/atlas.h
@@ -24,20 +24,18 @@ namespace interface
 		uint segment_id = 0;
 	};
 
-	// LOD lower than this will have shadow baked into its texture
+	// LOD above this does not cast shadows. Every LOD is lit and shaded the
+	// same way; only the shadow it casts on the rest of the scene is dropped,
+	// which is not visible at the distance those LODs are drawn at.
 	const int MAX_LOD_WITH_SHADOWS = 2;
-
-	const uint8_t ATLAS_LOD_TOP_FACE = 0x10;
-	const uint8_t ATLAS_LOD_SEMIBRIGHT1_FACE = 0x20;
-	const uint8_t ATLAS_LOD_SEMIBRIGHT2_FACE = 0x40;
-	const uint8_t ATLAS_LOD_BAKE_SHADOWS = 0x80;
 
 	struct AtlasSegmentDefinition
 	{
 		ss_ resource_name; // If "", segment won't be added
 		magic::IntVector2 total_segments;
 		magic::IntVector2 select_segment;
-		// Mask 0x0f: LOD level, mask 0xf0: flags
+		// LOD level: 0 is the texture as it is, n >= 2 samples it n texels at
+		// a time so that one LOD voxel shows what n voxels of it would have.
 		uint8_t lod_simulation = 0;
 		// TODO: Rotation
 

--- a/src/lua_bindings/spatial_update_queue.cpp
+++ b/src/lua_bindings/spatial_update_queue.cpp
@@ -4,8 +4,9 @@
 #include "core/log.h"
 #include <tolua++.h>
 #include <Vector3.h>
-#include <list>
-#include <algorithm>
+#include <cassert>
+#include <map>
+#include <unordered_map>
 #define MODULE "lua_bindings"
 
 #define DEF_METHOD(name){ \
@@ -35,6 +36,17 @@ struct SpatialUpdateQueue
 	struct Value {
 		ss_ type;
 		uint32_t node_id = -1;
+
+		bool operator==(const Value &other) const {
+			return node_id == other.node_id && type == other.type;
+		}
+	};
+
+	struct ValueHash {
+		size_t operator()(const Value &v) const {
+			return std::hash<ss_>()(v.type) ^
+					(std::hash<uint32_t>()(v.node_id) * 2654435761u);
+		}
 	};
 
 	struct Item { // Queue item
@@ -46,78 +58,28 @@ struct SpatialUpdateQueue
 		float far_trigger_d = -1.0f;
 		float f = -1.0f;
 		float fw = -1.0f;
-
-		bool operator>(const Item &other) const;
 	};
 
-	// Set of values with iterators for fast access of items, so that items
-	// can be removed quickly by value
-	struct ValueSet
-	{
-		struct Entry
-		{
-			Value value;
-			std::list<Item>::iterator it;
-
-			Entry(const Value &value, std::list<Item>::iterator it =
-					std::list<Item>::iterator()):
-				value(value), it(it)
-			{}
-			bool operator>(const Entry &other) const {
-				if(value.node_id > other.value.node_id)
-					return true;
-				if(value.node_id < other.value.node_id)
-					return false;
-				return value.type > other.value.type;
-			}
-		};
-
-		// sorted list in descending node_id and type order
-		std::list<Entry> m_set;
-
-		void clear(){
-			m_set.clear();
-		}
-		void insert(const Value &value, std::list<Item>::iterator queue_it){
-			Entry entry(value, queue_it);
-			auto it = std::lower_bound(m_set.begin(), m_set.end(), entry,
-					std::greater<Entry>());
-			if(it == m_set.end())
-				m_set.insert(it, entry);
-			else if(it->value.node_id != value.node_id ||
-					it->value.type != value.type)
-				m_set.insert(it, entry);
-			else
-				*it = entry;
-		}
-		void remove(const Value &value){
-			Entry entry(value);
-			auto it = std::lower_bound(m_set.begin(), m_set.end(), entry,
-					std::greater<Entry>());
-			if(it == m_set.end())
-				return;
-			m_set.erase(it);
-		}
-		std::list<Item>::iterator*find(const Value &value){
-			Entry entry(value);
-			auto it = std::lower_bound(m_set.begin(), m_set.end(), entry,
-					std::greater<Entry>());
-			if(it == m_set.end())
-				return nullptr;
-			if(it->value.node_id != value.node_id ||
-					it->value.type != value.type)
-				return nullptr;
-			return &(it->it);
-		}
-	};
+	// Items that are due (f <= 1) come before ones that are not, and among
+	// those the smallest fw is the most important. That is the order the queue
+	// is popped in, so it is the order the map keeps.
+	typedef std::pair<bool, float> Key; // (f > 1.0f, fw)
+	typedef std::multimap<Key, Item> Queue;
 
 	Vector3 m_p;
 	Vector3 m_queue_oldest_p;
-	size_t m_queue_length = 0; // GCC std::list's size() is O(n)
-	std::list<Item> m_queue;
-	std::list<Item> m_old_queue;
+	Queue m_queue;
+	// Iterators into m_queue by value, so that an item can be found and
+	// replaced without walking the queue
+	std::unordered_map<Value, Queue::iterator, ValueHash> m_index;
+	// Items waiting to be re-put with a new f; a plain stack, because they are
+	// all going to be re-sorted anyway
+	sv_<Item> m_old_queue;
 
-	ValueSet m_value_set;
+	static Key key_of(const Item &item)
+	{
+		return Key(item.f > 1.0f, item.fw);
+	}
 
 	void update(int max_operations)
 	{
@@ -128,9 +90,9 @@ struct SpatialUpdateQueue
 		for(int i = 0; i<max_operations; i++){
 			if(m_old_queue.empty())
 				break;
-			Item &item = m_old_queue.back();
-			put_item(item);
+			Item item = m_old_queue.back();
 			m_old_queue.pop_back();
+			put_item(item);
 		}
 	}
 
@@ -138,9 +100,11 @@ struct SpatialUpdateQueue
 	{
 		m_p = p;
 		if(m_old_queue.empty() && (m_p - m_queue_oldest_p).Length() > 20){
-			m_queue_length = 0;
-			m_value_set.clear();
-			m_old_queue.swap(m_queue);
+			m_old_queue.reserve(m_queue.size());
+			for(auto &pair : m_queue)
+				m_old_queue.push_back(pair.second);
+			m_queue.clear();
+			m_index.clear();
 			m_queue_oldest_p = m_p;
 		}
 	}
@@ -175,25 +139,19 @@ struct SpatialUpdateQueue
 
 		// Find old entry; if the old entry is more important, discard the new
 		// one; if the old entry is less important, remove the old entry
-		std::list<Item>::iterator *itp = m_value_set.find(item.value);
-		if(itp != nullptr){
-			Item &old_item = **itp;
-			if(old_item.fw < item.fw){
+		auto index_it = m_index.find(item.value);
+		if(index_it != m_index.end()){
+			if(index_it->second->second.fw < item.fw){
 				// Old item is more important
 				return;
-			} else {
-				// New item is more important
-				m_queue.erase(*itp);
-				m_queue_length--;
-				m_value_set.remove(item.value);
 			}
+			// New item is more important
+			m_queue.erase(index_it->second);
+			m_index.erase(index_it);
 		}
 
-		auto it = std::lower_bound(m_queue.begin(), m_queue.end(),
-				item, std::greater<Item>()); // position in descending order
-		auto inserted_it = m_queue.insert(it, item);
-		m_queue_length++;
-		m_value_set.insert(item.value, inserted_it);
+		m_index[item.value] = m_queue.insert(
+				std::make_pair(key_of(item), item));
 	}
 
 	void put(const Vector3 &p, float near_weight, float near_trigger_d,
@@ -218,46 +176,106 @@ struct SpatialUpdateQueue
 	{
 		if(m_queue.empty())
 			throw Exception("SpatialUpdateQueue::pop(): Empty");
-		Item &item = m_queue.back();
-		m_value_set.remove(item.value);
-		m_queue.pop_back();
-		m_queue_length--;
+		auto it = m_queue.begin();
+		m_index.erase(it->second.value);
+		m_queue.erase(it);
 	}
 
 	Value& get_value()
 	{
 		if(m_queue.empty())
 			throw Exception("SpatialUpdateQueue::get_value(): Empty");
-		return m_queue.back().value;
+		return m_queue.begin()->second.value;
 	}
 
 	float get_f()
 	{
 		if(m_queue.empty())
 			throw Exception("SpatialUpdateQueue::get_f(): Empty");
-		return m_queue.back().f;
+		return m_queue.begin()->second.f;
 	}
 
 	float get_fw()
 	{
 		if(m_queue.empty())
 			throw Exception("SpatialUpdateQueue::get_fw(): Empty");
-		return m_queue.back().fw;
+		return m_queue.begin()->second.fw;
 	}
 
 	size_t get_length()
 	{
-		return m_queue_length;
+		return m_queue.size();
 	}
 };
 
-bool SpatialUpdateQueue::Item::operator>(const Item &other) const
+// The queue decides the order chunks are meshed in, and a silent ordering or
+// replacement bug there shows up only as chunks meshing late. Runs at startup;
+// it is a few microseconds.
+static void self_check()
 {
-	if(f > 1.0f && other.f <= 1.0f)
-		return true;
-	if(f <= 1.0f && other.f > 1.0f)
-		return false;
-	return fw > other.fw;
+	auto item_value = [](const char *type, uint32_t node_id){
+		SpatialUpdateQueue::Value v;
+		v.type = type;
+		v.node_id = node_id;
+		return v;
+	};
+
+	// Whichever is closest to its near trigger comes first, and f > 1 (not due
+	// yet) goes behind f <= 1 whatever the weights say
+	{
+		SpatialUpdateQueue q;
+		q.set_p(Vector3(0, 0, 0));
+		q.put(Vector3(50, 0, 0), 1.0f, 100.0f, -1.0f, -1.0f,
+				item_value("geometry", 1)); // f = 0.5
+		q.put(Vector3(10, 0, 0), 1.0f, 100.0f, -1.0f, -1.0f,
+				item_value("geometry", 2)); // f = 0.1
+		q.put(Vector3(200, 0, 0), 0.01f, 100.0f, -1.0f, -1.0f,
+				item_value("geometry", 3)); // f = 2, lowest fw of the three
+		assert(q.get_length() == 3);
+		assert(q.get_value().node_id == 2);
+		q.pop();
+		assert(q.get_value().node_id == 1);
+		q.pop();
+		assert(q.get_value().node_id == 3);
+		q.pop();
+		assert(q.empty());
+	}
+
+	// The same value put twice is one item: the more important put wins,
+	// whichever order the two come in
+	{
+		SpatialUpdateQueue q;
+		q.set_p(Vector3(0, 0, 0));
+		q.put(Vector3(50, 0, 0), 0.1f, 100.0f, -1.0f, -1.0f,
+				item_value("geometry", 1)); // fw = 5
+		q.put(Vector3(50, 0, 0), 1.0f, 100.0f, -1.0f, -1.0f,
+				item_value("geometry", 1)); // fw = 0.5, more important
+		assert(q.get_length() == 1);
+		assert(q.get_fw() < 1.0f);
+		q.put(Vector3(50, 0, 0), 0.1f, 100.0f, -1.0f, -1.0f,
+				item_value("geometry", 1)); // less important, discarded
+		assert(q.get_length() == 1);
+		assert(q.get_fw() < 1.0f);
+		// Same node, other type, is a different value
+		q.put(Vector3(50, 0, 0), 1.0f, 100.0f, -1.0f, -1.0f,
+				item_value("physics", 1));
+		assert(q.get_length() == 2);
+	}
+
+	// Moving far enough re-puts everything against the new position
+	{
+		SpatialUpdateQueue q;
+		q.set_p(Vector3(0, 0, 0));
+		q.put(Vector3(0, 0, 0), 1.0f, 100.0f, -1.0f, -1.0f,
+				item_value("geometry", 1));
+		q.put(Vector3(500, 0, 0), 1.0f, 100.0f, -1.0f, -1.0f,
+				item_value("geometry", 2));
+		q.set_p(Vector3(500, 0, 0));
+		assert(q.empty()); // Everything is waiting to be re-put
+		q.update(10);
+		assert(q.get_length() == 2);
+		assert(q.get_value().node_id == 2); // Now the near one
+	}
 }
 
 struct LuaSUQ
@@ -401,6 +419,8 @@ void init_spatial_update_queue(lua_State *L)
 		lua_pushcfunction(L, l_##name); \
 		lua_setglobal(L, "__buildat_" #name); \
 }
+	self_check();
+
 	LuaSUQ::register_metatable(L);
 
 	DEF_BUILDAT_FUNC(SpatialUpdateQueue);


### PR DESCRIPTION
Investigated worldgen, voxel streaming and rendering performance by flying
straight and level over infinite terrain in `games/bomber_drone`, with the
on-screen profiler (F9) and `perf` on both the client and the server.

## What was slow

Client, per frame:

* The spatial update queue was a sorted `std::list` with a second sorted
  `std::list` as its by-value index. `std::lower_bound` over a list iterator
  walks the list, so every put walked a few thousand items several times over.
  21% of the client's CPU; the voxelworld Lua update alone was 45 ms of every
  frame. Mesh generation itself was already threaded and was not the problem.
* Urho3D's `LuaScript` ran a full `lua_gc` collect every frame, walking a heap
  that is large and mostly live. 20 ms per frame, 23% of the client's CPU.

Server, per section:

* voxelworld built a `RigidBody` and collision boxes for every chunk whether or
  not anything was simulated against them, and Bullet then kept their AABBs up
  to date forever. 19% of the server's CPU, competing with world generation for
  the module lock. It is a `create_instance()` parameter now, defaulting to off
  -- a parameter and not a setting because the initial sections are created in
  the instance constructor.

The only thing in the tree that had the server simulate against the voxel world
was the test box that digger and infidigger dropped into it, and that is removed
here: `games/geometry` and `games/geometry2` demonstrate the same thing more
thoroughly in a small test scene, with a dynamic voxel body against a static
voxel collision mesh and both shape types side by side. So nothing passes the
new parameter as `true`. Say the word if the whole server-side chunk physics
path should go rather than sit behind an off-by-default switch.

## Measured

Four cruise samples of `RunFrame` avg, and the whole run's world generation.
Debug build, -O1.

| | before | after |
|---|---|---|
| frame time | 52.9 ms (~19 fps) | 22.9 ms (~44 fps) |
| sections generated in the run | 277 | 688 |
| worldgen queue peak | 62 | 16 |

The queue no longer runs away, so the view ahead of the drone fills in at cruise
speed instead of ending in the streaming edge.

## LOD

LOD needed the visual work. It was not using the lighting the rest of the scene
used at all: it threw away the real normals for a constant "up" one, took its
shading from multipliers baked into a copy of the texture, and past LOD 2
dropped the skylight and drew unlit. That was built for a scene lit in LDR, and
in one lit in HDR and tonemapped the far LODs came out pale and flat with a
brightness step at the boundary that was far more visible than the coarseness of
the LOD itself.

LOD geometry now keeps its real normals and its skylight and uses the same
material as LOD 1, so the only difference across a boundary is resolution. The
LOD texture averages the `lod x lod` source texels it stands for instead of
picking one of them, which removes a blotchy pattern that had nothing to do with
the texture and shimmered as the camera moved. A voxel ends up with 6 LOD atlas
segments instead of 18, and LOD is now cheaper than drawing everything at LOD 1
again.

## Checks

* The spatial update queue's ordering and replacement rules have an
  assert-based self-check that runs at client startup.
* bomber_drone, digger, infidigger and voxel_lighting were each run and
  screenshotted. The games' `main.cpp` is compiled at runtime, so a `make` does
  not check them.

`doc/most_important_performance_issues.txt` is rewritten with what is left:
skylight for a freshly generated section is now the largest server cost, and
the software occlusion buffer and the atlas rebuild are what is left on the
client.