### PR TITLE
Randomized port for launcher-started local games

### DIFF
--- a/builtin/network/network.cpp
+++ b/builtin/network/network.cpp
@@ -4,6 +4,7 @@
 #include "core/log.h"
 #include "interface/module.h"
 #include "interface/server.h"
+#include "interface/server_config.h"
 #include "interface/event.h"
 #include "interface/tcpsocket.h"
 #include "interface/packet_stream.h"
@@ -116,8 +117,8 @@ struct Module: public interface::Module, public network::Interface
 
 	void on_start()
 	{
-		ss_ address = "any4";
-		ss_ port = "20000";
+		ss_ address = m_server->get_config().get<ss_>("network_address");
+		ss_ port = m_server->get_config().get<ss_>("network_port");
 
 		if(!m_listening_socket->bind_fd(address, port) ||
 				!m_listening_socket->listen_fd()){

--- a/client/api.lua
+++ b/client/api.lua
@@ -10,6 +10,7 @@ buildat.stop_local_server = __buildat_stop_local_server
 buildat.request_stop_local_server = __buildat_request_stop_local_server
 buildat.force_kill_local_server = __buildat_force_kill_local_server
 buildat.local_server_ready = __buildat_local_server_ready
+buildat.local_server_port = __buildat_local_server_port
 buildat.local_server_running = __buildat_local_server_running
 buildat.extension_path    = __buildat_extension_path
 buildat.get_time_us       = __buildat_get_time_us

--- a/extensions/__menu/init.lua
+++ b/extensions/__menu/init.lua
@@ -29,7 +29,7 @@ local function show_connect_to_server()
 	line_edit:SetName("connect_to_server line_edit")
 	line_edit.minHeight = 24
 	line_edit.minWidth = 300
-	line_edit:SetText("localhost:20000")
+	line_edit:SetText("localhost:29500")
 	line_edit:SetFocus(true)
 
 	local connect_button = window:CreateChild("Button")

--- a/extensions/launch_menu/init.lua
+++ b/extensions/launch_menu/init.lua
@@ -110,7 +110,7 @@ local function show_connect_to_server()
 	window:SetAlignment(HA_LEFT, VA_CENTER)
 
 	local address_edit = make_labeled_edit(window, "Address", "localhost")
-	local port_edit = make_labeled_edit(window, "Port (optional)", "20000")
+	local port_edit = make_labeled_edit(window, "Port (optional)", "29500")
 	address_edit:SetFocus(true)
 
 	local function do_connect()

--- a/extensions/launch_menu/init.lua
+++ b/extensions/launch_menu/init.lua
@@ -178,7 +178,7 @@ local function show_starting(game)
 		end
 		if buildat.local_server_ready() then
 			done = true
-			connect_or_show_error("localhost")
+			connect_or_show_error("localhost:"..buildat.local_server_port())
 			return
 		end
 		if not buildat.local_server_running() then

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -235,12 +235,14 @@ static ss_ pick_free_local_port()
 {
 	std::random_device rd;
 	for(int i = 0; i < 100; i++){
-		int port = 30000 + rd() % 20000;
+		// 29168...29999 is unassigned in IANA's registry and below the
+		// ephemeral port range, so nothing else should want it
+		int port = 29168 + rd() % 832;
 		ss_ port_s = std::to_string(port);
 		if(!interface::probe_connect("127.0.0.1", port_s))
 			return port_s;
 	}
-	return "20000";
+	return "29500";
 }
 
 static ss_ pidfile_path()

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -48,6 +48,7 @@ extern "C" {
 #include <lauxlib.h>
 }
 #include <signal.h>
+#include <random>
 #include <cstdio>
 #include <cstring>
 #ifndef _WIN32
@@ -223,6 +224,24 @@ static bool valid_game_name(const ss_ &name)
 
 // Survives CApp reboot so disconnect can kill the server we started.
 static interface::process::Handle g_local_server;
+// Port the local server was told to listen on ("" if none was started)
+static ss_ g_local_server_port;
+
+// simplified: A free port is picked by probing; a race with another process
+// grabbing it in between is possible but harmless for a local game (the server
+// exits and the menu says so). Upgrade path: have the server bind port 0 and
+// report the actual port back to the client.
+static ss_ pick_free_local_port()
+{
+	std::random_device rd;
+	for(int i = 0; i < 100; i++){
+		int port = 30000 + rd() % 20000;
+		ss_ port_s = std::to_string(port);
+		if(!interface::probe_connect("127.0.0.1", port_s))
+			return port_s;
+	}
+	return "20000";
+}
 
 static ss_ pidfile_path()
 {
@@ -327,11 +346,11 @@ static void stop_local_server()
 	interface::process::terminate(g_local_server);
 	clear_pidfile();
 	for(int i = 0; i < 40; i++){
-		if(!interface::probe_connect("127.0.0.1", "20000"))
+		if(!interface::probe_connect("127.0.0.1", g_local_server_port))
 			return;
 		interface::os::sleep_us(50000);
 	}
-	log_w(MODULE, "Local server did not release port 20000");
+	log_w(MODULE, "Local server did not release port %s", cs(g_local_server_port));
 }
 
 namespace app {
@@ -718,6 +737,7 @@ struct CApp: public App, public magic::Application
 		DEF_BUILDAT_FUNC(force_kill_local_server)
 		DEF_BUILDAT_FUNC(local_server_ready)
 		DEF_BUILDAT_FUNC(local_server_running)
+		DEF_BUILDAT_FUNC(local_server_port)
 		DEF_BUILDAT_FUNC(send_packet);
 		DEF_BUILDAT_FUNC(get_file_path)
 		DEF_BUILDAT_FUNC(get_file_content)
@@ -1153,8 +1173,10 @@ struct CApp: public App, public magic::Application
 		}
 
 		game_path = interface::fs::get_absolute_path(game_path);
+		g_local_server_port = pick_free_local_port();
+		log_i(MODULE, "Starting local server on port %s", cs(g_local_server_port));
 		g_local_server = interface::process::start(
-				server_path, {"-m", game_path});
+				server_path, {"-m", game_path, "-P", g_local_server_port});
 		if(!g_local_server.valid()){
 			lua_pushboolean(L, false);
 			lua_pushstring(L, "Failed to start server");
@@ -1218,7 +1240,15 @@ struct CApp: public App, public magic::Application
 			lua_pushboolean(L, false);
 			return 1;
 		}
-		lua_pushboolean(L, interface::probe_connect("127.0.0.1", "20000"));
+		lua_pushboolean(L, interface::probe_connect("127.0.0.1",
+				g_local_server_port));
+		return 1;
+	}
+
+	// local_server_port() -> string
+	static int l_local_server_port(lua_State *L)
+	{
+		lua_pushstring(L, g_local_server_port.c_str());
 		return 1;
 	}
 

