### PR TITLE
aggregate: place buildings by eye, with thumbnails on the menu

### DIFF
--- a/doc/client_api.txt
+++ b/doc/client_api.txt
@@ -178,6 +178,21 @@ SubscribeToEvent(object, event_name, callback)
 - Return value: Name of the generated global callback which can be unusbscbribed
   from Urho3D via UnsubscribeFromEvent(event_name, callback_name).
 
+render_scene_to_texture(scene, camera_node, w, h) -> Texture2D
+- A scene drawn into a texture instead of into the window. What wants it is a
+  thumbnail: a voxel volume or a model seen on its own, on a button, which is
+  what the structures menu in games/aggregate wears.
+- The camera node needs a Camera component. The texture keeps updating every
+  frame, so geometry built asynchronously -- set_voxel_geometry() -- appears
+  when it arrives without anything asking for another update.
+- One function rather than RenderSurface and its update modes, because a
+  thumbnail is all anyone has needed. Neither the texture nor its viewport is
+  ever freed; the upgrade path, for a live mirror or a portal, is to expose
+  RenderSurface properly.
+- The scene is drawn with its own viewport and no postprocessing, so a scene
+  lit for the main viewport's HDR tonemapping comes out blown out. Light a
+  thumbnail scene for the low dynamic range it is.
+
 replicate
 ---------
 Interface to server->client synchronized (replicated) scenes.

--- a/extensions/urho3d/init.lua
+++ b/extensions/urho3d/init.lua
@@ -328,6 +328,15 @@ function Safe.UnsubscribeFromEvent(sub_event_type, cb_name)
 	remove_global_event_handler(sub_event_type, cb_name)
 end
 
+-- A scene drawn into a texture instead of into the window, for a thumbnail:
+-- see l_render_scene_to_texture() in src/lua_bindings/misc_urho3d.cpp for what
+-- the texture does and does not do.
+Safe.render_scene_to_texture = wrap_function({"Scene", "Node", "number",
+		"number"}, function(scene, camera_node, w, h)
+	return wrap_instance("Texture2D", __buildat_render_scene_to_texture(
+			scene, camera_node, w, h))
+end)
+
 --
 -- Unsafe interface
 --

--- a/games/aggregate/main/client_lua/init.lua
+++ b/games/aggregate/main/client_lua/init.lua
@@ -629,6 +629,151 @@ local function overlook(lc, uc)
 			math.deg(math.atan2(oy, horiz)), 0, 0)
 end
 
