### PR TITLE
Client Lua API: TCP and UDP sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ if(BUILD_CLIENT)
 		src/lua_bindings/voxel_volume.cpp
 		src/lua_bindings/spatial_update_queue.cpp
 		src/lua_bindings/misc_urho3d.cpp
+		src/lua_bindings/network.cpp
 		src/lua_bindings/replicate.cpp
 	)
 

--- a/doc/client_api.txt
+++ b/doc/client_api.txt
@@ -180,19 +180,41 @@ TCP and UDP sockets, with the user in the loop: the first connection or
 datagram to an address in a week needs the user to accept the address and give
 it a description. Answers live in cache/network_addresses.csv.
 
+The socket objects are LuaSocket's, as far as the safety layer allows. What
+differs from LuaSocket:
+- Opening a socket takes a callback, because the user has to answer the dialog
+  first, and the address comes with it: there is no socket.tcp() / socket.udp()
+  followed by connect() or setpeername()
+- A socket only talks to the one address the user accepted. Listening sockets
+  and unconnected UDP do not exist here; setpeername(), setsockname() and
+  sendto() to another address return nil and a message
+- The sockets are always non-blocking, as with LuaSocket's settimeout(0);
+  settimeout() accepts 0 and warns about anything else
+- socket.select(), socket.sleep(), socket.dns and socket.bind() are not
+  provided. Poll the sockets from an Update handler instead
+- socket:address() is not LuaSocket's; it is the address as the user accepted
+  it, for showing in a UI
+
 tcp_connect(host: string, port: number, cb: function)
 udp_connect(host: string, port: number, cb: function)
 - cb(socket, error) is called once the user has answered; socket is nil if the
   connection was not made or the user declined
-- A socket is connected to one peer; a UDP socket only receives datagrams from
-  the address it was opened for
-- socket:send(data: string) -> was it all sent
-- socket:receive() -> data; "" means nothing has arrived
-- socket:good() -> false once the peer has closed the connection or the socket
-  has errored
-- socket:error() -> why it is not good()
-- socket:address() -> "host:port"
-- socket:close()
+
+gettime() -> seconds
+
+Socket methods, as in LuaSocket:
+- send(data [, i [, j]]) -> index of the last byte sent, or nil, error
+  [, index of the last byte sent]
+- TCP receive([pattern [, prefix]]) -> data, or nil, error [, partial data].
+  Pattern is a number of bytes, "*a" until the peer closes the connection, or
+  "*l" one line (the default). Error is "timeout" when what was asked for has
+  not arrived yet, or "closed".
+- UDP receive([size]) -> one datagram, truncated to size if given
+- UDP receivefrom([size]) -> data, ip, port
+- getpeername() -> ip, port
+- getsockname() -> ip, port
+- settimeout(0)
+- close()
 
 See extensions/network_test for a working example:
   $ bin/buildat_client -m network_test

--- a/doc/client_api.txt
+++ b/doc/client_api.txt
@@ -174,11 +174,38 @@ replicate.main_scene
   Urho3D. With urho3d.REPLICATED (native default) they will end up in the
   synchronized ID space and will be overridden by data coming from the server.
 
+network
+-------
+TCP and UDP sockets, with the user in the loop: the first connection or
+datagram to an address in a week needs the user to accept the address and give
+it a description. Answers live in cache/network_addresses.csv.
+
+tcp_connect(host: string, port: number, cb: function)
+udp_connect(host: string, port: number, cb: function)
+- cb(socket, error) is called once the user has answered; socket is nil if the
+  connection was not made or the user declined
+- A socket is connected to one peer; a UDP socket only receives datagrams from
+  the address it was opened for
+- socket:send(data: string) -> was it all sent
+- socket:receive() -> data; "" means nothing has arrived
+- socket:good() -> false once the peer has closed the connection or the socket
+  has errored
+- socket:error() -> why it is not good()
+- socket:address() -> "host:port"
+- socket:close()
+
+See extensions/network_test for a working example:
+  $ bin/buildat_client -m network_test
+
 ui_utils
 --------
 UI utiltiies.
 
 show_message_dialog(message)
+
+show_notification(text, duration_s)
+- A small non-modal notice in the top right corner, gone after duration_s
+  (2 seconds by default)
 
 
 Unsafe interfaces of built-in extensions

