### PR TITLE
Loading text for voxel_physics and voxel_lighting

### DIFF
--- a/games/voxel_lighting/main/client_lua/init.lua
+++ b/games/voxel_lighting/main/client_lua/init.lua
@@ -509,6 +509,19 @@ do
 	magic.ui:SetFocusElement(nil)
 end
 
+-- The terrain is generated on the server after the client has connected, which
+-- takes a few seconds and shows as nothing but sky. Say what is going on until
+-- the first chunk's geometry exists.
+local wait_text = magic.ui.root:CreateChild("Text")
+wait_text:SetText("Generating terrain...")
+wait_text:SetFont(magic.cache:GetResource("Font", buildat.font_mono), 24)
+wait_text.horizontalAlignment = magic.HA_CENTER
+wait_text.verticalAlignment = magic.VA_CENTER
+wait_text:SetPosition(0, 0)
+voxelworld.sub_geometry_update(function(node)
+	wait_text:SetText("")
+end)
+
 magic.SubscribeToEvent("KeyDown", function(event_type, event_data)
 	local key = event_data:GetInt("Key")
 	if key == magic.KEY_TAB then

--- a/games/voxel_physics/main/client_lua/init.lua
+++ b/games/voxel_physics/main/client_lua/init.lua
@@ -120,6 +120,19 @@ title_text.verticalAlignment = magic.VA_TOP
 title_text:SetPosition(0, 10)
 magic.ui:SetFocusElement(nil)
 
+-- The terrain is generated on the server after the client has connected, which
+-- takes a few seconds and shows as nothing but sky. Say what is going on until
+-- the first chunk's geometry exists.
+local wait_text = magic.ui.root:CreateChild("Text")
+wait_text:SetText("Generating terrain...")
+wait_text:SetFont(magic.cache:GetResource("Font", buildat.font_mono), 24)
+wait_text.horizontalAlignment = magic.HA_CENTER
+wait_text.verticalAlignment = magic.VA_CENTER
+wait_text:SetPosition(0, 0)
+voxelworld.sub_geometry_update(function(node)
+	wait_text:SetText("")
+end)
+
 -- The pieces. They are replicated scene nodes carrying voxel data in their
 -- vars, not part of the voxel world, so the geometry is built here out of the
 -- world's own registry: same textures and atlas as the terrain.


### PR DESCRIPTION
Both games showed nothing but the fog/sky color while the server generated the world after the client connected: measured ~6 s for voxel_physics, about a second for voxel_lighting. digger, bomber_drone and infidigger already say what is going on; these two did not.

A centered "Generating terrain..." text, cleared on the first `voxelworld.sub_geometry_update()` callback, i.e. as soon as a chunk's geometry exists.

Verified with `-c` command sequences: screenshot at 1.5 s shows the text, screenshot after generation shows the world with no text left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)