--- a/src/client/state.cpp
+++ b/src/client/state.cpp
@@ -138,7 +138,7 @@ struct CState: public State
 			return false;
 		}
 		if(port == ""){
-			port = "20000";
+			port = "29500";
 		}
 		return connect_host_port(host, port, error);
 	}

--- a/src/server/config.cpp
+++ b/src/server/config.cpp
@@ -16,6 +16,8 @@ Config::Config()
 	set_default("share_path", "");
 	set_default("urho3d_path", "");
 	set_default("compiler_command", "");
+	set_default("network_address", "any4");
+	set_default("network_port", "20000");
 
 	set_default("skip_compiling_modules", json::object());
 }

--- a/src/server/config.cpp
+++ b/src/server/config.cpp
@@ -17,7 +17,7 @@ Config::Config()
 	set_default("urho3d_path", "");
 	set_default("compiler_command", "");
 	set_default("network_address", "any4");
-	set_default("network_port", "20000");
+	set_default("network_port", "29500");
 
 	set_default("skip_compiling_modules", json::object());
 }

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
 
 	std::string module_path;
 
-	const char opts[100] = "hm:r:i:S:U:c:l:L:C:";
+	const char opts[100] = "hm:r:i:S:U:c:l:L:C:A:P:";
 	const char usagefmt[1000] =
 			"Usage: %s [OPTION]...\n"
 			"  -h                   Show this help\n"
@@ -69,6 +69,8 @@ int main(int argc, char *argv[])
 			"  -l [integer]         Set maximum log level (0...5)\n"
 			"  -L [log file path]   Append log to a specified file\n"
 			"  -C [module_name]     Skip compiling specified module\n"
+			"  -A [address]         Set listening address (default any4)\n"
+			"  -P [port]            Set network port (default 20000)\n"
 			;
 
 	int c;
@@ -102,6 +104,14 @@ int main(int argc, char *argv[])
 		case 'c':
 			log_i(MODULE, "config.compiler_command: %s", c55_optarg);
 			config.set("compiler_command", c55_optarg);
+			break;
+		case 'A':
+			log_i(MODULE, "config.network_address: %s", c55_optarg);
+			config.set("network_address", c55_optarg);
+			break;
+		case 'P':
+			log_i(MODULE, "config.network_port: %s", c55_optarg);
+			config.set("network_port", c55_optarg);
 			break;
 		case 'l':
 			log_set_max_level(atoi(c55_optarg));

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
 			"  -L [log file path]   Append log to a specified file\n"
 			"  -C [module_name]     Skip compiling specified module\n"
 			"  -A [address]         Set listening address (default any4)\n"
-			"  -P [port]            Set network port (default 20000)\n"
+			"  -P [port]            Set network port (default 29500)\n"
 			;
 
 	int c;


### PR DESCRIPTION
Local games started from the launcher no longer use a fixed port.

- Server gains `network_address` / `network_port` config values with `-A` and `-P` command line options; the network module reads them instead of hardcoding `any4:20000`.
- Client picks a free port before starting a local server, passes it with `-P`, and uses it for the readiness probe, the shutdown wait and the connect address in the launch menu. New Lua binding `buildat.local_server_port()`.
- Default port changes from 20000 to 29500. 20000 is assigned to DNP in IANA's registry and is crowded with squatters; 29168...29999 has no assignments and is below the ephemeral port range, so its middle is the new default and the local game's random port is drawn from that block.

Tested by starting the server with `-A 127.0.0.1 -P 34568` and with no options, checking the listening address in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)