+-- The shapes of the structures, as the server builds them at the origin: a
+-- serialized volume, and the box it occupies relative to the builder's own
+-- origin. Asked for at connect rather than at menu-open, so that nothing
+-- waits for a round trip when the menu goes up.
+local structure_shapes = {}
+
+buildat.sub_packet("main:structure_shape", function(data)
+	local values = cereal.binary_input(data, {"object",
+		{"name", "string"},
+		{"lc", {"object",
+			{"x", "int32_t"}, {"y", "int32_t"}, {"z", "int32_t"},
+		}},
+		{"uc", {"object",
+			{"x", "int32_t"}, {"y", "int32_t"}, {"z", "int32_t"},
+		}},
+		{"data", "string"},
+	})
+	structure_shapes[values.name] = values
+	-- Meshed now rather than when it is chosen: a preview built at the
+	-- moment the menu closes queues behind whatever chunks are being meshed,
+	-- which around a moving camera is a wait. The node is kept disabled and
+	-- reused; nothing simulates it and it costs a hidden drawable.
+	local node = scene:CreateChild("preview_"..values.name)
+	node.enabled = false
+	values.node = node
+	-- Without skylight: a volume standing on its own has none to read, and
+	-- the vertex colours would come out black
+	buildat.set_voxel_geometry(node, values.data,
+			voxelworld.get_voxel_registry(), voxelworld.get_atlas_registry(),
+			false, function()
+				voxel_shading.apply_to_node(node)
+			end)
+	log:info("shape of "..values.name..": ("..
+			(values.uc.x - values.lc.x + 1)..", "..
+			(values.uc.y - values.lc.y + 1)..", "..
+			(values.uc.z - values.lc.z + 1)..") voxels, "..
+			#values.data.." bytes")
+end)
+
+for _, st in ipairs(STRUCTURES) do
+	buildat.send_packet("main:request_structure_shape", cereal.binary_output(
+			{name = st.name}, {"object", {"name", "string"}}))
+end
+
+-- Placement mode
+-- --------------
+--
+-- The chosen structure is drawn where it would go, as an ordinary drawable
+-- in the main scene: nothing merges it into the world, nothing simulates it,
+-- and it depth-sorts where it stands. The mouse moves it over the terrain
+-- and the right button sends the place_structure the menu used to send by
+-- itself.
+local placement = nil
+-- The server answers a placement with the box it took up, and the handler
+-- takes the camera to it. That is for a building placed from where you
+-- stand; one placed by eye is already in frame.
+local suppress_overlook_once = false
+
+-- Fixed while placement mode is up: the camera sits 15 out on each of +X and
+-- +Z and 40 above, looking at what is selected.
+local PLACE_CAM = {x = 15, y = 40, z = 15}
+local PLACE_YAW = 225  -- The horizontal part of (-15, -40, -15)
+local PLACE_PITCH = math.deg(math.atan2(PLACE_CAM.y,
+		math.sqrt(PLACE_CAM.x * PLACE_CAM.x + PLACE_CAM.z * PLACE_CAM.z)))
+-- Voxels per mouse count, which is about what the look sensitivity is
+local PLACE_MOUSE_SPEED = 0.1
+
+-- The ground under an X/Z: the first thing from above that is occupied, and
+-- the building sits on top of it. Centre only -- a building over uneven
+-- ground reading as buried is what says to try the footprint's corners.
+local function ground_at(x, z, near_y)
+	-- Generous downwards, because the mouse can cross a cliff in a frame and
+	-- a search that ends above the ground would leave the building hanging
+	-- -- or, worse, keep it where it was and let it drift
+	for y = near_y + 60, near_y - 200, -1 do
+		if occupied_at(buildat.Vector3(x, y, z)) then
+			return y + 1
+		end
+	end
+	return near_y
+end
+
+-- Where the builder's origin has to go for the box to be centred on x/z with
+-- its bottom on y
+local function placement_origin(sh, x, y, z)
+	return {
+		x = x - math.floor((sh.lc.x + sh.uc.x) / 2),
+		y = y - sh.lc.y,
+		z = z - math.floor((sh.lc.z + sh.uc.z) / 2),
+	}
+end
+
+local function update_placement()
+	local sh = placement.shape
+	placement.y = ground_at(placement.x, placement.z, placement.y)
+	local o = placement_origin(sh, placement.x, placement.y, placement.z)
+	-- The mesh is centred on the volume, and the volume is the box with one
+	-- voxel of padding around it; see create_chunk_node() for the same sum
+	local w = sh.uc.x - sh.lc.x + 1
+	local h = sh.uc.y - sh.lc.y + 1
+	local d = sh.uc.z - sh.lc.z + 1
+	placement.node.position = magic.Vector3(
+			o.x + sh.lc.x + w / 2 - 0.5,
+			o.y + sh.lc.y + h / 2 - 0.5,
+			o.z + sh.lc.z + d / 2 - 0.5)
+	-- The camera follows the building and nothing else: the angle is fixed,
+	-- so what is on screen only ever slides
+	local cam = magic.Vector3(placement.x + PLACE_CAM.x,
+			placement.y + PLACE_CAM.y, placement.z + PLACE_CAM.z)
+	player_node.position = cam - camera_node.position
+	player_node.rotation = magic.Quaternion(0, PLACE_YAW, 0)
+	camera_node.rotation = magic.Quaternion(PLACE_PITCH, 0, 0)
+end
+
+local function end_placement()
+	if not placement then return end
+	placement.node.enabled = false
+	placement = nil
+	magic.input:GetMouseMove() -- Thrown away; see the Update handler
+end
+
+local function start_placement(name)
+	local sh = structure_shapes[name]
+	if not sh then
+		log:warning("placement: the shape of "..name.." has not arrived")
+		return
+	end
+	end_placement()
+	set_free_move(true)
+	local p = player_node:GetWorldPosition()
+	placement = {
+		name = name,
+		shape = sh,
+		node = sh.node,
+		x = math.floor(p.x + 0.5),
+		y = math.floor(p.y + 0.5),
+		z = math.floor(p.z + 0.5),
+	}
+	placement.fx, placement.fz = placement.x, placement.z
+	placement.node.enabled = true
+	update_placement()
+	pointed_voxel_visual_node.enabled = false
+	magic.input:SetMouseVisible(false)
+end
+
 -- The views: the same voxels meshed out of a registry whose materials wear a
 -- gradient instead of their texture, by how close they are to failing. The
 -- server builds one per mode and sends them; see build_view_registry() in
@@ -702,6 +847,10 @@ buildat.sub_packet("main:structure_placed", function(data)
 			{"x", "int32_t"}, {"y", "int32_t"}, {"z", "int32_t"},
 		}},
 	})
