### PR TITLE
Fix noise naming

### DIFF
--- a/games/bomber_drone/main/main.cpp
+++ b/games/bomber_drone/main/main.cpp
@@ -63,14 +63,14 @@ struct Worldgen: public worldgen::GeneratorInterface
 		interface::v3f spread_h(280, 280, 280);
 		interface::NoiseParams np_h(0, 14, spread_h, 0, 5, 0.45);
 		interface::Noise noise_h(&np_h, 3, w, d);
-		noise_h.perlinMap2D(lc.getX() + spread_h.X/2,
+		noise_h.fbmMap2D(lc.getX() + spread_h.X/2,
 				lc.getZ() + spread_h.Z/2);
 		noise_h.transformNoiseMap();
 
 		interface::v3f spread_b(48, 48, 48);
 		interface::NoiseParams np_b(0, 3, spread_b, 11, 3, 0.5);
 		interface::Noise noise_b(&np_b, 3, w, d);
-		noise_b.perlinMap2D(lc.getX() + spread_b.X/2,
+		noise_b.fbmMap2D(lc.getX() + spread_b.X/2,
 				lc.getZ() + spread_b.Z/2);
 		noise_b.transformNoiseMap();
 

--- a/games/digger/main/main.cpp
+++ b/games/digger/main/main.cpp
@@ -84,7 +84,7 @@ struct Worldgen: public worldgen::GeneratorInterface
 			int d = uc.getZ() - lc.getZ() + 1;
 
 			interface::Noise noise(&np, 3, w, d);
-			noise.perlinMap2D(lc.getX() + spread.X/2, lc.getZ() + spread.Z/2);
+			noise.fbmMap2D(lc.getX() + spread.X/2, lc.getZ() + spread.Z/2);
 			noise.transformNoiseMap(); // ?
 
 			size_t noise_i = 0;

--- a/games/infidigger/main/main.cpp
+++ b/games/infidigger/main/main.cpp
@@ -63,14 +63,14 @@ struct Worldgen: public worldgen::GeneratorInterface
 		interface::v3f spread_h(280, 280, 280);
 		interface::NoiseParams np_h(0, 14, spread_h, 0, 5, 0.45);
 		interface::Noise noise_h(&np_h, 3, w, d);
-		noise_h.perlinMap2D(lc.getX() + spread_h.X/2,
+		noise_h.fbmMap2D(lc.getX() + spread_h.X/2,
 				lc.getZ() + spread_h.Z/2);
 		noise_h.transformNoiseMap();
 
 		interface::v3f spread_b(48, 48, 48);
 		interface::NoiseParams np_b(0, 3, spread_b, 11, 3, 0.5);
 		interface::Noise noise_b(&np_b, 3, w, d);
-		noise_b.perlinMap2D(lc.getX() + spread_b.X/2,
+		noise_b.fbmMap2D(lc.getX() + spread_b.X/2,
 				lc.getZ() + spread_b.Z/2);
 		noise_b.transformNoiseMap();
 

--- a/games/multisection_lighting/main/main.cpp
+++ b/games/multisection_lighting/main/main.cpp
@@ -160,7 +160,7 @@ struct Worldgen: public worldgen::GeneratorInterface
 			// Sampled at scene coordinates, so the terrain under the cave is
 			// the terrain voxel_lighting's cave was carved into
 			interface::Noise noise(&np, 3, nw, nd);
-			noise.perlinMap2D(nx0 - SCENE_OFFSET_X + spread.X/2,
+			noise.fbmMap2D(nx0 - SCENE_OFFSET_X + spread.X/2,
 					nz0 - SCENE_OFFSET_Z + spread.Z/2);
 			noise.transformNoiseMap();
 
@@ -175,7 +175,7 @@ struct Worldgen: public worldgen::GeneratorInterface
 			// TUNING: pick a cave mouth whose cave stays under the terrain
 			if(section_p == pv::Vector3DInt16(0, 0, 0)){
 				interface::Noise wn(&np, 3, WORLD_SIZE, WORLD_SIZE);
-				wn.perlinMap2D(spread.X/2, spread.Z/2);
+				wn.fbmMap2D(spread.X/2, spread.Z/2);
 				wn.transformNoiseMap();
 				auto wnoise = [&](int x, int z){
 					if(x < 0 || x >= WORLD_SIZE || z < 0 || z >= WORLD_SIZE)
@@ -296,7 +296,7 @@ struct Worldgen: public worldgen::GeneratorInterface
 			// the noise map of the sections the mouth is over. One extra
 			// sample of the same noise gives it to all of them.
 			interface::Noise mouth_noise(&np, 3, 1, 1);
-			mouth_noise.perlinMap2D(mouth_x - SCENE_OFFSET_X + spread.X/2,
+			mouth_noise.fbmMap2D(mouth_x - SCENE_OFFSET_X + spread.X/2,
 					mouth_z - SCENE_OFFSET_Z + spread.Z/2);
 			mouth_noise.transformNoiseMap();
 			float mouth_surface = mouth_noise.result[0] + GROUND_OFFSET +

--- a/games/voxel_lighting/main/main.cpp
+++ b/games/voxel_lighting/main/main.cpp
@@ -126,7 +126,7 @@ struct Worldgen: public worldgen::GeneratorInterface
 			// at this one it would swing the surface across the whole volume.
 			interface::NoiseParams np(0, TERRAIN_AMPLITUDE, spread, 0, 5, 0.4);
 			interface::Noise noise(&np, 3, w, d);
-			noise.perlinMap2D(lc.getX() + spread.X/2, lc.getZ() + spread.Z/2);
+			noise.fbmMap2D(lc.getX() + spread.X/2, lc.getZ() + spread.Z/2);
 			noise.transformNoiseMap();
 
 			// Reported so GROUND_OFFSET and TERRAIN_AMPLITUDE can be retuned

--- a/src/impl/noise.cpp
+++ b/src/impl/noise.cpp
@@ -140,6 +140,7 @@ float triLinearInterpolation(
 
 
 #if 0
+// Actual gradient (Perlin) noise, unlike the value noise used below
 float noise2d_gradient(float x, float y, int seed)
 {
 	// Calculate the integer coordinates
@@ -165,7 +166,7 @@ float noise2d_gradient(float x, float y, int seed)
 #endif
 
 
-float noise2d_gradient(float x, float y, int seed)
+float noise2d_value(float x, float y, int seed)
 {
 	// Calculate the integer coordinates
 	int x0 = floor(x);
@@ -183,7 +184,7 @@ float noise2d_gradient(float x, float y, int seed)
 }
 
 
-float noise3d_gradient(float x, float y, float z, int seed)
+float noise3d_value(float x, float y, float z, int seed)
 {
 	// Calculate the integer coordinates
 	int x0 = floor(x);
@@ -209,7 +210,7 @@ float noise3d_gradient(float x, float y, float z, int seed)
 }
 
 
-float noise2d_perlin(float x, float y, int seed,
+float noise2d_fbm(float x, float y, int seed,
 		int octaves, float persistence)
 {
 	float a = 0;
@@ -217,7 +218,7 @@ float noise2d_perlin(float x, float y, int seed,
 	float g = 1.0;
 	for (int i = 0; i < octaves; i++)
 	{
-		a += g * noise2d_gradient(x * f, y * f, seed + i);
+		a += g * noise2d_value(x * f, y * f, seed + i);
 		f *= 2.0;
 		g *= persistence;
 	}
@@ -225,7 +226,7 @@ float noise2d_perlin(float x, float y, int seed,
 }
 
 
-float noise2d_perlin_abs(float x, float y, int seed,
+float noise2d_fbm_abs(float x, float y, int seed,
 		int octaves, float persistence)
 {
 	float a = 0;
@@ -233,7 +234,7 @@ float noise2d_perlin_abs(float x, float y, int seed,
 	float g = 1.0;
 	for (int i = 0; i < octaves; i++)
 	{
-		a += g * fabs(noise2d_gradient(x * f, y * f, seed + i));
+		a += g * fabs(noise2d_value(x * f, y * f, seed + i));
 		f *= 2.0;
 		g *= persistence;
 	}
@@ -241,7 +242,7 @@ float noise2d_perlin_abs(float x, float y, int seed,
 }
 
 
-float noise3d_perlin(float x, float y, float z, int seed,
+float noise3d_fbm(float x, float y, float z, int seed,
 		int octaves, float persistence)
 {
 	float a = 0;
@@ -249,7 +250,7 @@ float noise3d_perlin(float x, float y, float z, int seed,
 	float g = 1.0;
 	for (int i = 0; i < octaves; i++)
 	{
-		a += g * noise3d_gradient(x * f, y * f, z * f, seed + i);
+		a += g * noise3d_value(x * f, y * f, z * f, seed + i);
 		f *= 2.0;
 		g *= persistence;
 	}
@@ -257,7 +258,7 @@ float noise3d_perlin(float x, float y, float z, int seed,
 }
 
 
-float noise3d_perlin_abs(float x, float y, float z, int seed,
+float noise3d_fbm_abs(float x, float y, float z, int seed,
 		int octaves, float persistence)
 {
 	float a = 0;
@@ -265,7 +266,7 @@ float noise3d_perlin_abs(float x, float y, float z, int seed,
 	float g = 1.0;
 	for (int i = 0; i < octaves; i++)
 	{
-		a += g * fabs(noise3d_gradient(x * f, y * f, z * f, seed + i));
+		a += g * fabs(noise3d_value(x * f, y * f, z * f, seed + i));
 		f *= 2.0;
 		g *= persistence;
 	}
@@ -283,7 +284,7 @@ float contour(float v)
 }
 
 
-///////////////////////// [ New perlin stuff ] ////////////////////////////
+///////////////////////// [ New value noise stuff ] //////////////////////////
 
 
 Noise::Noise(NoiseParams *np, int seed, int sx, int sy) {
@@ -385,7 +386,7 @@ void Noise::resizeNoiseBuf(bool is3d) {
  * next octave.
  */
 #define idx(x, y) ((y) * nlx + (x))
-void Noise::gradientMap2D(float x, float y, float step_x, float step_y, int seed) {
+void Noise::valueMap2D(float x, float y, float step_x, float step_y, int seed) {
 	float v00, v01, v10, v11, u, v, orig_u;
 	int index, i, j, x0, y0, noisex, noisey;
 	int nlx, nly;
@@ -439,7 +440,7 @@ void Noise::gradientMap2D(float x, float y, float step_x, float step_y, int seed
 
 
 #define idx(x, y, z) ((z) * nly * nlx + (y) * nlx + (x))
-void Noise::gradientMap3D(float x, float y, float z,
+void Noise::valueMap3D(float x, float y, float z,
 						  float step_x, float step_y, float step_z,
 						  int seed) {
 	float v000, v010, v100, v110;
@@ -523,7 +524,7 @@ void Noise::gradientMap3D(float x, float y, float z,
 #undef idx
 
 
-float *Noise::perlinMap2D(float x, float y) {
+float *Noise::fbmMap2D(float x, float y) {
 	float f = 1.0, g = 1.0;
 	int i, j, index, oct;
 
@@ -533,7 +534,7 @@ float *Noise::perlinMap2D(float x, float y) {
 	memset(result, 0, sizeof(float) * sx * sy);
 
 	for (oct = 0; oct < np->octaves; oct++) {
-		gradientMap2D(x * f, y * f,
+		valueMap2D(x * f, y * f,
 			f / np->spread.X, f / np->spread.Y,
 			seed + np->seed + oct);
 
@@ -553,7 +554,7 @@ float *Noise::perlinMap2D(float x, float y) {
 }
 
 
-float *Noise::perlinMap2DModulated(float x, float y, float *persist_map) {
+float *Noise::fbmMap2DModulated(float x, float y, float *persist_map) {
 	float f = 1.0;
 	int i, j, index, oct;
 
@@ -567,7 +568,7 @@ float *Noise::perlinMap2DModulated(float x, float y, float *persist_map) {
 		g[index] = 1.0;
 
 	for (oct = 0; oct < np->octaves; oct++) {
-		gradientMap2D(x * f, y * f,
+		valueMap2D(x * f, y * f,
 			f / np->spread.X, f / np->spread.Y,
 			seed + np->seed + oct);
 
@@ -588,7 +589,7 @@ float *Noise::perlinMap2DModulated(float x, float y, float *persist_map) {
 }
 
 
-float *Noise::perlinMap3D(float x, float y, float z) {
+float *Noise::fbmMap3D(float x, float y, float z) {
 	float f = 1.0, g = 1.0;
 	int i, j, k, index, oct;
 
@@ -599,7 +600,7 @@ float *Noise::perlinMap3D(float x, float y, float z) {
 	memset(result, 0, sizeof(float) * sx * sy * sz);
 
 	for (oct = 0; oct < np->octaves; oct++) {
-		gradientMap3D(x * f, y * f, z * f,
+		valueMap3D(x * f, y * f, z * f,
 			f / np->spread.X, f / np->spread.Y, f / np->spread.Z,
 			seed + np->seed + oct);
 

--- a/src/interface/noise.h
+++ b/src/interface/noise.h
@@ -103,83 +103,86 @@ namespace interface
 		void setOctaves(int octaves);
 		void resizeNoiseBuf(bool is3d);
 
-		void gradientMap2D(
+		void valueMap2D(
 				float x, float y,
 				float step_x, float step_y,
 				int seed);
-		void gradientMap3D(
+		void valueMap3D(
 				float x, float y, float z,
 				float step_x, float step_y, float step_z,
 				int seed);
-		float* perlinMap2D(float x, float y);
-		float* perlinMap2DModulated(float x, float y, float *persist_map);
-		float* perlinMap3D(float x, float y, float z);
+		float* fbmMap2D(float x, float y);
+		float* fbmMap2DModulated(float x, float y, float *persist_map);
+		float* fbmMap3D(float x, float y, float z);
 		void transformNoiseMap();
 	};
+
+	// Value noise (not gradient/Perlin noise): the hashes below are the lattice
+	// values themselves, interpolated between. The _fbm variants sum octaves.
 
 	// Return value: -1 ... 1
 	float noise2d(int x, int y, int seed);
 	float noise3d(int x, int y, int z, int seed);
 
-	float noise2d_gradient(float x, float y, int seed);
-	float noise3d_gradient(float x, float y, float z, int seed);
+	float noise2d_value(float x, float y, int seed);
+	float noise3d_value(float x, float y, float z, int seed);
 
-	float noise2d_perlin(float x, float y, int seed,
+	float noise2d_fbm(float x, float y, int seed,
 			int octaves, float persistence);
 
-	float noise2d_perlin_abs(float x, float y, int seed,
+	float noise2d_fbm_abs(float x, float y, int seed,
 			int octaves, float persistence);
 
-	float noise3d_perlin(float x, float y, float z, int seed,
+	float noise3d_fbm(float x, float y, float z, int seed,
 			int octaves, float persistence);
 
-	float noise3d_perlin_abs(float x, float y, float z, int seed,
+	float noise3d_fbm_abs(float x, float y, float z, int seed,
 			int octaves, float persistence);
 
 	inline float easeCurve(float t){
 		return t * t * t * (t * (6.f * t - 15.f) + 10.f);
 	}
 
-	inline float NoisePerlin2D(const NoiseParams *np, float x, float y, float s)
+	inline float NoiseFbm2D(const NoiseParams *np, float x, float y, float s)
 	{
-		return (np->offset + np->scale * noise2d_perlin(
+		return (np->offset + np->scale * noise2d_fbm(
 				(float)x / np->spread.X,
 				(float)y / np->spread.Y,
 				s + np->seed, np->octaves, np->persist));
 	}
 
-	inline float NoisePerlin2DNoTxfm(
+	inline float NoiseFbm2DNoTxfm(
 			const NoiseParams *np, float x, float y, float s)
 	{
-		return (noise2d_perlin(
+		return (noise2d_fbm(
 				(float)x / np->spread.X,
 				(float)y / np->spread.Y,
 				s + np->seed, np->octaves, np->persist));
 	}
 
-	inline float NoisePerlin2DPosOffset(const NoiseParams *np, float x, float xoff,
+	inline float NoiseFbm2DPosOffset(const NoiseParams *np, float x, float xoff,
 			float y, float yoff, float s)
 	{
-		return (np->offset + np->scale * noise2d_perlin(
+		return (np->offset + np->scale * noise2d_fbm(
 				(float)xoff + (float)x / np->spread.X,
 				(float)yoff + (float)y / np->spread.Y,
 				s + np->seed, np->octaves, np->persist));
 	}
 
-	inline float NoisePerlin2DNoTxfmPosOffset(const NoiseParams *np, float x,
+	inline float NoiseFbm2DNoTxfmPosOffset(const NoiseParams *np, float x,
 			float xoff, float y, float yoff, float s)
 	{
-		return (noise2d_perlin(
+		return (noise2d_fbm(
 				(float)xoff + (float)x / np->spread.X,
 				(float)yoff + (float)y / np->spread.Y,
 				s + np->seed, np->octaves, np->persist));
 	}
 
-	inline float NoisePerlin3D(
+	inline float NoiseFbm3D(
 			const NoiseParams *np, float x, float y, float z, float s)
 	{
 		return (np->offset + np->scale *
-				noise3d_perlin((float)x / np->spread.X, (float)y / np->spread.Y,
+				noise3d_fbm((float)x / np->spread.X, (float)y / np->spread.Y,
 				(float)z / np->spread.Z, s + np->seed, np->octaves, np->persist));
 	}
 }


### PR DESCRIPTION
The lattice noise in `src/impl/noise.cpp` interpolates hash values directly at
the lattice points, so it is value noise rather than gradient (Perlin) noise,
and the octave summation is fBm. Names now say that:

- `noise2d/3d_gradient` -> `noise2d/3d_value`
- `noise2d/3d_perlin[_abs]` -> `noise2d/3d_fbm[_abs]`
- `Noise::gradientMap2D/3D` -> `valueMap2D/3D`
- `Noise::perlinMap2D/3D[Modulated]` -> `fbmMap2D/3D[Modulated]`
- `NoisePerlin2D/3D*` -> `NoiseFbm2D/3D*`

Game modules updated for the `fbmMap2D` rename. No behavior change. The
`#if 0` block that is actual gradient noise keeps its name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)