--- a/extensions/network/csv.lua
+++ b/extensions/network/csv.lua
@@ -1,0 +1,53 @@
+-- Buildat: extension/network/csv.lua
+-- http://www.apache.org/licenses/LICENSE-2.0
+-- Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+--
+-- Minimal CSV, for extension/network's address store. See test_csv.lua.
+
+local M = {}
+
+function M.quote(field)
+	return '"'..tostring(field):gsub('"', '""')..'"'
+end
+
+function M.parse_line(line)
+	local fields = {}
+	local i = 1
+	while true do
+		local field
+		if line:sub(i, i) == '"' then
+			local parts = {}
+			i = i + 1
+			while true do
+				local j = line:find('"', i, true)
+				if not j then -- Unterminated quote; take the rest
+					table.insert(parts, line:sub(i))
+					i = #line + 1
+					break
+				end
+				table.insert(parts, line:sub(i, j - 1))
+				if line:sub(j + 1, j + 1) == '"' then
+					table.insert(parts, '"')
+					i = j + 2
+				else
+					i = j + 1
+					break
+				end
+			end
+			field = table.concat(parts)
+		else
+			local j = line:find(",", i, true) or (#line + 1)
+			field = line:sub(i, j - 1)
+			i = j
+		end
+		table.insert(fields, field)
+		if line:sub(i, i) ~= "," then
+			break
+		end
+		i = i + 1
+	end
+	return fields
+end
+
+return M
+-- vim: set noet ts=4 sw=4:

--- a/extensions/network/init.lua
+++ b/extensions/network/init.lua
@@ -7,15 +7,24 @@
 -- address and name it. Answers are remembered in
 -- cache/network_addresses.csv.
 --
---   local network = require("buildat/extension/network")
---   network.udp_connect("localhost", 30001, function(socket, err)
---       if not socket then log:error(err) return end
---       socket:send("hello")
---       local data = socket:receive() -- "" if nothing arrived yet
+--   local socket = require("buildat/extension/network")
+--   socket.udp_connect("localhost", 30001, function(sock, err)
+--       if not sock then log:error(err) return end
+--       sock:send("hello")
+--       local data, err = sock:receive() -- nil, "timeout" if nothing yet
 --   end)
 --
--- The socket is connected to one peer; a UDP socket only receives datagrams
--- from the address it was opened for.
+-- The socket objects are LuaSocket's, as far as the safety layer allows:
+--
+-- * Opening a socket takes a callback, because the user has to answer the
+--   dialog first, and the address comes with it: there is no socket.tcp() /
+--   socket.udp() followed by connect() or setpeername().
+-- * A socket only talks to the one address the user accepted. Listening
+--   sockets and unconnected UDP do not exist here.
+-- * The sockets are always non-blocking, as with settimeout(0); settimeout()
+--   accepts 0 and warns about anything else.
+-- * socket.select(), socket.sleep(), socket.dns and socket.bind() are not
+--   provided. A game polls its sockets from an Update handler instead.
 
 local log = buildat.Logger("extension/network")
 local ui_utils = require("buildat/extension/ui_utils").safe
@@ -175,10 +184,30 @@ local function ask_user(uri, entry, on_answer)
 end
 
 -- The sockets
+--
+-- The interface is LuaSocket's, as far as the safety layer allows: opening a
+-- socket takes a callback because the user has to answer first, and there are
+-- no listening sockets and no unconnected UDP. Everything after opening --
+-- send, receive, patterns, error strings, timeouts -- works like LuaSocket
+-- with settimeout(0).
+
+-- LuaSocket's word for why receive() or send() got nothing done
+local function socket_error(socket)
+	if socket:good() then
+		return "timeout"
+	end
+	local err = socket:error()
+	if err == "" then
+		return "closed"
+	end
+	return err
+end
 
 -- Plain Lua wrapper; the socket object from C++ is not sandbox-safe, and this
 -- is where the first-packet notification happens.
-local function wrap_socket(socket, uri, is_udp)
+local function wrap_common(socket, uri, is_udp)
+	local w = {}
+
 	local function notify()
 		if notified[uri] then
 			return
@@ -186,34 +215,176 @@ local function wrap_socket(socket, uri, is_udp)
 		notified[uri] = true
 		ui_utils.show_notification("Connected to "..socket:address())
 	end
-
 	if not is_udp then
-		notify()
+		notify() -- The connection itself is the event for TCP
 	end
 
-	local w = {}
-	function w:send(data)
-		local ok = socket:send(data)
-		if ok then
+	-- send(data [, i [, j]]) -> index of the last byte sent
+	function w:send(data, i, j)
+		local first = i or 1
+		if first < 0 then
+			first = #data + first + 1
+		end
+		local part = data:sub(first, j or -1)
+		local sent = socket:send(part)
+		if sent > 0 then
 			notify()
 		end
-		return ok
+		if sent < 0 then
+			return nil, socket_error(socket)
+		end
+		if is_udp then
+			-- A datagram goes whole or not at all
+			if sent < #part then
+				return nil, socket_error(socket)
+			end
+			return 1
+		end
+		if sent == #part then
+			return first + sent - 1
+		end
+		return nil, "timeout", first + sent - 1
 	end
-	function w:receive()
-		return socket:receive()
+
+	function w:close()
+		socket:close()
+		return 1
 	end
-	function w:good()
-		return socket:good()
+
+	function w:getpeername()
+		return socket:peer_ip(), socket:peer_port()
 	end
-	function w:error()
-		return socket:error()
+
+	function w:getsockname()
+		return socket:local_ip(), socket:local_port()
 	end
+
+	-- simplified: the sockets are always non-blocking, which is what
+	-- settimeout(0) asks for. Upgrade path if a script needs to wait: select()
+	-- around the recv() in src/lua_bindings/network.cpp.
+	function w:settimeout(value, mode)
+		if value ~= nil and value ~= 0 then
+			log:warning("settimeout("..tostring(value)..
+					"): only 0 is supported; staying non-blocking")
+		end
+		return 1
+	end
+
+	function w:setoption(option, value)
+		return nil, "setoption() is not supported"
+	end
+
+	-- Not LuaSocket's, but the address as the user accepted it
 	function w:address()
 		return socket:address()
 	end
-	function w:close()
-		socket:close()
+
+	return w
+end
+
+local function wrap_tcp(socket, uri)
+	local w = wrap_common(socket, uri, false)
+	local buffer = ""
+
+	local function pump()
+		while true do
+			local data = socket:receive()
+			if data == "" then
+				return
+			end
+			buffer = buffer..data
+		end
 	end
+
+	local function take_all()
+		local data = buffer
+		buffer = ""
+		return data
+	end
+
+	-- receive([pattern [, prefix]]): a number of bytes, "*a" until the peer
+	-- closes the connection, or "*l" one line (the default). What was read
+	-- before a timeout comes back as the third value; pass it back as prefix.
+	function w:receive(pattern, prefix)
+		prefix = prefix or ""
+		pattern = pattern or "*l"
+		pump()
+		if type(pattern) == "number" then
+			if #buffer >= pattern then
+				local data = buffer:sub(1, pattern)
+				buffer = buffer:sub(pattern + 1)
+				return prefix..data
+			end
+			return nil, socket_error(socket), prefix..take_all()
+		end
+		if pattern == "*a" then
+			local data = prefix..take_all()
+			if socket:good() then
+				return nil, "timeout", data
+			end
+			if socket:error() == "closed" then
+				return data
+			end
+			return nil, socket:error(), data
+		end
+		if pattern == "*l" then
+			local i = buffer:find("\n", 1, true)
+			if i then
+				local line = buffer:sub(1, i - 1)
+				buffer = buffer:sub(i + 1)
+				if line:sub(-1) == "\r" then
+					line = line:sub(1, -2)
+				end
+				return prefix..line
+			end
+			return nil, socket_error(socket), prefix..take_all()
+		end
+		error("receive(): unknown pattern "..tostring(pattern))
+	end
+
+	return w
+end
+
+local function wrap_udp(socket, uri)
+	local w = wrap_common(socket, uri, true)
+
+	-- receive([size]): one datagram, truncated to size if given. An empty
+	-- datagram is indistinguishable from no datagram.
+	function w:receive(size)
+		local data = socket:receive()
+		if data == "" then
+			return nil, socket_error(socket)
+		end
+		if size and #data > size then
+			return data:sub(1, size)
+		end
+		return data
+	end
+
+	function w:receivefrom(size)
+		local data, err = w.receive(self, size)
+		if not data then
+			return nil, err
+		end
+		return data, socket:peer_ip(), socket:peer_port()
+	end
+
+	-- The socket only talks to the address the user accepted
+	function w:sendto(data, ip, port)
+		if ip ~= socket:peer_ip() or tonumber(port) ~= socket:peer_port() then
+			return nil, "this socket is connected to "..socket:address()
+		end
+		return w.send(self, data)
+	end
+
+	function w:setpeername(ip, port)
+		return nil, "the peer is set when the socket is opened"
+	end
+
+	function w:setsockname(ip, port)
+		return nil, "listening sockets are not supported"
+	end
+
 	return w
 end
 
@@ -225,8 +396,8 @@ local function open_socket(is_udp, host, port, cb)
 		cb(nil, socket:error())
 		return
 	end
-	cb(wrap_socket(socket, (is_udp and "udp://" or "tcp://")..
-			host..":"..port, is_udp))
+	local uri = (is_udp and "udp://" or "tcp://")..host..":"..port
+	cb(is_udp and wrap_udp(socket, uri) or wrap_tcp(socket, uri))
 end
 
 -- cb(socket, error): socket is nil if the connection was not made or the user
@@ -262,8 +433,14 @@ function M.safe.udp_connect(host, port, cb)
 	connect(true, host, port, cb)
 end
 
+-- LuaSocket's socket.gettime()
+function M.safe.gettime()
+	return buildat.get_time_us() / 1000000
+end
+
 M.tcp_connect = M.safe.tcp_connect
 M.udp_connect = M.safe.udp_connect
+M.gettime = M.safe.gettime
 
 return M
 -- vim: set noet ts=4 sw=4:

--- a/extensions/network/init.lua
+++ b/extensions/network/init.lua
@@ -1,0 +1,269 @@
+-- Buildat: extension/network/init.lua
+-- http://www.apache.org/licenses/LICENSE-2.0
+-- Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+--
+-- TCP and UDP sockets for scripts, with the user in the loop: the first
+-- connection or datagram to an address in a week needs the user to accept the
+-- address and name it. Answers are remembered in
+-- cache/network_addresses.csv.
+--
+--   local network = require("buildat/extension/network")
+--   network.udp_connect("localhost", 30001, function(socket, err)
+--       if not socket then log:error(err) return end
+--       socket:send("hello")
+--       local data = socket:receive() -- "" if nothing arrived yet
+--   end)
+--
+-- The socket is connected to one peer; a UDP socket only receives datagrams
+-- from the address it was opened for.
+
+local log = buildat.Logger("extension/network")
+local ui_utils = require("buildat/extension/ui_utils").safe
+local uistack = require("buildat/extension/uistack")
+local magic = require("buildat/extension/urho3d").safe
+local M = {safe = {}}
+
+local ACCEPTANCE_VALID_S = 7 * 24 * 3600
+
+local store_path = __buildat_get_path("cache").."/network_addresses.csv"
+
+-- Addresses this session has already notified about
+local notified = {}
+
+-- The store
+--
+-- CSV, because there are a handful of rows, they want to be readable and
+-- editable by hand, and there is no schema to migrate. Every field is quoted so
+-- that a description can contain a comma or a quote.
+
+local csv = dofile(__buildat_extension_path("network").."/csv.lua")
+
+-- uri -> {accepted=, uri=, description=, created=, last_attempt=}
+local function load_store()
+	local entries = {}
+	local file = io.open(store_path, "r")
+	if not file then
+		return entries
+	end
+	for line in file:lines() do
+		if line ~= "" and not line:match("^accepted,") then
+			local f = csv.parse_line(line)
+			if f[2] and f[2] ~= "" then
+				entries[f[2]] = {
+					accepted = (f[1] == "true"),
+					uri = f[2],
+					description = f[3] or "",
+					created = tonumber(f[4]) or 0,
+					last_attempt = tonumber(f[5]) or 0,
+				}
+			end
+		end
+	end
+	file:close()
+	return entries
+end
+
+local function save_store(entries)
+	local uris = {}
+	for uri, _ in pairs(entries) do
+		table.insert(uris, uri)
+	end
+	table.sort(uris)
+	local file, err = io.open(store_path, "w")
+	if not file then
+		log:error("Cannot write "..store_path..": "..tostring(err))
+		return
+	end
+	file:write("accepted,address,description,created,last_attempt\n")
+	for _, uri in ipairs(uris) do
+		local e = entries[uri]
+		file:write(table.concat({
+			csv.quote(e.accepted and "true" or "false"),
+			csv.quote(e.uri),
+			csv.quote(e.description),
+			csv.quote(math.floor(e.created)),
+			csv.quote(math.floor(e.last_attempt)),
+		}, ",").."\n")
+	end
+	file:close()
+end
+
+local function store_answer(uri, accepted, description, old_entry)
+	local entries = load_store()
+	local now = os.time()
+	entries[uri] = {
+		accepted = accepted,
+		uri = uri,
+		-- A description is one line of text
+		description = tostring(description or ""):gsub("[\r\n]", " "),
+		created = (old_entry and old_entry.created ~= 0) and old_entry.created or now,
+		last_attempt = now,
+	}
+	save_store(entries)
+end
+
+local function touch_entry(uri)
+	local entries = load_store()
+	if entries[uri] then
+		entries[uri].last_attempt = os.time()
+		save_store(entries)
+	end
+end
+
+-- The dialog
+
+local function format_time(t)
+	if not t or t == 0 then
+		return "never"
+	end
+	return os.date("%Y-%m-%d %H:%M", t)
+end
+
+-- on_answer(accepted: boolean, description: string)
+local function ask_user(uri, entry, on_answer)
+	local root = uistack.main:push({desc="network permission dialog"})
+	root.defaultStyle = magic.cache:GetResource(
+			"XMLFile", "__menu/res/main_style.xml")
+
+	local menu = ui_utils.vertical_menu(root, {min_width = 400})
+	local window = menu.window
+
+	local function add_text(text)
+		local t = window:CreateChild("Text")
+		t:SetStyleAuto()
+		t.text = text
+		t:SetTextAlignment(HA_LEFT)
+		return t
+	end
+
+	add_text("A script wants to use the network:")
+	add_text(uri)
+	if entry then
+		add_text("You have seen this address before:")
+		add_text("  Answer: "..(entry.accepted and "accepted" or "declined"))
+		add_text("  Description: "..entry.description)
+		add_text("  First asked: "..format_time(entry.created))
+		add_text("  Last attempt: "..format_time(entry.last_attempt))
+	end
+	add_text("Description (what is this peer?):")
+
+	local edit = window:CreateChild("LineEdit")
+	edit:SetStyleAuto()
+	edit.minHeight = 24
+	edit.minWidth = 380
+	edit:SetText(entry and entry.description or "")
+	edit:SetFocus(true)
+
+	local answered = false
+	local function answer(accepted)
+		if answered then
+			return
+		end
+		answered = true
+		local description = edit:GetText()
+		uistack.main:pop(root)
+		on_answer(accepted, description)
+	end
+
+	menu:add("Accept", function() answer(true) end)
+	menu:add("Decline", function() answer(false) end)
+	menu:on_key(function(key)
+		if key == KEY_ESCAPE then
+			answer(false)
+		end
+	end)
+end
+
+-- The sockets
+
+-- Plain Lua wrapper; the socket object from C++ is not sandbox-safe, and this
+-- is where the first-packet notification happens.
+local function wrap_socket(socket, uri, is_udp)
+	local function notify()
+		if notified[uri] then
+			return
+		end
+		notified[uri] = true
+		ui_utils.show_notification("Connected to "..socket:address())
+	end
+
+	if not is_udp then
+		notify()
+	end
+
+	local w = {}
+	function w:send(data)
+		local ok = socket:send(data)
+		if ok then
+			notify()
+		end
+		return ok
+	end
+	function w:receive()
+		return socket:receive()
+	end
+	function w:good()
+		return socket:good()
+	end
+	function w:error()
+		return socket:error()
+	end
+	function w:address()
+		return socket:address()
+	end
+	function w:close()
+		socket:close()
+	end
+	return w
+end
+
+local function open_socket(is_udp, host, port, cb)
+	local socket = is_udp and
+			__buildat_udp_connect(host, tostring(port)) or
+			__buildat_tcp_connect(host, tostring(port))
+	if not socket:good() then
+		cb(nil, socket:error())
+		return
+	end
+	cb(wrap_socket(socket, (is_udp and "udp://" or "tcp://")..
+			host..":"..port, is_udp))
+end
+
+-- cb(socket, error): socket is nil if the connection was not made or the user
+-- declined the address
+local function connect(is_udp, host, port, cb)
+	if type(host) ~= "string" or not tonumber(port) or type(cb) ~= "function" then
+		error("network: connect(host: string, port: number, cb: function)")
+	end
+	local uri = (is_udp and "udp://" or "tcp://")..host..":"..port
+	local entry = load_store()[uri]
+	if entry and entry.accepted and
+			os.time() - entry.last_attempt < ACCEPTANCE_VALID_S then
+		touch_entry(uri)
+		open_socket(is_udp, host, port, cb)
+		return
+	end
+	log:info("Asking the user about "..uri)
+	ask_user(uri, entry, function(accepted, description)
+		store_answer(uri, accepted, description, entry)
+		if not accepted then
+			cb(nil, "Declined by user: "..uri)
+			return
+		end
+		open_socket(is_udp, host, port, cb)
+	end)
+end
+
+function M.safe.tcp_connect(host, port, cb)
+	connect(false, host, port, cb)
+end
+
+function M.safe.udp_connect(host, port, cb)
+	connect(true, host, port, cb)
+end
+
+M.tcp_connect = M.safe.tcp_connect
+M.udp_connect = M.safe.udp_connect
+
+return M
+-- vim: set noet ts=4 sw=4:

--- a/extensions/network/test_csv.lua
+++ b/extensions/network/test_csv.lua
@@ -1,0 +1,37 @@
+-- Buildat: extension/network/test_csv.lua
+-- http://www.apache.org/licenses/LICENSE-2.0
+-- Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+--
+-- Run: lua extensions/network/test_csv.lua
+
+local csv = dofile((arg[0]:match("^(.*)/[^/]*$") or ".").."/csv.lua")
+
+local function check_roundtrip(fields)
+	local line = {}
+	for _, f in ipairs(fields) do
+		table.insert(line, csv.quote(f))
+	end
+	local parsed = csv.parse_line(table.concat(line, ","))
+	assert(#parsed == #fields, "field count: "..#parsed.." vs "..#fields)
+	for i, f in ipairs(fields) do
+		assert(parsed[i] == f, "field "..i..": "..parsed[i].." vs "..f)
+	end
+end
+
+check_roundtrip({"true", "udp://127.0.0.1:30000", "Test server", "1757000000", "0"})
+check_roundtrip({"false", "tcp://example.com:80", 'a "quoted", comma-y one', "1", "2"})
+check_roundtrip({"", "", "", "", ""})
+
+-- Unquoted fields, as a hand-edited file may have them
+local f = csv.parse_line('true,udp://127.0.0.1:30000,My server,1,2')
+assert(f[1] == "true" and f[3] == "My server" and f[5] == "2", "unquoted fields")
+
+-- Mixed, and a trailing empty field
+f = csv.parse_line('true,"desc",')
+assert(#f == 3 and f[2] == "desc" and f[3] == "", "trailing empty field")
+
+-- Unterminated quote: take what is there instead of erroring
+f = csv.parse_line('"unterminated')
+assert(f[1] == "unterminated", "unterminated quote")
+
+print("test_csv.lua: ok")

--- a/extensions/network_test/init.lua
+++ b/extensions/network_test/init.lua
@@ -9,6 +9,7 @@
 -- With no arguments it opens a UDP socket to localhost:30001 (a Luanti
 -- server), sends one datagram and shows whatever comes back.
 local log = buildat.Logger("extension/network_test")
+local dump = buildat.dump
 local magic = require("buildat/extension/urho3d").safe
 local uistack = require("buildat/extension/uistack")
 local network = require("buildat/extension/network")
@@ -42,6 +43,8 @@ function M.boot()
 			set_status("udp_connect failed: "..err)
 			return
 		end
+		log:info("Socket at "..dump({socket:getsockname()}).." talking to "..
+				dump({socket:getpeername()})) 
 		-- A Luanti reliable packet with a nonsense body: the server ACKs a
 		-- reliable packet before it looks at what is inside, which is enough
 		-- of a reply to check the receive path with.
@@ -51,18 +54,23 @@ function M.boot()
 				0x00,                   -- channel
 				0x03, 0xff, 0xdc,       -- reliable, seqnum
 				0x01, 0x00, 0x02)       -- original, TOSERVER_INIT
-		if not socket:send(packet) then
-			set_status("send failed: "..socket:error())
+		local sent, send_err = socket:send(packet)
+		if not sent then
+			set_status("send failed: "..send_err)
 			return
 		end
 		set_status("Sent a datagram to "..socket:address())
+		local done = false
 		magic.SubscribeToEvent("Update", function(event_type, event_data)
-			if not socket:good() then
+			if done then
 				return
 			end
-			local data = socket:receive()
-			if data ~= "" then
+			local data, err = socket:receive()
+			if data then
 				set_status("Received "..#data.." bytes from "..socket:address())
+			elseif err ~= "timeout" then
+				set_status("receive failed: "..err)
+				done = true
 			end
 		end)
 	end)

--- a/extensions/network_test/init.lua
+++ b/extensions/network_test/init.lua
@@ -1,0 +1,72 @@
+-- Buildat: extension/network_test/init.lua
+-- http://www.apache.org/licenses/LICENSE-2.0
+-- Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+--
+-- A menu extension that exercises extension/network against one address:
+--
+--   $ bin/buildat_client -m network_test -w 800x600
+--
+-- With no arguments it opens a UDP socket to localhost:30001 (a Luanti
+-- server), sends one datagram and shows whatever comes back.
+local log = buildat.Logger("extension/network_test")
+local magic = require("buildat/extension/urho3d").safe
+local uistack = require("buildat/extension/uistack")
+local network = require("buildat/extension/network")
+local M = {safe = nil}
+
+local HOST = "localhost"
+local PORT = 30001
+
+function M.boot()
+	local root = uistack.main:push({desc="network_test"})
+	root.defaultStyle = magic.cache:GetResource(
+			"XMLFile", "__menu/res/main_style.xml")
+
+	local window = root:CreateChild("Window")
+	window:SetStyleAuto()
+	window:SetLayout(LM_VERTICAL, 10, magic.IntRect(10, 10, 10, 10))
+	local status = window:CreateChild("Text")
+	status:SetStyleAuto()
+
+	local function set_status(text)
+		log:info(text)
+		status.text = text
+		-- Alignment does not follow a later resize
+		window:SetAlignment(HA_LEFT, VA_BOTTOM)
+	end
+
+	set_status("Asking about udp://"..HOST..":"..PORT)
+
+	network.udp_connect(HOST, PORT, function(socket, err)
+		if not socket then
+			set_status("udp_connect failed: "..err)
+			return
+		end
+		-- A Luanti reliable packet with a nonsense body: the server ACKs a
+		-- reliable packet before it looks at what is inside, which is enough
+		-- of a reply to check the receive path with.
+		local packet = string.char(
+				0x4f, 0x45, 0x74, 0x03, -- protocol id
+				0x00, 0x00,             -- peer id: inexistent
+				0x00,                   -- channel
+				0x03, 0xff, 0xdc,       -- reliable, seqnum
+				0x01, 0x00, 0x02)       -- original, TOSERVER_INIT
+		if not socket:send(packet) then
+			set_status("send failed: "..socket:error())
+			return
+		end
+		set_status("Sent a datagram to "..socket:address())
+		magic.SubscribeToEvent("Update", function(event_type, event_data)
+			if not socket:good() then
+				return
+			end
+			local data = socket:receive()
+			if data ~= "" then
+				set_status("Received "..#data.." bytes from "..socket:address())
+			end
+		end)
+	end)
+end
+
+return M
+-- vim: set noet ts=4 sw=4:

--- a/extensions/ui_utils/init.lua
+++ b/extensions/ui_utils/init.lua
@@ -276,5 +276,52 @@ function M.safe.show_confirm_dialog(message, on_yes, on_no)
 	end)
 end
 
+-- A small non-modal notice in the top right corner. It does not take focus and
+-- disappears by itself. A second call replaces what is showing.
+local notification = nil
+local notification_update_subscribed = false
+
+function M.safe.show_notification(text, duration_s)
+	duration_s = duration_s or 2.0
+
+	if notification then
+		notification.window:Remove()
+		notification = nil
+	end
+
+	local window = magic.ui.root:CreateChild("Window")
+	window.defaultStyle = magic.cache:GetResource(
+			"XMLFile", "__menu/res/main_style.xml")
+	window:SetStyleAuto()
+	window:SetName("show_notification window")
+	window:SetLayout(LM_VERTICAL, 0, magic.IntRect(10, 6, 10, 6))
+	window:SetFocusMode(FM_NOTFOCUSABLE)
+
+	local message_text = window:CreateChild("Text")
+	message_text:SetStyleAuto()
+	message_text.text = text
+
+	-- Align once the text is in; alignment does not follow a later resize
+	window:SetAlignment(HA_RIGHT, VA_TOP)
+
+	notification = {
+		window = window,
+		end_time_us = buildat.get_time_us() + duration_s * 1000000,
+	}
+
+	-- One subscription for the lifetime of the process. Unsubscribing from
+	-- inside a handler breaks extension/urho3d's global event multiplexer.
+	if not notification_update_subscribed then
+		notification_update_subscribed = true
+		magic.SubscribeToEvent("Update",
+		function(event_type, event_data)
+			if notification and buildat.get_time_us() >= notification.end_time_us then
+				notification.window:Remove()
+				notification = nil
+			end
+		end)
+	end
+end
+
 return M
 -- vim: set noet ts=4 sw=4:

--- a/src/lua_bindings/init.cpp
+++ b/src/lua_bindings/init.cpp
@@ -17,6 +17,7 @@ extern void init_mesh(lua_State *L);
 extern void init_voxel_volume(lua_State *L);
 extern void init_spatial_update_queue(lua_State *L);
 extern void init_misc_urho3d(lua_State *L);
+extern void init_network(lua_State *L);
 
 void init(lua_State *L)
 {
@@ -31,6 +32,7 @@ void init(lua_State *L)
 	init_voxel_volume(L);
 	init_spatial_update_queue(L);
 	init_misc_urho3d(L);
+	init_network(L);
 }
 
 } // namespace lua_bindingss

--- a/src/lua_bindings/network.cpp
+++ b/src/lua_bindings/network.cpp
@@ -1,0 +1,308 @@
+// http://www.apache.org/licenses/LICENSE-2.0
+// Copyright 2014 Perttu Ahola <celeron55@gmail.com>
+#include "lua_bindings/util.h"
+#include "core/log.h"
+#ifdef _WIN32
+	#include "ports/windows_sockets.h"
+#else
+	#include <unistd.h>
+	#include <sys/types.h>
+	#include <sys/socket.h>
+	#include <errno.h>
+	#include <fcntl.h>
+	#include <netinet/in.h>
+	#include <netinet/tcp.h>
+	#include <netdb.h>
+#endif
+#include <luabind/luabind.hpp>
+#include <string.h>
+#include <vector>
+#define MODULE "lua_bindings"
+
+// Sockets for Lua. This is the raw layer; it does not ask the user about
+// anything. The extension environment guards it (extensions/network).
+//
+// The connect functions always return a socket object; if the connection could
+// not be made, socket:good() is false and socket:error() tells why.
+
+namespace lua_bindings {
+
+// TCP connect blocks for up to this long. simplified: no connecting state to
+// poll from Lua; a slow peer stalls one frame. Upgrade path if that shows up:
+// keep the socket in a connecting state and finish it in receive()/send().
+static const int TCP_CONNECT_TIMEOUT_MS = 5000;
+
+static const size_t RECEIVE_BUFFER_SIZE = 65536;
+
+static void close_socket_fd(int fd)
+{
+#ifdef _WIN32
+	closesocket(fd);
+#else
+	::close(fd);
+#endif
+}
+
+static ss_ last_socket_error()
+{
+#ifdef _WIN32
+	char buf[128];
+	snprintf(buf, sizeof buf, "winsock error %i", WSAGetLastError());
+	return buf;
+#else
+	return strerror(errno);
+#endif
+}
+
+static bool would_block()
+{
+#ifdef _WIN32
+	int e = WSAGetLastError();
+	return e == WSAEWOULDBLOCK || e == WSAEINPROGRESS;
+#else
+	return errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR;
+#endif
+}
+
+static bool connect_in_progress()
+{
+#ifdef _WIN32
+	return WSAGetLastError() == WSAEWOULDBLOCK;
+#else
+	return errno == EINPROGRESS;
+#endif
+}
+
+static bool set_nonblocking(int fd)
+{
+#ifdef _WIN32
+	u_long on = 1;
+	return ioctlsocket(fd, FIONBIO, &on) == 0;
+#else
+	int flags = fcntl(fd, F_GETFL, 0);
+	if(flags == -1)
+		return false;
+	return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+#endif
+}
+
+struct LuaSocket
+{
+	int m_fd = -1;
+	bool m_udp = false;
+	ss_ m_remote; // "host:port" as given by the caller
+	ss_ m_error;
+
+	LuaSocket(bool udp, const ss_ &remote):
+		m_udp(udp), m_remote(remote)
+	{}
+
+	~LuaSocket()
+	{
+		close();
+	}
+
+	void fail(const ss_ &error)
+	{
+		m_error = error;
+		close();
+	}
+
+	// Waits until the non-blocking connect() on m_fd finishes
+	bool wait_connected()
+	{
+		struct timeval tv;
+		tv.tv_sec = TCP_CONNECT_TIMEOUT_MS / 1000;
+		tv.tv_usec = (TCP_CONNECT_TIMEOUT_MS % 1000) * 1000;
+		fd_set wfds;
+		FD_ZERO(&wfds);
+		FD_SET(m_fd, &wfds);
+		int r = select(m_fd + 1, NULL, &wfds, NULL, &tv);
+		if(r == 0){
+			m_error = "connect timed out";
+			return false;
+		}
+		if(r < 0){
+			m_error = "select: "+last_socket_error();
+			return false;
+		}
+		int so_error = 0;
+		socklen_t len = sizeof(so_error);
+		if(getsockopt(m_fd, SOL_SOCKET, SO_ERROR, (char*)&so_error, &len) != 0){
+			m_error = "getsockopt: "+last_socket_error();
+			return false;
+		}
+		if(so_error != 0){
+			m_error = "connect: "+ss_(strerror(so_error));
+			return false;
+		}
+		return true;
+	}
+
+	bool connect_to(const ss_ &host, const ss_ &port)
+	{
+		struct addrinfo hints;
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_family = AF_UNSPEC;
+		hints.ai_socktype = m_udp ? SOCK_DGRAM : SOCK_STREAM;
+		struct addrinfo *res0 = NULL;
+		int err = getaddrinfo(host.c_str(), port.c_str(), &hints, &res0);
+		if(err || res0 == NULL){
+			m_error = ss_("getaddrinfo: ")+gai_strerror(err);
+			return false;
+		}
+		m_error = "no address to connect to";
+		for(struct addrinfo *res = res0; res != NULL; res = res->ai_next){
+			int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+			if(fd == -1){
+				m_error = "socket: "+last_socket_error();
+				continue;
+			}
+			if(!set_nonblocking(fd)){
+				m_error = "failed to set socket non-blocking";
+				close_socket_fd(fd);
+				continue;
+			}
+			m_fd = fd;
+			// UDP connect() only sets the default peer; it does not block.
+			// It also makes the socket drop datagrams from anyone else.
+			if(connect(fd, res->ai_addr, res->ai_addrlen) == 0)
+				break;
+			if(!m_udp && connect_in_progress()){
+				if(wait_connected()) // Sets m_error if it fails
+					break;
+			} else {
+				m_error = "connect: "+last_socket_error();
+			}
+			close();
+		}
+		freeaddrinfo(res0);
+		if(m_fd == -1)
+			return false;
+		m_error = "";
+		if(!m_udp){
+			int val = 1;
+			setsockopt(m_fd, IPPROTO_TCP, TCP_NODELAY, (const char*)&val,
+					sizeof(val));
+		}
+		return true;
+	}
+
+	// Lua interface
+
+	bool good() const
+	{
+		return m_fd != -1;
+	}
+
+	ss_ error() const
+	{
+		return m_error;
+	}
+
+	ss_ address() const
+	{
+		return m_remote;
+	}
+
+	// send(data) -> was everything sent
+	bool send(const ss_ &data)
+	{
+		if(m_fd == -1)
+			return false;
+		size_t sent_total = 0;
+		while(sent_total < data.size()){
+			int sent = ::send(m_fd, &data[sent_total], data.size() - sent_total, 0);
+			if(sent < 0){
+				if(would_block()){
+					// simplified: no send queue. TCP writers should retry with
+					// what wasn't sent; UDP datagrams are all-or-nothing anyway.
+					return false;
+				}
+				fail("send: "+last_socket_error());
+				return false;
+			}
+			if(m_udp)
+				return (size_t)sent == data.size();
+			sent_total += sent;
+		}
+		return true;
+	}
+
+	// receive() -> data; "" means nothing was available. If the peer closed the
+	// connection or the socket errored, good() turns false.
+	ss_ receive()
+	{
+		if(m_fd == -1)
+			return "";
+		std::vector<char> buf(RECEIVE_BUFFER_SIZE);
+		int r = recv(m_fd, &buf[0], buf.size(), 0);
+		if(r == 0){
+			if(!m_udp){
+				fail("peer closed the connection");
+				return "";
+			}
+			return ""; // Empty datagram; indistinguishable from nothing
+		}
+		if(r < 0){
+			if(would_block())
+				return "";
+			fail("recv: "+last_socket_error());
+			return "";
+		}
+		return ss_(&buf[0], r);
+	}
+
+	void close()
+	{
+		if(m_fd != -1){
+			close_socket_fd(m_fd);
+			m_fd = -1;
+		}
+	}
+};
+
+static sp_<LuaSocket> connect_socket(bool udp, const ss_ &host, const ss_ &port)
+{
+	sp_<LuaSocket> socket(new LuaSocket(udp, host+":"+port));
+	if(!socket->connect_to(host, port)){
+		log_w(MODULE, "%s connect to %s:%s failed: %s", udp ? "udp" : "tcp",
+				cs(host), cs(port), cs(socket->error()));
+	} else {
+		log_v(MODULE, "%s socket connected to %s:%s", udp ? "udp" : "tcp",
+				cs(host), cs(port));
+	}
+	return socket;
+}
+
+static sp_<LuaSocket> tcp_connect(const ss_ &host, const ss_ &port)
+{
+	return connect_socket(false, host, port);
+}
+
+static sp_<LuaSocket> udp_connect(const ss_ &host, const ss_ &port)
+{
+	return connect_socket(true, host, port);
+}
+
+void init_network(lua_State *L)
+{
+	using namespace luabind;
+
+	module(L)[
+		class_<LuaSocket, bases<>, sp_<LuaSocket>>("Socket")
+			.def("good", &LuaSocket::good)
+			.def("error", &LuaSocket::error)
+			.def("address", &LuaSocket::address)
+			.def("send", &LuaSocket::send)
+			.def("receive", &LuaSocket::receive)
+			.def("close", &LuaSocket::close),
+		def("__buildat_tcp_connect", &tcp_connect),
+		def("__buildat_udp_connect", &udp_connect)
+	];
+}
+
+} // namespace lua_bindings
+
+// codestyle:disable (currently util/codestyle.sh screws up the .def formatting)
+// vim: set noet ts=4 sw=4:

--- a/src/lua_bindings/network.cpp
+++ b/src/lua_bindings/network.cpp
@@ -16,6 +16,7 @@
 #endif
 #include <luabind/luabind.hpp>
 #include <string.h>
+#include <stdlib.h> // atoi()
 #include <vector>
 #define MODULE "lua_bindings"
 
@@ -41,6 +42,19 @@ static void close_socket_fd(int fd)
 #else
 	::close(fd);
 #endif
+}
+
+static bool sockaddr_to_ip_port(const struct sockaddr *sa, socklen_t len,
+		ss_ &ip, int &port)
+{
+	char host[NI_MAXHOST];
+	char serv[NI_MAXSERV];
+	if(getnameinfo(sa, len, host, sizeof host, serv, sizeof serv,
+			NI_NUMERICHOST | NI_NUMERICSERV) != 0)
+		return false;
+	ip = host;
+	port = atoi(serv);
+	return true;
 }
 
 static ss_ last_socket_error()
@@ -92,6 +106,8 @@ struct LuaSocket
 	bool m_udp = false;
 	ss_ m_remote; // "host:port" as given by the caller
 	ss_ m_error;
+	ss_ m_peer_ip;
+	int m_peer_port = 0;
 
 	LuaSocket(bool udp, const ss_ &remote):
 		m_udp(udp), m_remote(remote)
@@ -180,6 +196,13 @@ struct LuaSocket
 		if(m_fd == -1)
 			return false;
 		m_error = "";
+		{
+			struct sockaddr_storage sa;
+			socklen_t len = sizeof(sa);
+			if(getpeername(m_fd, (struct sockaddr*)&sa, &len) == 0)
+				sockaddr_to_ip_port((struct sockaddr*)&sa, len,
+						m_peer_ip, m_peer_port);
+		}
 		if(!m_udp){
 			int val = 1;
 			setsockopt(m_fd, IPPROTO_TCP, TCP_NODELAY, (const char*)&val,
@@ -200,33 +223,69 @@ struct LuaSocket
 		return m_error;
 	}
 
+	// "host:port" as the caller gave it; for showing to the user
 	ss_ address() const
 	{
 		return m_remote;
 	}
 
-	// send(data) -> was everything sent
-	bool send(const ss_ &data)
+	ss_ peer_ip() const
+	{
+		return m_peer_ip;
+	}
+
+	int peer_port() const
+	{
+		return m_peer_port;
+	}
+
+	ss_ local_ip() const
+	{
+		ss_ ip;
+		int port = 0;
+		local_address(ip, port);
+		return ip;
+	}
+
+	int local_port() const
+	{
+		ss_ ip;
+		int port = 0;
+		local_address(ip, port);
+		return port;
+	}
+
+	void local_address(ss_ &ip, int &port) const
 	{
 		if(m_fd == -1)
-			return false;
+			return;
+		struct sockaddr_storage sa;
+		socklen_t len = sizeof(sa);
+		if(getsockname(m_fd, (struct sockaddr*)&sa, &len) == 0)
+			sockaddr_to_ip_port((struct sockaddr*)&sa, len, ip, port);
+	}
+
+	// send(data) -> bytes sent, or -1 if the socket errored. Less than the
+	// whole thing means the send buffer is full; there is no send queue here,
+	// the caller retries with the rest.
+	int send(const ss_ &data)
+	{
+		if(m_fd == -1)
+			return -1;
 		size_t sent_total = 0;
 		while(sent_total < data.size()){
 			int sent = ::send(m_fd, &data[sent_total], data.size() - sent_total, 0);
 			if(sent < 0){
-				if(would_block()){
-					// simplified: no send queue. TCP writers should retry with
-					// what wasn't sent; UDP datagrams are all-or-nothing anyway.
-					return false;
-				}
+				if(would_block())
+					break;
 				fail("send: "+last_socket_error());
-				return false;
+				return -1;
 			}
-			if(m_udp)
-				return (size_t)sent == data.size();
 			sent_total += sent;
+			if(m_udp) // One datagram per call, whole or not at all
+				break;
 		}
-		return true;
+		return sent_total;
 	}
 
 	// receive() -> data; "" means nothing was available. If the peer closed the
@@ -239,7 +298,7 @@ struct LuaSocket
 		int r = recv(m_fd, &buf[0], buf.size(), 0);
 		if(r == 0){
 			if(!m_udp){
-				fail("peer closed the connection");
+				fail("closed");
 				return "";
 			}
 			return ""; // Empty datagram; indistinguishable from nothing
@@ -294,6 +353,10 @@ void init_network(lua_State *L)
 			.def("good", &LuaSocket::good)
 			.def("error", &LuaSocket::error)
 			.def("address", &LuaSocket::address)
+			.def("peer_ip", &LuaSocket::peer_ip)
+			.def("peer_port", &LuaSocket::peer_port)
+			.def("local_ip", &LuaSocket::local_ip)
+			.def("local_port", &LuaSocket::local_port)
 			.def("send", &LuaSocket::send)
 			.def("receive", &LuaSocket::receive)
 			.def("close", &LuaSocket::close),


### PR DESCRIPTION
Groundwork for a Luanti client extension: scripts can now open TCP and UDP sockets.

`src/lua_bindings/network.cpp` gives Lua a socket connected to one peer, with non-blocking send/receive. `extension/network` puts the user in the loop:

- The first connection or datagram to an address in a week opens a dialog with the address, whatever is already known about it, and a field for a description.
- Answers go to `cache/network_addresses.csv`: acceptance, `proto://host:port`, description, creation time and last attempt time. CSV because there are a handful of rows, they want to be hand-editable, and there is no schema to migrate; every field is quoted so a description can contain a comma or a quote.
- A declined address, or one not used in a week, is asked about again, showing the stored entry.
- The first connection to an address in a session shows "Connected to \<address\>" in the top right corner for two seconds (`ui_utils.show_notification()`).

## LuaSocket

The socket objects are LuaSocket's where the safety layer allows it: `send(data, i, j)` returning the index of the last byte sent, `receive(pattern, prefix)` with `"*l"` (the default), `"*a"` and a byte count for TCP and a size for UDP, `nil, "timeout"` and `nil, "closed"` with partial data as the third value, `getpeername()`, `getsockname()`, `settimeout(0)`, `close()`, `gettime()`.

What differs, and why:

- Opening a socket takes a callback: the user has to answer the dialog first, and the address comes with it. So no `socket.tcp()` / `socket.udp()` followed by `connect()` or `setpeername()`.
- A socket only talks to the one address the user accepted. No listening sockets and no unconnected UDP; `setpeername()`, `setsockname()` and `sendto()` to another address return `nil` and a message rather than being absent.
- Always non-blocking, as with `settimeout(0)`. `settimeout()` accepts 0 and warns about anything else.
- `socket.select()`, `socket.sleep()`, `socket.dns` and `socket.bind()` are not provided; a game polls its sockets from an `Update` handler.

## Checked

`extension/network_test` is a menu extension that opens a UDP socket, sends a Luanti reliable packet and shows what comes back:

    $ bin/buildat_client -m network_test

Against a Luanti server on localhost and a UDP echo: dialog, accept, send, receive, `getpeername`/`getsockname`, and the store remembering the answer and updating `last_attempt`. Against a TCP server: `send` returning 18 for an 18-byte write, `send("XXhelloYY", 3, -3)` returning 7 with the server receiving `hello`, `receive()` giving `first line` with the CRLF stripped, `receive(3)` giving `ABC`, `receive("*a")` giving `nil, "timeout", "DEFrest of it"`, and `"closed"` once the peer went away.

Note that `localhost` can resolve to `::1` while a server listens on IPv4 only; use `127.0.0.1` there.

`lua extensions/network/test_csv.lua` checks the store's CSV quoting and parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)