+	if suppress_overlook_once then
+		suppress_overlook_once = false
+		return
+	end
 	-- Only in free move: standing inside what was just built is the other
 	-- way to experience it, and taking the camera away would spoil it
 	if free_move then
@@ -740,9 +889,8 @@ local function open_structure_menu()
 	menu.window:SetAlignment(magic.HA_CENTER, magic.VA_CENTER)
 	for _, st in ipairs(STRUCTURES) do
 		menu:add(st.label, function()
-			-- Where the player stands, so a building goes up around them
-			place_structure(st.name, player_node:GetWorldPosition())
 			close_structure_menu()
+			start_placement(st.name)
 		end)
 	end
 	structure_menu = {root = root, menu = menu}
@@ -755,6 +903,13 @@ magic.SubscribeToEvent("KeyDown", function(event_type, event_data)
 	-- closes it. Without this, escape would disconnect the client from
 	-- inside a menu, which is not what anyone means by escape.
 	if structure_menu then
+		return
+	end
+	if placement then
+		-- Escape means "not this one" here, and not "disconnect"
+		if key == magic.KEY_ESCAPE then
+			end_placement()
+		end
 		return
 	end
 	if key == magic.KEY_ESCAPE then
@@ -809,6 +964,18 @@ magic.SubscribeToEvent("MouseButtonDown", function(event_type, event_data)
 	end
 	local button = event_data:GetInt("Button")
 	log:info("MouseButtonDown: "..button)
+	if placement then
+		if button == magic.MOUSEB_RIGHT then
+			local o = placement_origin(placement.shape,
+					placement.x, placement.y, placement.z)
+			suppress_overlook_once = true
+			place_structure(placement.name, magic.Vector3(o.x, o.y, o.z))
+		end
+		if button == magic.MOUSEB_RIGHT or button == magic.MOUSEB_LEFT then
+			end_placement()
+		end
+		return
+	end
 	if button == magic.MOUSEB_RIGHT then
 		local p = pointed_voxel_p_above
 		-- Water with nothing in reach goes in front of you instead, a voxel
@@ -880,7 +1047,9 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 	-- dims the reflected sky under ground; see builtin/voxel_shading
 	voxel_shading.update(dt)
 
-	if camera_node then
+	-- Nothing is pointed at while a building is being placed: the marker
+	-- would sit inside the preview and the buttons mean something else
+	if camera_node and not placement then
 		local p, p_above = find_pointed_voxel(camera_node)
 		pointed_voxel_p = p
 		pointed_voxel_p_above = p_above
@@ -920,10 +1089,28 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 			player_node.position = magic.Vector3(0, 500, 0)
 		end
 
+		-- Read whether or not it is used: the delta accumulates either
+		-- way, and a frame that skips it would hand the whole sweep across
+		-- a menu to the frame after it
 		local dmouse = magic.input:GetMouseMove()
 		--log:info("dmouse: ("..dmouse.x..", "..dmouse.y..")")
-		camera_node:Pitch(dmouse.y * 0.1)
-		player_node:Yaw(dmouse.x * 0.1)
+		if placement then
+			-- Screen right and screen away, under the fixed yaw: moving the
+			-- mouse right has to move the building right on screen, which
+			-- is not a world axis
+			local yaw = math.rad(PLACE_YAW)
+			local rx, rz = math.cos(yaw), -math.sin(yaw)
+			local fx, fz = math.sin(yaw), math.cos(yaw)
+			local s = PLACE_MOUSE_SPEED
+			placement.fx = placement.fx + (dmouse.x * rx - dmouse.y * fx) * s
+			placement.fz = placement.fz + (dmouse.x * rz - dmouse.y * fz) * s
+			placement.x = math.floor(placement.fx + 0.5)
+			placement.z = math.floor(placement.fz + 0.5)
+			update_placement()
+		elseif not structure_menu then
+			camera_node:Pitch(dmouse.y * 0.1)
+			player_node:Yaw(dmouse.x * 0.1)
+		end
 		--[[log:info("y="..player_node:GetRotation():YawAngle())
 		log:info("p="..camera_node:GetRotation():PitchAngle())]]
 
@@ -933,7 +1120,7 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 		end
 		hold_physics_while_floor_rebuilds(dt)
 
-		if free_move then
+		if free_move and not placement then
 			-- Level, along the horizontal part of where the camera looks, so
 			-- that looking down at something and holding W flies over it
 			-- instead of into it. Space and shift are what go up and down.
@@ -1044,6 +1231,10 @@ magic.SubscribeToEvent("Update", function(event_type, event_data)
 				" (1-5)  structures: B  free move: Tab"..
 				(free_move and " (on)" or "").."  view: V"..
 				(view_mode ~= 0 and " ("..VIEW_NAMES[view_mode]..")" or "")
+		if placement then
+			line = "placing "..placement.name..
+					"  right click to place, escape to cancel"
+		end
 		-- What the pointed voxel is and how close it is to failing, which
 		-- is the whole debug interface between digs
 		if pointed_voxel_p then

--- a/games/aggregate/main/client_lua/init.lua
+++ b/games/aggregate/main/client_lua/init.lua
@@ -635,6 +635,57 @@ end
 -- waits for a round trip when the menu goes up.
 local structure_shapes = {}
 
+-- A thumbnail of one structure: its own scene, its own camera, and the
+-- volume framed in it, rendered into a texture the menu button wears. A
+-- scene of its own rather than a view mask, because "on its own" is then
+-- true by construction and there is no terrain to leave out.
+--
+-- The main viewport tonemaps an HDR frame and this one does not, so the
+-- light here is a plain low-dynamic-range light and not the world's sun.
+local THUMB_SIZE = 96
+local THUMB_SUN = 2.2
+
+local function make_thumbnail(sh)
+	local tscene = magic.Scene.new()
+	tscene:CreateComponent("Octree")
+	local zone = tscene:CreateChild("zone"):CreateComponent("Zone")
+	zone.boundingBox = magic.BoundingBox(-1000, 1000)
+	zone.ambientColor = SKY_AMBIENT
+	zone.fogColor = magic.Color(0.60, 0.72, 0.88)
+	zone.fogStart = 1000
+	zone.fogEnd = 1001
+	zone.override = true
+	zone.zoneTexture = magic.cache:GetResource("TextureCube",
+			voxel_shading.sky_cubemap)
+	local light_node = tscene:CreateChild("light")
+	light_node.direction = magic.Vector3(SUN_DIR.x, SUN_DIR.y, SUN_DIR.z)
+	local light = light_node:CreateComponent("Light")
+	light.lightType = magic.LIGHT_DIRECTIONAL
+	light.castShadows = false
+	light.brightness = THUMB_SUN
+	light.color = magic.Color(1.0, 0.96, 0.88)
+
+	-- The node sits at the origin, so the box is centred there too; the
+	-- camera is off a corner and above, far enough back for its size, the
+	-- same sum overlook() does
+	local node = tscene:CreateChild("structure")
+	buildat.set_voxel_geometry(node, sh.data,
+			voxelworld.get_voxel_registry(), voxelworld.get_atlas_registry(),
+			false, function()
+				voxel_shading.apply_to_node(node)
+			end)
+	local size = math.max(sh.uc.x - sh.lc.x, sh.uc.y - sh.lc.y,
+			sh.uc.z - sh.lc.z) + 1
+	local d = size * 1.3 + 6
+	local cam_node = tscene:CreateChild("camera")
+	local camera = cam_node:CreateComponent("Camera")
+	camera.farClip = 1000
+	cam_node.position = magic.Vector3(-0.62 * d, 0.55 * d, -0.62 * d)
+	cam_node:LookAt(magic.Vector3(0, 0, 0))
+	return magic.render_scene_to_texture(tscene, cam_node,
+			THUMB_SIZE, THUMB_SIZE)
+end
+
 buildat.sub_packet("main:structure_shape", function(data)
 	local values = cereal.binary_input(data, {"object",
 		{"name", "string"},
@@ -647,20 +698,24 @@ buildat.sub_packet("main:structure_shape", function(data)
 		{"data", "string"},
 	})
 	structure_shapes[values.name] = values
-	-- Meshed now rather than when it is chosen: a preview built at the
-	-- moment the menu closes queues behind whatever chunks are being meshed,
-	-- which around a moving camera is a wait. The node is kept disabled and
-	-- reused; nothing simulates it and it costs a hidden drawable.
-	local node = scene:CreateChild("preview_"..values.name)
-	node.enabled = false
-	values.node = node
-	-- Without skylight: a volume standing on its own has none to read, and
-	-- the vertex colours would come out black
-	buildat.set_voxel_geometry(node, values.data,
-			voxelworld.get_voxel_registry(), voxelworld.get_atlas_registry(),
-			false, function()
-				voxel_shading.apply_to_node(node)
-			end)
+	-- Meshed as soon as the voxel registry is there rather than when the
+	-- structure is chosen: a preview built at the moment the menu closes
+	-- queues behind whatever chunks are being meshed, which around a moving
+	-- camera is a wait. The node is kept disabled and reused; nothing
+	-- simulates it and it costs a hidden drawable.
+	voxelworld.sub_ready(function()
+		local node = scene:CreateChild("preview_"..values.name)
+		node.enabled = false
+		values.node = node
+		-- Without skylight: a volume standing on its own has none to read,
+		-- and the vertex colours would come out black
+		buildat.set_voxel_geometry(node, values.data,
+				voxelworld.get_voxel_registry(),
+				voxelworld.get_atlas_registry(), false, function()
+					voxel_shading.apply_to_node(node)
+				end)
+		values.thumbnail = make_thumbnail(values)
+	end)
 	log:info("shape of "..values.name..": ("..
 			(values.uc.x - values.lc.x + 1)..", "..
 			(values.uc.y - values.lc.y + 1)..", "..
@@ -721,6 +776,16 @@ local function placement_origin(sh, x, y, z)
 	}
 end
 
+-- What that has to hold, whatever the builder's origin sits at inside the
+-- box: the box ends up centred on the X/Z and standing on the Y
+do
+	local sh = {lc = {x = -8, y = -1, z = -2}, uc = {x = 8, y = 6, z = 30}}
+	local o = placement_origin(sh, 100, 50, 200)
+	assert(o.x + (sh.lc.x + sh.uc.x) / 2 == 100, "placement_origin: x")
+	assert(o.y + sh.lc.y == 50, "placement_origin: y")
+	assert(o.z + (sh.lc.z + sh.uc.z) / 2 == 200, "placement_origin: z")
+end
+
 local function update_placement()
 	local sh = placement.shape
 	placement.y = ground_at(placement.x, placement.z, placement.y)
@@ -752,7 +817,7 @@ end
 
 local function start_placement(name)
 	local sh = structure_shapes[name]
-	if not sh then
+	if not sh or not sh.node then
 		log:warning("placement: the shape of "..name.." has not arrived")
 		return
 	end
@@ -888,10 +953,33 @@ local function open_structure_menu()
 	})
 	menu.window:SetAlignment(magic.HA_CENTER, magic.VA_CENTER)
 	for _, st in ipairs(STRUCTURES) do
-		menu:add(st.label, function()
+		local action = function()
 			close_structure_menu()
 			start_placement(st.name)
-		end)
+		end
+		local sh = structure_shapes[st.name]
+		-- Until a thumbnail exists the button is the label alone, which is
+		-- what the menu was before there were any
+		if not sh or not sh.thumbnail then
+			menu:add(st.label, action)
+		else
+			local button = menu.window:CreateChild("Button")
+			button:SetStyleAuto()
+			button:SetName("Button")
+			button:SetLayout(magic.LM_HORIZONTAL, 10,
+					magic.IntRect(6, 6, 6, 6))
+			button.minHeight = THUMB_SIZE + 12
+			button.minWidth = 330
+			local image = button:CreateChild("BorderImage")
+			image.texture = sh.thumbnail
+			image.minWidth = THUMB_SIZE
+			image.minHeight = THUMB_SIZE
+			local text = button:CreateChild("Text")
+			text:SetName("ButtonText")
+			text:SetStyleAuto()
+			text.text = st.label
+			menu:add(button, action)
+		end
 	end
 	structure_menu = {root = root, menu = menu}
 	magic.input:SetMouseVisible(true)

--- a/games/aggregate/main/main.cpp
+++ b/games/aggregate/main/main.cpp
@@ -1028,6 +1028,8 @@ struct Module: public interface::Module
 				"network:packet_received/main:dig_voxel"));
 		m_server->sub_event(this, Event::t(
 				"network:packet_received/main:place_structure"));
+		m_server->sub_event(this, Event::t(
+				"network:packet_received/main:request_structure_shape"));
 		m_server->sub_event(this, Event::t("worldgen:queue_modified"));
 		m_server->sub_event(this, Event::t("core:tick"));
 	}
@@ -1045,6 +1047,8 @@ struct Module: public interface::Module
 				on_dig_voxel, network::Packet)
 		EVENT_TYPEN("network:packet_received/main:place_structure",
 				on_place_structure, network::Packet)
+		EVENT_TYPEN("network:packet_received/main:request_structure_shape",
+				on_request_structure_shape, network::Packet)
 		EVENT_TYPEN("worldgen:queue_modified",
 				on_worldgen_queue_modified, worldgen::QueueModifiedEvent);
 		EVENT_TYPEN("core:tick", on_tick, interface::TickEvent);
@@ -2617,6 +2621,92 @@ struct Module: public interface::Module
 		}
 	}
 
+	// Which builder a name means. Both putting a structure into the world
+	// and sending its shape to a client go through this, so there is one
+	// list of names and not two.
+	static bool build_structure(Build &b, const ss_ &name,
+			const pv::Vector3DInt32 &o)
+	{
+		if(name == "chamber")
+			build_chamber(b, o);
+		else if(name == "cathedral")
+			build_cathedral(b, o);
+		else if(name == "bridge")
+			build_bridge(b, o);
+		else if(name == "mineshaft")
+			build_mineshaft(b, o);
+		else
+			return false;
+		return true;
+	}
+
+	// What a build takes up, air included: a structure clears its own
+	// footprint, and the box that has to be clear is the box it occupies.
+	static void bounds_of(const Build &b, pv::Vector3DInt32 &lc,
+			pv::Vector3DInt32 &uc)
+	{
+		lc = uc = b.voxels[0].first;
+		for(auto &vp : b.voxels){
+			lc.setX(std::min(lc.getX(), vp.first.getX()));
+			lc.setY(std::min(lc.getY(), vp.first.getY()));
+			lc.setZ(std::min(lc.getZ(), vp.first.getZ()));
+			uc.setX(std::max(uc.getX(), vp.first.getX()));
+			uc.setY(std::max(uc.getY(), vp.first.getY()));
+			uc.setZ(std::max(uc.getZ(), vp.first.getZ()));
+		}
+	}
+
+	// The shape of a structure, built at the origin and serialized as a
+	// volume. The client draws it as a preview and as a thumbnail; building
+	// it at a zero origin is what lets the client work out for itself where
+	// to put the thing, since the box then says where the builder's origin
+	// sits inside it.
+	void on_request_structure_shape(const network::Packet &packet)
+	{
+		ss_ name;
+		{
+			std::istringstream is(packet.data, std::ios::binary);
+			cereal::PortableBinaryInputArchive ar(is);
+			ar(name);
+		}
+		Build b;
+		if(!build_structure(b, name, pv::Vector3DInt32(0, 0, 0))){
+			log_w(MODULE, "C%i: no structure called \"%s\"",
+					packet.sender, cs(name));
+			return;
+		}
+		pv::Vector3DInt32 lc, uc;
+		bounds_of(b, lc, uc);
+
+		// One voxel of air around the box, which is what the mesher needs in
+		// order to draw the faces at its edge -- the same padding a chunk
+		// carries
+		const pv::Vector3DInt32 one(1, 1, 1);
+		VoxelVolume volume(pv::Region(lc - one, uc + one),
+				aggregate_format().planes);
+		const interface::VoxelSample air = mix_voxel(MIX_AIR);
+		for(int z = lc.getZ() - 1; z <= uc.getZ() + 1; z++)
+		for(int y = lc.getY() - 1; y <= uc.getY() + 1; y++)
+		for(int x = lc.getX() - 1; x <= uc.getX() + 1; x++)
+			volume.set_sample_at(x, y, z, air);
+		for(auto &vp : b.voxels)
+			volume.set_sample_at(vp.first.getX(), vp.first.getY(),
+					vp.first.getZ(), placed_voxel(vp.second));
+
+		ss_ data = interface::serialize_volume_compressed(volume);
+		log_i(MODULE, "C%i: shape of %s: " PV3I_FORMAT "..." PV3I_FORMAT
+				", %zu bytes", packet.sender, cs(name), PV3I_PARAMS(lc),
+				PV3I_PARAMS(uc), data.size());
+		std::ostringstream os(std::ios::binary);
+		{
+			cereal::PortableBinaryOutputArchive ar(os);
+			ar(name, lc, uc, data);
+		}
+		network::access(m_server, [&](network::Interface *inetwork){
+			inetwork->send(packet.sender, "main:structure_shape", os.str());
+		});
+	}
+
 	void on_place_structure(const network::Packet &packet)
 	{
 		ss_ name;
@@ -2627,15 +2717,7 @@ struct Module: public interface::Module
 			ar(name, p);
 		}
 		Build b;
-		if(name == "chamber")
-			build_chamber(b, p);
-		else if(name == "cathedral")
-			build_cathedral(b, p);
-		else if(name == "bridge")
-			build_bridge(b, p);
-		else if(name == "mineshaft")
-			build_mineshaft(b, p);
-		else {
+		if(!build_structure(b, name, p)){
 			log_w(MODULE, "C%i: no structure called \"%s\"",
 					packet.sender, cs(name));
 			return;
@@ -2662,15 +2744,8 @@ struct Module: public interface::Module
 		// What it takes up, so that a client in free move can put itself
 		// somewhere the whole thing is in frame instead of the player having
 		// to fly around looking for it
-		pv::Vector3DInt32 lc = b.voxels[0].first, uc = b.voxels[0].first;
-		for(auto &vp : b.voxels){
-			lc.setX(std::min(lc.getX(), vp.first.getX()));
-			lc.setY(std::min(lc.getY(), vp.first.getY()));
-			lc.setZ(std::min(lc.getZ(), vp.first.getZ()));
-			uc.setX(std::max(uc.getX(), vp.first.getX()));
-			uc.setY(std::max(uc.getY(), vp.first.getY()));
-			uc.setZ(std::max(uc.getZ(), vp.first.getZ()));
-		}
+		pv::Vector3DInt32 lc, uc;
+		bounds_of(b, lc, uc);
 		std::ostringstream os(std::ios::binary);
 		{
 			cereal::PortableBinaryOutputArchive ar(os);

--- a/src/lua_bindings/misc_urho3d.cpp
+++ b/src/lua_bindings/misc_urho3d.cpp
@@ -10,6 +10,13 @@
 #include <Scene.h>
 #include <Profiler.h>
 #include <ResourceCache.h>
+#include <Camera.h>
+#include <Graphics.h>
+#include <Node.h>
+#include <Renderer.h>
+#include <RenderSurface.h>
+#include <Texture2D.h>
+#include <Viewport.h>
 #define MODULE "lua_bindings"
 
 namespace magic = Urho3D;
@@ -99,6 +106,57 @@ static int l_add_resource_dir(lua_State *L)
 	return 1;
 }
 
+// render_scene_to_texture(scene: Scene, camera_node: Node, w, h) -> Texture2D
+//
+// A scene drawn into a texture instead of into the window. What wants it is a
+// thumbnail: a model or a voxel volume seen on its own, on a button.
+//
+// One function rather than RenderSurface, its update modes and the texture
+// formats, because a thumbnail is all anyone has needed; exposing the surface
+// properly is what a live mirror or a portal would want.
+//
+// simplified: the surface updates every frame for as long as the texture
+// lives, and neither is ever freed. A thumbnail's scene is a few thousand
+// voxels at 96x96, so this is cheap, and it is what makes a texture correct
+// after geometry that was built asynchronously arrives. The upgrade path is
+// a manual update mode and a call to queue one.
+static int l_render_scene_to_texture(lua_State *L)
+{
+	tolua_Error tolua_err;
+	GET_TOLUA_STUFF(scene, 1, Scene);
+	GET_TOLUA_STUFF(camera_node, 2, Node);
+	int w = lua_tointeger(L, 3);
+	int h = lua_tointeger(L, 4);
+	if(w <= 0 || h <= 0 || w > 4096 || h > 4096)
+		return luaL_error(L, "render_scene_to_texture(): %ix%i is not a "
+				"sensible size", w, h);
+	Camera *camera = camera_node->GetComponent<Camera>();
+	if(camera == nullptr)
+		return luaL_error(L, "render_scene_to_texture(): the node has no "
+				"Camera component");
+
+	Context *context = scene->GetContext();
+	SharedPtr<Texture2D> texture(new Texture2D(context));
+	texture->SetSize(w, h, Graphics::GetRGBFormat(), TEXTURE_RENDERTARGET);
+	texture->SetFilterMode(FILTER_BILINEAR);
+	RenderSurface *surface = texture->GetRenderSurface();
+	if(surface == nullptr)
+		return luaL_error(L, "render_scene_to_texture(): the texture has no "
+				"render surface");
+	surface->SetViewport(0, new Viewport(context, scene, camera));
+	surface->SetUpdateMode(SURFACE_UPDATEALWAYS);
+
+	// Held by a reference that is never released, because what goes to Lua is
+	// a raw pointer and nothing else holds one. Deliberately leaked rather
+	// than kept in a container: a container of SharedPtr destroyed at exit
+	// tears a viewport down after Urho3D's context is gone, which is a crash
+	// on the way out.
+	texture->AddRef();
+
+	tolua_pushusertype(L, (void*)texture.Get(), "Texture2D");
+	return 1;
+}
+
 void init_misc_urho3d(lua_State *L)
 {
 #define DEF_BUILDAT_FUNC(name){ \
@@ -108,6 +166,7 @@ void init_misc_urho3d(lua_State *L)
 	DEF_BUILDAT_FUNC(profiler_block_begin);
 	DEF_BUILDAT_FUNC(profiler_block_end);
 	DEF_BUILDAT_FUNC(add_resource_dir);
+	DEF_BUILDAT_FUNC(render_scene_to_texture);
 }
 
 } // namespace lua_bindingss


### PR DESCRIPTION
The structures menu becomes a placement flow. Choosing a building starts a
placement mode: the building is drawn where it would go, the mouse moves it
over the terrain with its bottom on the ground, the right button puts it
there, and the left button or escape leaves without placing. The camera sits
at a fixed angle above and behind it while this is up. Nothing checks where a
building lands: stacking one on a tree or on another building is the player's
call.

The shape comes from the server, built at the origin and serialized as a
volume, so the client can work out where the builder's origin has to go for
the box to be centred on an X/Z with its bottom on a Y. All four are fetched
and meshed at connect.

While the menu or a placement is up, the mouse no longer turns the camera.

New engine binding: `urho3d.render_scene_to_texture(scene, camera_node, w, h)`
returns a Texture2D the scene is drawn into. The menu buttons wear a
thumbnail of each structure, rendered from a scene of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)