### PR TITLE
luanti_client: a sun, a sky and weather on the PBR path

### DIFF
--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -232,12 +232,20 @@ void VS()
     // a smooth gradient with no sun drawn in it, so a sharper reflection of it
     // looks no different from a blurred one. A turned normal moves the direct
     // sunlight's own highlight instead, which is the bright thing in the scene.
-    const float SPOT_TILT = 0.45;
+    //
+    // It is also what decides how far from the light the sparkle reaches. A
+    // spot turned this far catches the sun from anywhere within that angle of
+    // the mirror direction, so a large one puts glints over a whole field
+    // rather than in the band where the light is actually being reflected.
+    const float SPOT_TILT = 0.18;
     // Bigger than the moving ones: a facet is a chip of rock, not a leaf.
     // Taken from the world position for the same reason as those, that a map
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
-    const float STATIC_SPOT_TILT = 0.35;
+    const float STATIC_SPOT_TILT = 0.15;
+    // How far towards white a spot takes the light it reflects; see where it
+    // is used, in the light pass
+    const float SPOT_WHITEN = 0.85;
     const float TRANSMISSION_RATE = 0.03;    // Cycles per second, mean
     const vec3 TRANSMISSION_WIND = vec3(0.35, 0.0, -0.2);
 
@@ -565,6 +573,18 @@ void PS()
             // shadow map does the darkening; in a cave there is no sun to
             // shadow.
             lightColor *= vSkyVisibility;
+        #endif
+
+        #ifdef VOXELSPOTS
+            // A spot is a mirror, and a mirror image of something as bright
+            // as the sun saturates whatever sees it: a glint off water reads
+            // white, not the colour of the light. Nothing here is bright
+            // enough to clip on its own, so the spot's share of the light is
+            // taken towards white directly. Only where there is a spot, and
+            // only for that pixel's light; the surface around it keeps the
+            // sun's own colour, which is where that colour belongs.
+            lightColor = mix(lightColor, vec3(GetIntensity(lightColor)),
+                max(surfaceSpots, staticSpots) * SPOT_WHITEN);
         #endif
 
         vec3 toCamera = normalize(cCameraPosPS - vWorldPos.xyz);

--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -14,8 +14,12 @@
 // the neutral grey of bounced light where it is not. Ambient occlusion and a
 // per-face brightness are already folded into both terms by the mesher.
 //
-// Direct light is deliberately left alone. The sun is shadow mapped, so
-// attenuating it by skylight as well would darken shadowed faces twice.
+// Direct light is deliberately left alone, unless VOXELSUNGATE is defined:
+// with it, the directional light is multiplied by the vertex color's alpha, so
+// that a world whose light value says "underground" gets no sun. That is for a
+// world whose light curve is built for it -- see PBR_LIGHT_MAP in the Luanti
+// client's world.lua; without such a curve it would darken shadowed faces
+// twice, which is why it is off by default.
 //
 // On top of that, two things the stock PBR shaders do differently:
 //
@@ -83,6 +87,11 @@ varying vec4 vWorldPos;
             varying highp vec4 vShadowPos[NUMCASCADES];
         #endif
     #endif
+    #ifdef VOXELSUNGATE
+        // How much of the sky this vertex sees, which on the light pass is
+        // what says whether the sun can reach it at all; see below
+        varying float vSkyVisibility;
+    #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;
     #endif
@@ -130,6 +139,10 @@ void VS()
     #ifdef PERPIXEL
         // Per-pixel forward lighting
         vec4 projWorldPos = vec4(worldPos, 1.0);
+
+        #ifdef VOXELSUNGATE
+            vSkyVisibility = iColor.a;
+        #endif
 
         #ifdef SHADOW
             // Shadow projection: transform from world space to shadow space
@@ -540,6 +553,20 @@ void PS()
         #else
             lightColor = cLightColor.rgb;
         #endif
+
+        #if defined(DIRLIGHT) && defined(VOXELSUNGATE)
+            // The sun does not reach underground, and nothing else in the
+            // scene knows that: a shadow map cannot tell a cave from a leaf
+            // canopy, because in both cases the sky is blocked by geometry
+            // that is being drawn. So the world's own light value is the
+            // gate, and it is built for exactly this -- see PBR_LIGHT_MAP in
+            // world.lua, which holds at full through a canopy and falls to
+            // nothing in rock. Under a tree the sun is at full here and the
+            // shadow map does the darkening; in a cave there is no sun to
+            // shadow.
+            lightColor *= vSkyVisibility;
+        #endif
+
         vec3 toCamera = normalize(cCameraPosPS - vWorldPos.xyz);
         vec3 lightVec = normalize(lightDir);
         float ndl = clamp((dot(normal, lightVec)), M_EPSILON, 1.0);

--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -243,9 +243,6 @@ void VS()
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
     const float STATIC_SPOT_TILT = 0.15;
-    // How far towards white a spot takes the light it reflects; see where it
-    // is used, in the light pass
-    const float SPOT_WHITEN = 0.85;
     const float TRANSMISSION_RATE = 0.03;    // Cycles per second, mean
     const vec3 TRANSMISSION_WIND = vec3(0.35, 0.0, -0.2);
 
@@ -573,18 +570,6 @@ void PS()
             // shadow map does the darkening; in a cave there is no sun to
             // shadow.
             lightColor *= vSkyVisibility;
-        #endif
-
-        #ifdef VOXELSPOTS
-            // A spot is a mirror, and a mirror image of something as bright
-            // as the sun saturates whatever sees it: a glint off water reads
-            // white, not the colour of the light. Nothing here is bright
-            // enough to clip on its own, so the spot's share of the light is
-            // taken towards white directly. Only where there is a spot, and
-            // only for that pixel's light; the surface around it keeps the
-            // sun's own colour, which is where that colour belongs.
-            lightColor = mix(lightColor, vec3(GetIntensity(lightColor)),
-                max(surfaceSpots, staticSpots) * SPOT_WHITEN);
         #endif
 
         vec3 toCamera = normalize(cCameraPosPS - vWorldPos.xyz);

--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -242,7 +242,11 @@ void VS()
     // Taken from the world position for the same reason as those, that a map
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
-    const float STATIC_SPOT_TILT = 0.15;
+    // Left where it was when the moving kind was narrowed: a facet is a chip
+    // of rock that is flat and stays turned, not a leaf that has caught the
+    // light for a moment, and narrowing it takes the speckle off sand and
+    // gravel rather than gathering it anywhere.
+    const float STATIC_SPOT_TILT = 0.35;
     // How narrowly the light through a surface is aimed at the camera. Light
     // coming through a leaf is light going the way it was already going, so it
     // is seen looking back along it and not from the side: at the width a

--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -1,3 +1,9 @@
+// extensions/luanti_client/res/PBRVoxel.glsl is a fork of this file, with an
+// art style of its own: its spot and transmission constants are tuned for a
+// world made of Luanti's plants and are deliberately not these. Carry a fix to
+// the machinery across by hand; leave the numbers that decide how something
+// looks alone, in both directions.
+//
 // Copied from CoreData/Shaders/GLSL/PBRLitSolid.glsl (Urho3D 1.7.1). Two
 // changes, both about how voxel skylight reaches the ambient term:
 //
@@ -232,27 +238,12 @@ void VS()
     // a smooth gradient with no sun drawn in it, so a sharper reflection of it
     // looks no different from a blurred one. A turned normal moves the direct
     // sunlight's own highlight instead, which is the bright thing in the scene.
-    //
-    // It is also what decides how far from the light the sparkle reaches. A
-    // spot turned this far catches the sun from anywhere within that angle of
-    // the mirror direction, so a large one puts glints over a whole field
-    // rather than in the band where the light is actually being reflected.
-    const float SPOT_TILT = 0.06;
+    const float SPOT_TILT = 0.45;
     // Bigger than the moving ones: a facet is a chip of rock, not a leaf.
     // Taken from the world position for the same reason as those, that a map
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
-    // Left where it was when the moving kind was narrowed: a facet is a chip
-    // of rock that is flat and stays turned, not a leaf that has caught the
-    // light for a moment, and narrowing it takes the speckle off sand and
-    // gravel rather than gathering it anywhere.
     const float STATIC_SPOT_TILT = 0.35;
-    // How narrowly the light through a surface is aimed at the camera. Light
-    // coming through a leaf is light going the way it was already going, so it
-    // is seen looking back along it and not from the side: at the width a
-    // sixth power gives, a canopy glows over a quarter of the sky and the glow
-    // stops reading as the sun behind it.
-    const float TRANSMISSION_FOCUS = 32.0;
     const float TRANSMISSION_RATE = 0.03;    // Cycles per second, mean
     const vec3 TRANSMISSION_WIND = vec3(0.35, 0.0, -0.2);
 
@@ -440,19 +431,11 @@ void PS()
             surfaceSpots = GetSurfaceSpots(vWorldPos.xyz, surfaceSrc.a);
             staticSpots = GetStaticSpots(vWorldPos.xyz,
                 texture2D(sNormalMap, vTexCoord.xy).a);
-            // A spot is glossy because it is a leaf or a facet that has
-            // turned, and one that has half turned is a smaller turn rather
-            // than a wider, duller highlight: the fade belongs in the tilt,
-            // which carries it below. Ramping the gloss on sharply instead is
-            // what keeps the half open cells -- which at any moment are most
-            // of them -- from being a broad sheen that follows the light
-            // across a whole field.
             float spotMask = max(surfaceSpots, staticSpots);
-            float spotGloss = spotMask * spotMask * spotMask;
-            roughness = mix(roughness, SPOT_ROUGHNESS, spotGloss);
+            roughness = mix(roughness, SPOT_ROUGHNESS, spotMask);
             // Full strength however matte the rest is, so that rock can be
             // dull everywhere except at its facets
-            specStrength = mix(specStrength, 1.0, spotGloss);
+            specStrength = mix(specStrength, 1.0, spotMask);
         #endif
     #else
         float roughness = cRoughness;
@@ -622,8 +605,7 @@ void PS()
             vec3 transmitted = mix(vec3(1.0), diffColor.rgb,
                 TRANSMISSION_TINT);
             float backNdl = max(0.0, -dot(normal, lightVec));
-            float forward = pow(max(0.0, dot(-lightVec, toCamera)),
-                TRANSMISSION_FOCUS);
+            float forward = pow(max(0.0, dot(-lightVec, toCamera)), 6.0);
             // A material with no spots at all is translucent all over
             #ifdef VOXELSPOTS
                 float through = surfaceSrc.a > 0.0 ? surfaceSpots : 1.0;

--- a/builtin/voxel_shading/client_data/PBRVoxel.glsl
+++ b/builtin/voxel_shading/client_data/PBRVoxel.glsl
@@ -237,12 +237,18 @@ void VS()
     // spot turned this far catches the sun from anywhere within that angle of
     // the mirror direction, so a large one puts glints over a whole field
     // rather than in the band where the light is actually being reflected.
-    const float SPOT_TILT = 0.18;
+    const float SPOT_TILT = 0.06;
     // Bigger than the moving ones: a facet is a chip of rock, not a leaf.
     // Taken from the world position for the same reason as those, that a map
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
     const float STATIC_SPOT_TILT = 0.15;
+    // How narrowly the light through a surface is aimed at the camera. Light
+    // coming through a leaf is light going the way it was already going, so it
+    // is seen looking back along it and not from the side: at the width a
+    // sixth power gives, a canopy glows over a quarter of the sky and the glow
+    // stops reading as the sun behind it.
+    const float TRANSMISSION_FOCUS = 32.0;
     const float TRANSMISSION_RATE = 0.03;    // Cycles per second, mean
     const vec3 TRANSMISSION_WIND = vec3(0.35, 0.0, -0.2);
 
@@ -430,11 +436,19 @@ void PS()
             surfaceSpots = GetSurfaceSpots(vWorldPos.xyz, surfaceSrc.a);
             staticSpots = GetStaticSpots(vWorldPos.xyz,
                 texture2D(sNormalMap, vTexCoord.xy).a);
+            // A spot is glossy because it is a leaf or a facet that has
+            // turned, and one that has half turned is a smaller turn rather
+            // than a wider, duller highlight: the fade belongs in the tilt,
+            // which carries it below. Ramping the gloss on sharply instead is
+            // what keeps the half open cells -- which at any moment are most
+            // of them -- from being a broad sheen that follows the light
+            // across a whole field.
             float spotMask = max(surfaceSpots, staticSpots);
-            roughness = mix(roughness, SPOT_ROUGHNESS, spotMask);
+            float spotGloss = spotMask * spotMask * spotMask;
+            roughness = mix(roughness, SPOT_ROUGHNESS, spotGloss);
             // Full strength however matte the rest is, so that rock can be
             // dull everywhere except at its facets
-            specStrength = mix(specStrength, 1.0, spotMask);
+            specStrength = mix(specStrength, 1.0, spotGloss);
         #endif
     #else
         float roughness = cRoughness;
@@ -604,7 +618,8 @@ void PS()
             vec3 transmitted = mix(vec3(1.0), diffColor.rgb,
                 TRANSMISSION_TINT);
             float backNdl = max(0.0, -dot(normal, lightVec));
-            float forward = pow(max(0.0, dot(-lightVec, toCamera)), 6.0);
+            float forward = pow(max(0.0, dot(-lightVec, toCamera)),
+                TRANSMISSION_FOCUS);
             // A material with no spots at all is translucent all over
             #ifdef VOXELSPOTS
                 float through = surfaceSrc.a > 0.0 ? surfaceSpots : 1.0;

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -108,7 +108,10 @@ which of the two is the dim one.
 A directional light does not know about the horizon, so one left on at night
 lights the undersides of everything, and its specular, which is the sparkle a
 surface asks for on water, on snow and on ore, is then the brightest thing in
-a night frame and is coming from the wrong side of the sky.
+a night frame and is coming from the wrong side of the sky. The clocks above
+are where the fade is shaped; the line itself is enforced separately, from
+where the body actually is, so that neither can shine from under the world
+whatever the clock says.
 
 The ambient on this path is the sky rather than the colour of sunlight, and
 the shader's ambient is that times how much sky the vertex sees plus the lamp

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -732,8 +732,13 @@ beyond 128 live single particles is dropped rather than queued.
 The clouds are a flat layer faked in the sky shader -- the view direction
 divided by its own y, which is what makes them crowd towards the horizon --
 rather than a layer at a height. So of what CLOUD_PARAMS says, the density
-becomes how much of the sky they cover and the speed becomes how fast the
-layer drifts, through a factor picked so that Luanti's own default drifts at
+becomes how much of the sky they cover -- which it already is: Luanti fills a
+cloud cell where its own noise falls below the density, the shader here fills
+where its noise rises above one minus the coverage, and since both are value
+noise of much the same shape and both are even about a half, the quantile
+carries straight across and the two clients cover the sky to within two parts
+in a hundred of each other -- and the speed becomes how fast the layer drifts,
+through a factor picked so that Luanti's own default drifts at
 the rate the shader had baked in before a game could ask for anything: twice
 the speed is twice as fast, and that is what the field is for. The height and
 the thickness have nothing to become and are dropped. Drawing the real thing

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -99,7 +99,8 @@ numbers for the same reasons.
 
 The sun is in the scene only while it is above the horizon: it fades in
 between 05:00 and 06:00 and out between 18:00 and 19:00, and the moon -- the
-same light from the other side of the sky, dim and cold -- does the opposite.
+same light from the other side of the sky at a tenth of it, cold, and with a
+shadow map of its own -- does the opposite.
 A directional light does not know about the horizon, so one left on at night
 lights the undersides of everything, and its specular, which is the sparkle a
 surface asks for on water, on snow and on ore, is then the brightest thing in

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -115,7 +115,10 @@ whatever the clock says.
 
 For the half hour either side of the sun crossing the horizon, at each end of
 the day, the sun's light goes towards the colour the game paints the horizon
-band with and the clouds go most of the way towards the sun's: at that hour
+band with -- weighted towards the crossing itself, so that it comes on gently
+at the edge of the window and a sun a quarter of an hour off the horizon is
+already red rather than a warm white -- and the clouds go most of the way
+towards the sun's: at that hour
 the sun is the only thing lighting them and it is lighting them from
 underneath, which is what makes a sunrise a sunrise rather than a sky that has
 got brighter. Outside that window neither is tinted at all.

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -113,8 +113,15 @@ are where the fade is shaped; the line itself is enforced separately, from
 where the body actually is, so that neither can shine from under the world
 whatever the clock says.
 
-Both are dimmed by the weather, because a directional light does not know
-there is a layer of cloud between it and the ground while the ambient does --
+Both go out entirely when the game hides them, which is the plainest thing it
+can say: VoxeLibre turns the sun, the moon and the stars off together the
+moment the weather turns, before it darkens a single colour, and a dimension
+with no sky turns them off for good. Something that cannot be seen casts no
+light, and what is left is the sky, which is what an overcast day is lit by.
+
+Short of that they are dimmed by the weather, because a directional light does
+not know there is a layer of cloud between it and the ground while the ambient
+does --
 a game darkens the sky colours it sends when the weather turns, and the direct
 light is then the only thing left insisting it is a clear day. Two things say
 overcast and a game uses one or the other: the cloud density, of which only

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -167,6 +167,12 @@ never touches the density and paints its clouds #FFF0F0 for a clear sky,
 #5D5D5F for rain and #3D3D3F for a thunderstorm. Full overcast leaves the sun
 a fifth of itself, which is a day with no shadows in it.
 
+There is a floor under it while the sun is down. The sky is the only ambient
+there is here, and a game's night sky can be black -- VoxeLibre paints one --
+which left a moon shadow with nothing in it at all once the moon started
+casting them. The floor is the moon's own cold colour at little enough that
+what the moon lights is still the brighter.
+
 The ambient on this path is the sky rather than the colour of sunlight, and
 the shader's ambient is that times how much sky the vertex sees plus the lamp
 light baked into the vertex colour. That alone is three tints: open ground

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -14,6 +14,17 @@ below protocol 48 and zstd from there on, the media announcement is a plain
 list of names and base64 hashes below 48, an item's image carries an
 animation only from 51 on, and the inventory is the rest of its packet below
 52.
+The day passes rather than arrives. The server says what time it is every few
+seconds; the client carries the clock on between those at the speed the server
+gave with it, the way Luanti's own does in Environment::stepTimeOfDay, or the
+sun would step across the sky. And the sky itself is eased rather than set:
+which set of colours a sky is drawn from -- night, dawn or day -- changes at a
+step there as here, and what keeps that from reading as one is that the sky is
+always on its way to the target rather than at it. A change too big to be the
+day moving, which is a game setting its clock or a sky arriving, is taken at
+once instead. That is Luanti's Sky::update() in shape, with the share of the
+way worked out from the frame's own length rather than fixed per frame.
+
 BUILDAT_LUANTI_ADDRESS sets the address the dialog starts with, which is what
 scripted runs (-c) use. BUILDAT_LUANTI_FORCE_DAY keeps the world at midday
 whatever the server's time is, for the same reason: a run of half a minute

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -197,6 +197,23 @@ to the atlas costs, and that loading time is the honest price of it. It is
 chosen before anything loads and fixed for the session for the same reason: the
 maps have to be on from the first texture the atlas builds.
 
+An object is drawn unlit -- Luanti draws its entities unlit too, and their
+textures are full of holes -- so what stands in for the light is a colour the
+shader multiplies the texture by. How that is worked out follows whichever
+path is running, because an object has to agree with the voxel it is standing
+on: on the vanilla path it is the sunlight colour times how much sky the voxel
+it is in sees, which is what the mesher bakes into a face; on the PBR path it
+is that path's own ambient plus a share of the sun, so a mob goes dark at
+night and warm at dusk along with the ground.
+
+The ceiling of that is shadows. An unlit thing has no normal, so it cannot be
+shadowed and one number has to serve both a mob in the open and a mob under a
+tree; what is picked lands between the two. Drawing objects lit instead --
+real normals, the real sun, the shadow map -- is the upgrade, and it is a
+larger one than it looks: there is no lit alpha-masked technique to hand, the
+sprites a game draws as flat quads turned to the camera would light oddly, and
+every entity in every game would have to be looked at again.
+
 On top of that, a voxel whose definition gives light gets a real light in the
 scene -- the two dozen nearest the camera, each with a range and a brightness
 from its light level, and an additive light pass in the technique for them to

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -108,6 +108,14 @@ sky's, and the same curve lifts the shadows, so a shadow under full skylight
 reads as shade rather than as a hole. games/voxel_lighting arrived at the same
 numbers for the same reasons.
 
+Where the sun and the moon are for the purpose of casting a shadow is stepped
+rather than smooth -- a degree and a half of sun at a time, about five seconds
+at Luanti's own clock speed. A shadow map is rasterized afresh every frame and
+a light that has turned between two of them rasterizes it differently, so the
+edges crawl; holding the direction still for a step at a time trades that for
+a small jump, which is much easier not to see. Only the direction is stepped:
+whether a body is up, how bright it is and what colour it is all stay smooth.
+
 The sun is in the scene only while it is above the horizon: it fades in
 between 05:00 and 06:00 and out between 18:00 and 19:00, and the moon -- the
 same light from the other side of the sky at a fiftieth of it, cold, and with
@@ -823,6 +831,12 @@ takes rather than constants, so a game that turns the sun off or asks for ten
 thousand stars gets that. What is not drawn is the textures a game can give
 the sun and the moon, or the cloud height and speed: the shader draws a
 square of its own colour and one layer of cloud at its own height.
+
+The stars are one per cell of a grid laid on the faces of a cube around the
+viewer -- which keeps a cell about the same size wherever it points, where a
+grid over a plane overhead crowds them at the horizon -- and that cube turns
+with the day, about the axis the sun goes round and by the same angle, which
+is what Luanti turns its own star mesh by. So they rise and set.
 
 What is next
 ------------

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -113,6 +113,13 @@ are where the fade is shaped; the line itself is enforced separately, from
 where the body actually is, so that neither can shine from under the world
 whatever the clock says.
 
+A cloud in the sun is drawn past white, so that the tone curve leaves it white
+rather than at about nine tenths, which reads as grey. That is ramped with the
+sun's own hour at each end of the day and is only given to the clouds the
+game's own colour says are white ones: a game that asks for grey clouds, which
+is how VoxeLibre says it is raining, is taken at its word and left where it
+was. The vanilla path does not do it at all, having no tone curve to survive.
+
 For the half hour either side of the sun crossing the horizon, at each end of
 the day, the sun's light goes towards the colour the game paints the horizon
 band with -- weighted towards the crossing itself, so that it comes on gently

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -87,11 +87,24 @@ shader dims the cube map by: the mouth of a tunnel reflects sky while its walls
 do not. The counter line says what it has found straight up and over how many
 blocks of voxels, which is the quickest way to see it is working at all.
 
-The ambient on this path is the sky's own colour rather than the colour of
-sunlight, and the shader's ambient is that times how much sky the vertex sees
-plus the lamp light baked into the vertex colour. That alone is three tints:
-open ground blue-white, under an overhang the same blue but dimmer, a cave
-only the warm light of its torches.
+The frame is rendered in HDR and tone mapped, which is what lets the sun be
+the sun: in a frame that clips at one, a sun strong enough to put a real
+shadow on the ground flattens every lit surface to white, and one weak enough
+not to do that has neither a visible colour nor a visible shadow. With the
+curve in, the sun is about fifty times the sky -- roughly what it is -- so a
+lit surface takes the sun's own warm colour instead of a mixture with the
+sky's, and the same curve lifts the shadows, so a shadow under full skylight
+reads as shade rather than as a hole. games/voxel_lighting arrived at the same
+numbers for the same reasons.
+
+The ambient on this path is the sky rather than the colour of sunlight, and
+the shader's ambient is that times how much sky the vertex sees plus the lamp
+light baked into the vertex colour. That alone is three tints: open ground
+blue-white, under an overhang the same blue but dimmer, a cave only the warm
+light of its torches. The sky is desaturated and dimmed on the way in, because
+the colour a game gives is the colour of the zenith and a surface sees the
+whole dome -- the pale band along the horizon and the glare around the sun as
+much as the blue overhead.
 
 The sun is a real directional light with a shadow map, and what keeps it from
 lighting the world twice is the light curve. Node lighting on this path is

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -113,6 +113,13 @@ are where the fade is shaped; the line itself is enforced separately, from
 where the body actually is, so that neither can shine from under the world
 whatever the clock says.
 
+For the half hour either side of the sun crossing the horizon, at each end of
+the day, the sun's light goes towards the colour the game paints the horizon
+band with and the clouds go most of the way towards the sun's: at that hour
+the sun is the only thing lighting them and it is lighting them from
+underneath, which is what makes a sunrise a sunrise rather than a sky that has
+got brighter. Outside that window neither is tinted at all.
+
 Both go out entirely when the game hides them, which is the plainest thing it
 can say: VoxeLibre turns the sun, the moon and the stars off together the
 moment the weather turns, before it darkens a single colour, and a dimension

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -22,7 +22,9 @@ itself, as Luanti's 0...24000, which is how the sky at dawn or at night gets
 looked at without waiting or asking the server for the privilege of setting
 its clock. BUILDAT_LUANTI_NAME sets the player name the dialog
 starts with, so that a test run does not fight a session of your own for the
-same player.
+same player. BUILDAT_LUANTI_PBR, set to anything non-empty, starts the dialog
+with the PBR checkbox ticked, so that a scripted run does not have to click it
+by pixel coordinates and a miss cannot be mistaken for the shader failing.
 
 Controls: the mouse looks, WASD walks, space jumps, ctrl sneaks, shift is
 faster, 1 to 8 pick a hotbar slot, the left mouse button digs what is pointed
@@ -69,10 +71,13 @@ It also discards texels below half alpha, which is what makes the holes in a
 leaf or a pane of glass be holes.
 
 The connect dialog's "Enable PBR" draws the same world with res/PBRVoxel.xml
-instead: the normal and surface maps the atlas derives from each texture, and
-reflections of a sky cube map. The vertex colours are its ambient, exactly as
-above, so a cave is as dark either way and nothing is meshed differently; what
-is added on top is the specular. Two things keep that specular honest. The
+instead: the normal and surface maps the atlas derives from each texture,
+reflections of a sky cube map, and the sun. What each surface is made of is
+guessed in surface.lua from the node's draw type, its groups, its name and
+whether it waves -- water is glossy and its highlights move, leaves let light
+through from behind, dirt is matte and bumpy, sand and snow have standing
+facets -- because a Luanti node definition says nothing about any of it. Two
+things keep the specular honest. The
 cube map beside the shader is one static noon gradient and is multiplied by the
 colour the sky is at this moment, so a sunset reflects orange and a night
 reflects almost nothing without anything being rebaked. And skyvis.lua marches
@@ -82,11 +87,26 @@ shader dims the cube map by: the mouth of a tunnel reflects sky while its walls
 do not. The counter line says what it has found straight up and over how many
 blocks of voxels, which is the quickest way to see it is working at all.
 
+The ambient on this path is the sky's own colour rather than the colour of
+sunlight, and the shader's ambient is that times how much sky the vertex sees
+plus the lamp light baked into the vertex colour. That alone is three tints:
+open ground blue-white, under an overhang the same blue but dimmer, a cave
+only the warm light of its torches.
+
+The sun is a real directional light with a shadow map, and what keeps it from
+lighting the world twice is the light curve. Node lighting on this path is
+remapped to answer one question -- am I underground -- and nothing else: full
+through a leaf canopy, nothing in rock, a smooth band in a doorway. The shader
+gates the sun by it, so a canopy is darkened by the shadow map, which is what
+a shadow map is good at, and a cave has no sun to shadow. The shadow map is
+two cascades over 24 and 96 nodes at 1024x1024, single-tap: biased for
+performance, because there are no graphics settings beyond this checkbox.
+Water, glass and ice cast no shadow, so a glass roof lets full sun through.
+
 It is off by default because the surface maps are most of what adding a texture
 to the atlas costs, and that loading time is the honest price of it. It is
 chosen before anything loads and fixed for the session for the same reason: the
-maps have to be on from the first texture the atlas builds. Not in it: sun
-shadows, which is a step of its own on top.
+maps have to be on from the first texture the atlas builds.
 
 On top of that, a voxel whose definition gives light gets a real light in the
 scene -- the two dozen nearest the camera, each with a range and a brightness
@@ -121,6 +141,9 @@ player.lua      The player's box: the keys, gravity, and collision against
 shapes.lua      Luanti's node shapes, as the quads a voxel definition takes
 skyvis.lua      How much sky the camera can see each way, for the PBR path's
                 reflections; ported from builtin/voxel_shading's module.lua
+surface.lua     What a node's surface is made of, guessed from its definition:
+                the six numbers per texture segment the atlas turns into
+                normal and spec maps
 objmesh.lua     Wavefront .obj, as the quads a voxel's shape is made of
 res/            What the client itself ships: the placeholder textures, and
                 the shaders and techniques this world is drawn with. Urho3D

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -740,8 +740,11 @@ carries straight across and the two clients cover the sky to within two parts
 in a hundred of each other -- and the speed becomes how fast the layer drifts,
 through a factor picked so that Luanti's own default drifts at
 the rate the shader had baked in before a game could ask for anything: twice
-the speed is twice as fast, and that is what the field is for. The height and
-the thickness have nothing to become and are dropped. Drawing the real thing
+the speed is twice as fast, and that is what the field is for. The cloud
+colour's alpha is how opaque the layer is drawn, which is what Luanti does
+with it, and the edge of a cloud is thin rather than a darker grey, so it
+blends into the sky. The height and the thickness have nothing to become and
+are dropped. Drawing the real thing
 -- a slab of cloud at a height, which the player can fly above and through --
 is deliberately not done; see the plan.
 

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -178,7 +178,11 @@ res/            What the client itself ships: the placeholder textures, and
                 the shaders and techniques this world is drawn with. Urho3D
                 finds them because share_path/extensions is a resource dir,
                 and a technique names a shader with a path of its own so it
-                does not have to live in the one shader directory
+                does not have to live in the one shader directory.
+                PBRVoxel.glsl is a fork of builtin/voxel_shading's and is not
+                kept in step with it: a good half of what is in it is an art
+                style, and a world made of Luanti's plants wants different
+                numbers from the sample game's. Both files say so at the top
 objects.lua     The things in the world that are not nodes: what the server
                 says they are and where
 itemdef.lua     ITEMDEF: what an item is, and what a tool can dig

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -113,6 +113,17 @@ are where the fade is shaped; the line itself is enforced separately, from
 where the body actually is, so that neither can shine from under the world
 whatever the clock says.
 
+Both are dimmed by the weather, because a directional light does not know
+there is a layer of cloud between it and the ground while the ambient does --
+a game darkens the sky colours it sends when the weather turns, and the direct
+light is then the only thing left insisting it is a clear day. Two things say
+overcast and a game uses one or the other: the cloud density, of which only
+what is above Luanti's own 0.4 is weather, since every game gets that whether
+it asks or not; and the cloud colour, which is how VoxeLibre says it -- it
+never touches the density and paints its clouds #FFF0F0 for a clear sky,
+#5D5D5F for rain and #3D3D3F for a thunderstorm. Full overcast leaves the sun
+a fifth of itself, which is a day with no shadows in it.
+
 The ambient on this path is the sky rather than the colour of sunlight, and
 the shader's ambient is that times how much sky the vertex sees plus the lamp
 light baked into the vertex colour. That alone is three tints: open ground

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -99,8 +99,12 @@ numbers for the same reasons.
 
 The sun is in the scene only while it is above the horizon: it fades in
 between 05:00 and 06:00 and out between 18:00 and 19:00, and the moon -- the
-same light from the other side of the sky at a tenth of it, cold, and with a
-shadow map of its own -- does the opposite.
+same light from the other side of the sky at a fiftieth of it, cold, and with
+a shadow map of its own -- does the opposite, on a day of its own that is a
+little longer than the sun's night. It is going by 04:30 and gone by 05:30,
+with the sun then half up, and does not come back until 18:30. That leaves it
+nine hours at full against the sun's twelve, which is one more way of saying
+which of the two is the dim one.
 A directional light does not know about the horizon, so one left on at night
 lights the undersides of everything, and its specular, which is the sparkle a
 surface asks for on water, on snow and on ore, is then the brightest thing in

--- a/doc/luanti_client.txt
+++ b/doc/luanti_client.txt
@@ -97,6 +97,14 @@ sky's, and the same curve lifts the shadows, so a shadow under full skylight
 reads as shade rather than as a hole. games/voxel_lighting arrived at the same
 numbers for the same reasons.
 
+The sun is in the scene only while it is above the horizon: it fades in
+between 05:00 and 06:00 and out between 18:00 and 19:00, and the moon -- the
+same light from the other side of the sky, dim and cold -- does the opposite.
+A directional light does not know about the horizon, so one left on at night
+lights the undersides of everything, and its specular, which is the sparkle a
+surface asks for on water, on snow and on ore, is then the brightest thing in
+a night frame and is coming from the wrong side of the sky.
+
 The ambient on this path is the sky rather than the colour of sunlight, and
 the shader's ambient is that times how much sky the vertex sees plus the lamp
 light baked into the vertex colour. That alone is three tints: open ground

--- a/extensions/luanti_client/client.lua
+++ b/extensions/luanti_client/client.lua
@@ -850,10 +850,15 @@ function M.new(socket, options, log)
 	-- one for the horizon at each of day, dawn and night; anything else --
 	-- "skybox" with six textures, "plain" with one colour -- has the
 	-- background colour and that is all.
+	-- {r, g, b, a}, each 0...255. The alpha is on the wire for every colour
+	-- and means something for some of them -- a cloud's is how opaque the
+	-- layer is -- so it is handed on; a caller that does not want it reads
+	-- the first three.
 	local function read_color(r)
 		local argb = r:u32()
 		return {math.floor(argb / 0x10000) % 0x100,
-				math.floor(argb / 0x100) % 0x100, argb % 0x100}
+				math.floor(argb / 0x100) % 0x100, argb % 0x100,
+				math.floor(argb / 0x1000000) % 0x100}
 	end
 
 	handlers[TOCLIENT.SET_SKY] = function(r)

--- a/extensions/luanti_client/client.lua
+++ b/extensions/luanti_client/client.lua
@@ -435,8 +435,12 @@ function M.new(socket, options, log)
 			-- out of 20, and breath out of 10 while under water
 			hp = nil,
 			breath = nil,
-			-- The server's time of day, 0...23999, and how fast it runs
+			-- The server's time of day, 0...23999, and how fast it runs.
+			-- time_of_day is the last thing the server said; time_of_day_f
+			-- is the same clock carried on between those, which is what
+			-- anything drawing the sky wants.
 			time_of_day = nil,
+			time_of_day_f = nil,
 			time_speed = 0,
 			blocks_received = 0,
 			-- Counters for the slow-frame line; see update() below
@@ -1123,6 +1127,7 @@ function M.new(socket, options, log)
 	handlers[TOCLIENT.TIME_OF_DAY] = function(r)
 		self.time_of_day = r:u16() % 24000
 		self.time_speed = r:f32()
+		self.time_of_day_f = self.time_of_day
 	end
 
 	handlers[TOCLIENT.BLOCKDATA] = function(r)
@@ -1287,6 +1292,15 @@ function M.new(socket, options, log)
 	local SILENCE_LIMIT_S = 20
 
 	function self:update(dtime)
+		-- The day goes on between the times the server says what it is.
+		-- Luanti's client does the same -- Environment::stepTimeOfDay -- and
+		-- for the same reason: the server sends the time every few seconds,
+		-- and a sky drawn from that alone steps across the sky rather than
+		-- crossing it. The server's word resets this whenever it arrives.
+		if self.time_of_day_f then
+			self.time_of_day_f = (self.time_of_day_f +
+					self.time_speed * 24000 / (24 * 3600) * dtime) % 24000
+		end
 		conn:update(dtime)
 		-- Once something has gone wrong there is nothing left to be smooth
 		-- for, and what is still in the queue is what says why

--- a/extensions/luanti_client/init.lua
+++ b/extensions/luanti_client/init.lua
@@ -39,6 +39,10 @@ local M = {safe = nil}
 -- which cannot easily clear a text field
 local DEFAULT_ADDRESS = os.getenv("BUILDAT_LUANTI_ADDRESS") or "localhost:30000"
 local DEFAULT_NAME = os.getenv("BUILDAT_LUANTI_NAME") or "buildat"
+-- The PBR checkbox's starting state. A scripted run has to hit the box by
+-- pixel coordinates otherwise, and a miss looks like the shader not working
+-- rather than like a missed click.
+local DEFAULT_PBR = (os.getenv("BUILDAT_LUANTI_PBR") or "") ~= ""
 
 -- How far the camera sees, and how far out blocks are kept, in nodes. The
 -- client asks the server for blocks by the same distance; see
@@ -3238,6 +3242,7 @@ show_connect_dialog = function(address, name)
 	local pbr_label = pbr_row:CreateChild("Text")
 	pbr_label:SetStyleAuto()
 	pbr_label.text = "Enable PBR (slower to load)"
+	pbr_check.checked = DEFAULT_PBR
 	-- The password is the field a second try is most likely about, and it is
 	-- the one that is not filled in
 	if address then

--- a/extensions/luanti_client/init.lua
+++ b/extensions/luanti_client/init.lua
@@ -88,11 +88,6 @@ local CRACK_FRAMES_DEFAULT = 5
 -- daynight_ratio() below, is the same kind of thing for the light.
 local FORCE_TIME = tonumber(os.getenv("BUILDAT_LUANTI_FORCE_TIME") or "")
 
--- How far the day has to move before the sky is worked out again, in
--- Luanti's own units of 1/24000th of a day: a full turn of the sun is 360
--- degrees over 24000, so this is about half a degree.
-local SKY_STEP = 30
-
 local HOTBAR_SLOTS = 8
 
 -- Media files are asked for in batches, so that one REQUEST_MEDIA does not
@@ -2333,8 +2328,6 @@ local function show_client(host, port, name, password, pbr)
 		-- edge of the window
 		magic.input:SetMouseVisible(false)
 
-		local last_daylight = nil
-		local last_time_of_day = 0
 
 		-- WASD on the horizontal plane whatever the camera is pitched at,
 		-- space to jump, ctrl to sneak, shift for a faster pace, and K to
@@ -2642,25 +2635,18 @@ local function show_client(host, port, name, password, pbr)
 			end
 			update_tooltip(dtime)
 			update_held_image()
-			local time_of_day = FORCE_TIME or client.time_of_day
+			-- The clock the client carries on between the server's word for
+			-- it, so that the day passes rather than arrives every few
+			-- seconds; see client.lua's update(). Handing it over every
+			-- frame costs nothing -- the world only records it, and draws
+			-- the sky from it in its own update.
+			local time_of_day = FORCE_TIME or client.time_of_day_f
 			if time_of_day then
 				-- A server can say what the light is whatever the time is,
 				-- which is how a game lights another dimension; the sun
 				-- still goes where the time says, as it does in Luanti.
-				local daylight = daynight_ratio(time_of_day,
-						client.day_night_override)
-				-- The ramp is smooth and the zone is not free to set, so
-				-- only a visible step is worth an update. The time itself
-				-- matters as well as the light it comes to: it is where the
-				-- sun is in the sky.
-				if not last_daylight or
-						math.abs(daylight - last_daylight) > 0.01 or
-						math.abs(time_of_day - last_time_of_day) >
-								SKY_STEP then
-					last_daylight = daylight
-					last_time_of_day = time_of_day
-					view:set_daylight(daylight, time_of_day)
-				end
+				view:set_daylight(daynight_ratio(time_of_day,
+						client.day_night_override), time_of_day)
 			end
 			-- Nothing is dropped until the server has said where the player
 			-- is: until then the camera is at the origin and everything that

--- a/extensions/luanti_client/res/LuantiSky.glsl
+++ b/extensions/luanti_client/res/LuantiSky.glsl
@@ -76,11 +76,37 @@ const float CLOUD_EDGE = 0.07;
 const float CLOUD_HORIZON = 0.16;
 const float CLOUD_FADE = 0.38;
 
-// The stars: one per cell of a grid laid over the direction, only some cells
-// holding one at all -- how many is cStarDensity, out of how many stars the
-// game asked for. Few enough to read as stars: at any greater density the
-// night sky is white noise.
-const float STAR_GRID = 220.0;
+// The stars: one per cell of a grid laid over the sky, only some cells holding
+// one at all -- how many is cStarDensity, out of how many stars the game asked
+// for. Few enough to read as stars: at any greater density the night sky is
+// white noise.
+//
+// The grid is on the faces of a cube around the viewer rather than on a plane
+// overhead, which keeps a cell about the same size wherever it is; a plane
+// crowds them at the horizon and thins them at the zenith. Six faces of
+// 2 x STAR_GRID cells is about 250 thousand of them, so the density a game of
+// a thousand stars comes to puts a thousand in the sky.
+const float STAR_GRID = 102.0;
+
+// Which cell of that a direction falls in: the face it points at, and where on
+// the face it lands
+vec3 StarCell(vec3 s)
+{
+    vec3 a = abs(s);
+    vec2 uv;
+    float face;
+    if(a.x >= a.y && a.x >= a.z){
+        uv = s.yz / a.x;
+        face = s.x > 0.0 ? 0.0 : 1.0;
+    } else if(a.y >= a.z){
+        uv = s.xz / a.y;
+        face = s.y > 0.0 ? 2.0 : 3.0;
+    } else {
+        uv = s.xy / a.z;
+        face = s.z > 0.0 ? 4.0 : 5.0;
+    }
+    return vec3(floor(uv * STAR_GRID), face);
+}
 
 float SkyHash(vec2 p)
 {
@@ -163,10 +189,17 @@ void PS()
     // The stars, behind everything else up there and only when the sky is
     // dark enough for them
     if(cStarFade > 0.0 && cStarDensity > 0.0 && d.y > -0.05){
-        vec2 cell = floor(vec2(d.x, d.z) / max(abs(d.y), 0.15) * STAR_GRID);
-        float pick = SkyHash(cell);
+        // Turned with the day, about the axis the sun goes round and by the
+        // same angle: Luanti turns its star mesh by 2 pi (wicked time - 1/4)
+        // about Z, and the sun's own direction is the cosine and sine of
+        // that, so it is the rotation. Stars rise and set with it.
+        vec3 turned = vec3(d.x * sun.x + d.y * sun.y,
+            d.y * sun.x - d.x * sun.y, d.z);
+        vec3 cell = StarCell(turned);
+        vec2 key = cell.xy + cell.z * 71.0;
+        float pick = SkyHash(key);
         if(pick < cStarDensity){
-            float twinkle = 0.55 + 0.45 * SkyHash(cell + 7.0);
+            float twinkle = 0.55 + 0.45 * SkyHash(key + 7.0);
             color += cStarColor * twinkle * cStarFade *
                     smoothstep(-0.05, 0.15, d.y);
         }

--- a/extensions/luanti_client/res/LuantiSky.glsl
+++ b/extensions/luanti_client/res/LuantiSky.glsl
@@ -28,6 +28,7 @@ uniform float cStarFade;
 // squares, zero for one it has turned off; how many of the star grid's cells
 // hold a star, and what colour; and how much of the sky the clouds cover.
 uniform float cSunSize;
+uniform float cSunOverexposure;
 uniform float cMoonSize;
 uniform float cStarDensity;
 uniform vec3 cStarColor;
@@ -54,14 +55,14 @@ const vec3 MOON_COLOR = vec3(0.86, 0.88, 0.94);
 // tint the horizon is painted with: a sun the colour of dawn at midday is
 // what the tint alone gives
 const vec3 SUN_COLOR = vec3(1.0, 0.97, 0.86);
-// The sun is brighter than anything else in the frame by orders of
-// magnitude, and there is no tone mapping to say so, so the only way to say
-// it is to let the disc clip: what a game's sun texture is painted as, or
-// SUN_COLOR, multiplied past one and clamped. The core comes out white and
-// the texture's own colour is left at the edges, where it is not clipped.
-// Scaled back to nothing as the sun comes down to the horizon, because a low
-// sun is a dim one and its colour is the whole point of it.
-const float SUN_OVEREXPOSURE = 1.5;
+// How far past white the sun's disc is drawn. The sun is brighter than
+// anything else in the frame by orders of magnitude and it has to be said
+// somehow: on the vanilla path the frame clips at one, so the disc is pushed
+// a little past it and its core comes out white with the texture's own colour
+// left at the edges; on the PBR path the frame is tone mapped and this is a
+// real multiplier, which is also what makes the bloom around it. Set from
+// world.lua. Scaled back to nothing as the sun comes down to the horizon,
+// because a low sun is a dim one and its colour is the point of it.
 
 const float CLOUD_SCALE = 6.0;
 const float CLOUD_PIXELS = 11.0;
@@ -194,8 +195,7 @@ void PS()
             sun_color = tex.rgb;
             cover *= tex.a;
         }
-        sun_color = min(sun_color * mix(SUN_OVEREXPOSURE, 1.0, low),
-            vec3(1.0));
+        sun_color *= mix(cSunOverexposure, 1.0, low);
         color = mix(color, sun_color, cover);
     }
     if(cMoonSize > 0.0){

--- a/extensions/luanti_client/res/LuantiSky.glsl
+++ b/extensions/luanti_client/res/LuantiSky.glsl
@@ -87,6 +87,10 @@ const float CLOUD_FADE = 0.38;
 // 2 x STAR_GRID cells is about 250 thousand of them, so the density a game of
 // a thousand stars comes to puts a thousand in the sky.
 const float STAR_GRID = 102.0;
+// How bright a star is drawn, against the colour the game gave them. Less than
+// the colour says, because the moon is the bright thing in a night sky and a
+// star drawn at its own colour comes out brighter than the moon does.
+const float STAR_BRIGHTNESS = 0.65;
 
 // Which cell of that a direction falls in: the face it points at, and where on
 // the face it lands
@@ -200,7 +204,7 @@ void PS()
         float pick = SkyHash(key);
         if(pick < cStarDensity){
             float twinkle = 0.55 + 0.45 * SkyHash(key + 7.0);
-            color += cStarColor * twinkle * cStarFade *
+            color += cStarColor * twinkle * cStarFade * STAR_BRIGHTNESS *
                     smoothstep(-0.05, 0.15, d.y);
         }
     }

--- a/extensions/luanti_client/res/LuantiSky.glsl
+++ b/extensions/luanti_client/res/LuantiSky.glsl
@@ -54,6 +54,14 @@ const vec3 MOON_COLOR = vec3(0.86, 0.88, 0.94);
 // tint the horizon is painted with: a sun the colour of dawn at midday is
 // what the tint alone gives
 const vec3 SUN_COLOR = vec3(1.0, 0.97, 0.86);
+// The sun is brighter than anything else in the frame by orders of
+// magnitude, and there is no tone mapping to say so, so the only way to say
+// it is to let the disc clip: what a game's sun texture is painted as, or
+// SUN_COLOR, multiplied past one and clamped. The core comes out white and
+// the texture's own colour is left at the edges, where it is not clipped.
+// Scaled back to nothing as the sun comes down to the horizon, because a low
+// sun is a dim one and its colour is the whole point of it.
+const float SUN_OVEREXPOSURE = 1.5;
 
 const float CLOUD_SCALE = 6.0;
 const float CLOUD_PIXELS = 11.0;
@@ -186,6 +194,8 @@ void PS()
             sun_color = tex.rgb;
             cover *= tex.a;
         }
+        sun_color = min(sun_color * mix(SUN_OVEREXPOSURE, 1.0, low),
+            vec3(1.0));
         color = mix(color, sun_color, cover);
     }
     if(cMoonSize > 0.0){

--- a/extensions/luanti_client/res/LuantiSky.glsl
+++ b/extensions/luanti_client/res/LuantiSky.glsl
@@ -33,6 +33,8 @@ uniform float cMoonSize;
 uniform float cStarDensity;
 uniform vec3 cStarColor;
 uniform float cCloudCoverage;
+// How opaque the layer is, which is the alpha the game gave its cloud colour
+uniform float cCloudAlpha;
 // Whether the game gave the sun or the moon a texture of its own. When it
 // did, sDiffMap holds the sun's and sNormalMap the moon's -- two units
 // because a material has no third one this needs -- and the square is that
@@ -66,7 +68,11 @@ const vec3 SUN_COLOR = vec3(1.0, 0.97, 0.86);
 
 const float CLOUD_SCALE = 6.0;
 const float CLOUD_PIXELS = 11.0;
-const float CLOUD_LIT_STEP = 0.07;
+// How wide the thin edge of a cloud is, in the noise's own units: the cells
+// that used to be drawn a darker grey are these, and they are drawn thin
+// instead. It starts at the threshold rather than straddling it, so that the
+// sky the clouds cover is still the sky the threshold says they cover.
+const float CLOUD_EDGE = 0.07;
 const float CLOUD_HORIZON = 0.16;
 const float CLOUD_FADE = 0.38;
 
@@ -173,11 +179,16 @@ void PS()
                 cElapsedTimePS * cCloudWind;
         float density = CloudDensity(floor(p * CLOUD_PIXELS) / CLOUD_PIXELS);
         float threshold = 1.0 - cCloudCoverage;
-        vec3 cloud = density > threshold + CLOUD_LIT_STEP ?
-                cCloudColor : cCloudColor * 0.72;
-        float cover = step(threshold, density) *
+        // How much of a cloud this cell is: solid well past the threshold,
+        // sky well short of it, and thinning across CLOUD_EDGE in between, so
+        // that the edge of a cloud blends into the sky rather than being a
+        // darker cloud. What the whole layer is worth on top of that is the
+        // alpha the game gave its cloud colour, which is what Luanti draws
+        // its own clouds with.
+        float into = clamp((density - threshold) / CLOUD_EDGE, 0.0, 1.0);
+        float cover = into * cCloudAlpha *
                 smoothstep(CLOUD_HORIZON, CLOUD_FADE, d.y);
-        color = mix(color, cloud, cover);
+        color = mix(color, cCloudColor, cover);
     }
 
     // The sun and the moon, over the clouds: they are the two things up there

--- a/extensions/luanti_client/res/PBRVoxel.glsl
+++ b/extensions/luanti_client/res/PBRVoxel.glsl
@@ -256,9 +256,6 @@ void VS()
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
     const float STATIC_SPOT_TILT = 0.15;
-    // How far towards white a spot takes the light it reflects; see where it
-    // is used, in the light pass
-    const float SPOT_WHITEN = 0.85;
     const float TRANSMISSION_RATE = 0.03;    // Cycles per second, mean
     const vec3 TRANSMISSION_WIND = vec3(0.35, 0.0, -0.2);
 
@@ -586,18 +583,6 @@ void PS()
             // shadow map does the darkening; in a cave there is no sun to
             // shadow.
             lightColor *= vSkyVisibility;
-        #endif
-
-        #ifdef VOXELSPOTS
-            // A spot is a mirror, and a mirror image of something as bright
-            // as the sun saturates whatever sees it: a glint off water reads
-            // white, not the colour of the light. Nothing here is bright
-            // enough to clip on its own, so the spot's share of the light is
-            // taken towards white directly. Only where there is a spot, and
-            // only for that pixel's light; the surface around it keeps the
-            // sun's own colour, which is where that colour belongs.
-            lightColor = mix(lightColor, vec3(GetIntensity(lightColor)),
-                max(surfaceSpots, staticSpots) * SPOT_WHITEN);
         #endif
 
         vec3 toCamera = normalize(cCameraPosPS - vWorldPos.xyz);

--- a/extensions/luanti_client/res/PBRVoxel.glsl
+++ b/extensions/luanti_client/res/PBRVoxel.glsl
@@ -255,7 +255,11 @@ void VS()
     // Taken from the world position for the same reason as those, that a map
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
-    const float STATIC_SPOT_TILT = 0.15;
+    // Left where it was when the moving kind was narrowed: a facet is a chip
+    // of rock that is flat and stays turned, not a leaf that has caught the
+    // light for a moment, and narrowing it takes the speckle off sand and
+    // gravel rather than gathering it anywhere.
+    const float STATIC_SPOT_TILT = 0.35;
     // How narrowly the light through a surface is aimed at the camera. Light
     // coming through a leaf is light going the way it was already going, so it
     // is seen looking back along it and not from the side: at the width a

--- a/extensions/luanti_client/res/PBRVoxel.glsl
+++ b/extensions/luanti_client/res/PBRVoxel.glsl
@@ -19,8 +19,12 @@
 // the neutral grey of bounced light where it is not. Ambient occlusion and a
 // per-face brightness are already folded into both terms by the mesher.
 //
-// Direct light is deliberately left alone. The sun is shadow mapped, so
-// attenuating it by skylight as well would darken shadowed faces twice.
+// Direct light is deliberately left alone, unless VOXELSUNGATE is defined:
+// with it, the directional light is multiplied by the vertex color's alpha, so
+// that a world whose light value says "underground" gets no sun. That is for a
+// world whose light curve is built for it -- see PBR_LIGHT_MAP in the Luanti
+// client's world.lua; without such a curve it would darken shadowed faces
+// twice, which is why it is off by default.
 //
 // On top of that, two things the stock PBR shaders do differently:
 //
@@ -88,6 +92,11 @@ varying vec4 vWorldPos;
             varying highp vec4 vShadowPos[NUMCASCADES];
         #endif
     #endif
+    #ifdef VOXELSUNGATE
+        // How much of the sky this vertex sees, which on the light pass is
+        // what says whether the sun can reach it at all; see below
+        varying float vSkyVisibility;
+    #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;
     #endif
@@ -135,6 +144,10 @@ void VS()
     #ifdef PERPIXEL
         // Per-pixel forward lighting
         vec4 projWorldPos = vec4(worldPos, 1.0);
+
+        #ifdef VOXELSUNGATE
+            vSkyVisibility = iColor.a;
+        #endif
 
         #ifdef SHADOW
             // Shadow projection: transform from world space to shadow space
@@ -553,6 +566,20 @@ void PS()
         #else
             lightColor = cLightColor.rgb;
         #endif
+
+        #if defined(DIRLIGHT) && defined(VOXELSUNGATE)
+            // The sun does not reach underground, and nothing else in the
+            // scene knows that: a shadow map cannot tell a cave from a leaf
+            // canopy, because in both cases the sky is blocked by geometry
+            // that is being drawn. So the world's own light value is the
+            // gate, and it is built for exactly this -- see PBR_LIGHT_MAP in
+            // world.lua, which holds at full through a canopy and falls to
+            // nothing in rock. Under a tree the sun is at full here and the
+            // shadow map does the darkening; in a cave there is no sun to
+            // shadow.
+            lightColor *= vSkyVisibility;
+        #endif
+
         vec3 toCamera = normalize(cCameraPosPS - vWorldPos.xyz);
         vec3 lightVec = normalize(lightDir);
         float ndl = clamp((dot(normal, lightVec)), M_EPSILON, 1.0);

--- a/extensions/luanti_client/res/PBRVoxel.glsl
+++ b/extensions/luanti_client/res/PBRVoxel.glsl
@@ -1,7 +1,38 @@
-// Forked from builtin/voxel_shading's PBRVoxel.glsl, which a Luanti client
-// cannot use: builtin/ is not on a client's resource path and there is no
-// buildat server to deliver it. One change of its own, cSkyColor below; keep
-// the two files in step when either is touched.
+// A fork of builtin/voxel_shading's PBRVoxel.glsl, and no longer a copy of it.
+//
+// It started as one because a Luanti client cannot use the built-in shader:
+// builtin/ is not on a client's resource path and there is no buildat server
+// to deliver it. What keeps the two apart now is that a good deal of what is
+// in here is an art style rather than a mechanism -- how far a spot turns, how
+// narrowly a leaf passes light through itself -- and this client's worlds and
+// games/voxel_lighting's are not the same worlds. Tuning one of them through a
+// shared file retunes the other, which is how voxel_lighting's rock quietly
+// lost its speckle.
+//
+// So the two are not kept in step. A fix to the machinery is worth carrying
+// across by hand; a number that decides how something looks is not. What
+// differs today, and why:
+//
+//   cSkyColor           Only here. The colour the sky is at this moment, which
+//                       the client pushes so that reflections follow the sky
+//                       it paints without a cube map being rebaked.
+//   SPOT_TILT           0.06 here, 0.45 there. A Luanti game's ground is
+//                       plants the whole way across and every one of them can
+//                       hold a spot, so the sparkle has to gather tightly
+//                       around the light or it reads as glitter over a field.
+//                       voxel_lighting's few surfaces are sparsely spotted and
+//                       a wide turn is what makes them catch anything at all.
+//   TRANSMISSION_FOCUS  A thirty-second power here against a sixth there, for
+//                       the same reason: a canopy of Luanti leaves glowing
+//                       over a quarter of the sky stops reading as the sun
+//                       behind it.
+//   spotGloss           Ramped on sharply here, linear there. With plants this
+//                       dense, the half open cells -- most of them at any
+//                       moment -- are a sheen that follows the light.
+//
+// STATIC_SPOT_TILT is the same number in both and wants to stay that way: a
+// facet is a chip of rock either way, and narrowing it does not gather the
+// speckle anywhere, it only takes it off the sand.
 //
 // Copied from CoreData/Shaders/GLSL/PBRLitSolid.glsl (Urho3D 1.7.1). Two
 // changes, both about how voxel skylight reaches the ambient term:

--- a/extensions/luanti_client/res/PBRVoxel.glsl
+++ b/extensions/luanti_client/res/PBRVoxel.glsl
@@ -245,12 +245,20 @@ void VS()
     // a smooth gradient with no sun drawn in it, so a sharper reflection of it
     // looks no different from a blurred one. A turned normal moves the direct
     // sunlight's own highlight instead, which is the bright thing in the scene.
-    const float SPOT_TILT = 0.45;
+    //
+    // It is also what decides how far from the light the sparkle reaches. A
+    // spot turned this far catches the sun from anywhere within that angle of
+    // the mirror direction, so a large one puts glints over a whole field
+    // rather than in the band where the light is actually being reflected.
+    const float SPOT_TILT = 0.18;
     // Bigger than the moving ones: a facet is a chip of rock, not a leaf.
     // Taken from the world position for the same reason as those, that a map
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
-    const float STATIC_SPOT_TILT = 0.35;
+    const float STATIC_SPOT_TILT = 0.15;
+    // How far towards white a spot takes the light it reflects; see where it
+    // is used, in the light pass
+    const float SPOT_WHITEN = 0.85;
     const float TRANSMISSION_RATE = 0.03;    // Cycles per second, mean
     const vec3 TRANSMISSION_WIND = vec3(0.35, 0.0, -0.2);
 
@@ -578,6 +586,18 @@ void PS()
             // shadow map does the darkening; in a cave there is no sun to
             // shadow.
             lightColor *= vSkyVisibility;
+        #endif
+
+        #ifdef VOXELSPOTS
+            // A spot is a mirror, and a mirror image of something as bright
+            // as the sun saturates whatever sees it: a glint off water reads
+            // white, not the colour of the light. Nothing here is bright
+            // enough to clip on its own, so the spot's share of the light is
+            // taken towards white directly. Only where there is a spot, and
+            // only for that pixel's light; the surface around it keeps the
+            // sun's own colour, which is where that colour belongs.
+            lightColor = mix(lightColor, vec3(GetIntensity(lightColor)),
+                max(surfaceSpots, staticSpots) * SPOT_WHITEN);
         #endif
 
         vec3 toCamera = normalize(cCameraPosPS - vWorldPos.xyz);

--- a/extensions/luanti_client/res/PBRVoxel.glsl
+++ b/extensions/luanti_client/res/PBRVoxel.glsl
@@ -250,12 +250,18 @@ void VS()
     // spot turned this far catches the sun from anywhere within that angle of
     // the mirror direction, so a large one puts glints over a whole field
     // rather than in the band where the light is actually being reflected.
-    const float SPOT_TILT = 0.18;
+    const float SPOT_TILT = 0.06;
     // Bigger than the moving ones: a facet is a chip of rock, not a leaf.
     // Taken from the world position for the same reason as those, that a map
     // lives in one voxel face and would repeat every voxel.
     const float STATIC_SPOT_CELLS = 6.0;     // Cells per voxel, per axis
     const float STATIC_SPOT_TILT = 0.15;
+    // How narrowly the light through a surface is aimed at the camera. Light
+    // coming through a leaf is light going the way it was already going, so it
+    // is seen looking back along it and not from the side: at the width a
+    // sixth power gives, a canopy glows over a quarter of the sky and the glow
+    // stops reading as the sun behind it.
+    const float TRANSMISSION_FOCUS = 32.0;
     const float TRANSMISSION_RATE = 0.03;    // Cycles per second, mean
     const vec3 TRANSMISSION_WIND = vec3(0.35, 0.0, -0.2);
 
@@ -443,11 +449,19 @@ void PS()
             surfaceSpots = GetSurfaceSpots(vWorldPos.xyz, surfaceSrc.a);
             staticSpots = GetStaticSpots(vWorldPos.xyz,
                 texture2D(sNormalMap, vTexCoord.xy).a);
+            // A spot is glossy because it is a leaf or a facet that has
+            // turned, and one that has half turned is a smaller turn rather
+            // than a wider, duller highlight: the fade belongs in the tilt,
+            // which carries it below. Ramping the gloss on sharply instead is
+            // what keeps the half open cells -- which at any moment are most
+            // of them -- from being a broad sheen that follows the light
+            // across a whole field.
             float spotMask = max(surfaceSpots, staticSpots);
-            roughness = mix(roughness, SPOT_ROUGHNESS, spotMask);
+            float spotGloss = spotMask * spotMask * spotMask;
+            roughness = mix(roughness, SPOT_ROUGHNESS, spotGloss);
             // Full strength however matte the rest is, so that rock can be
             // dull everywhere except at its facets
-            specStrength = mix(specStrength, 1.0, spotMask);
+            specStrength = mix(specStrength, 1.0, spotGloss);
         #endif
     #else
         float roughness = cRoughness;
@@ -617,7 +631,8 @@ void PS()
             vec3 transmitted = mix(vec3(1.0), diffColor.rgb,
                 TRANSMISSION_TINT);
             float backNdl = max(0.0, -dot(normal, lightVec));
-            float forward = pow(max(0.0, dot(-lightVec, toCamera)), 6.0);
+            float forward = pow(max(0.0, dot(-lightVec, toCamera)),
+                TRANSMISSION_FOCUS);
             // A material with no spots at all is translucent all over
             #ifdef VOXELSPOTS
                 float through = surfaceSrc.a > 0.0 ? surfaceSpots : 1.0;

--- a/extensions/luanti_client/res/PBRVoxel.xml
+++ b/extensions/luanti_client/res/PBRVoxel.xml
@@ -4,14 +4,21 @@
      What the connect dialog's "Enable PBR" turns on.
 
      ALPHAMASK because a Luanti texture is a cutout -- a plant, a rail, a
-     ladder -- and this is the technique those faces get too.
+     ladder -- and this is the technique those faces get too. The shadow pass
+     needs it as well, or a leaf casts the shadow of a solid cube.
+
+     VOXELSUNGATE gates the directional light by how much sky the vertex sees,
+     so that the sun does not shine in a cave; see PBRVoxel.glsl and
+     PBR_LIGHT_MAP in world.lua. The vertex shader needs the define too,
+     because the varying it carries is declared in both.
 
      No VOXELMODIFIERS: the voxel format this client builds binds no surface
      modifier, so the vertex tangent carries nothing to read. -->
 <technique vs="luanti_client/res/PBRVoxel" ps="luanti_client/res/PBRVoxel"
-        psdefines="DIFFMAP ALPHAMASK PBR METALLIC VOXELNORMALMAP VOXELIBL VOXELSPOTS VOXELTRANSLUCENCY">
+        vsdefines="VOXELSUNGATE"
+        psdefines="DIFFMAP ALPHAMASK PBR METALLIC VOXELNORMALMAP VOXELIBL VOXELSPOTS VOXELTRANSLUCENCY VOXELSUNGATE">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="depth" vs="Depth" ps="Depth" />
-    <pass name="shadow" vs="Shadow" ps="Shadow" />
+    <pass name="shadow" vs="Shadow" ps="Shadow" psdefines="ALPHAMASK" />
 </technique>

--- a/extensions/luanti_client/res/PBRVoxelAlpha.xml
+++ b/extensions/luanti_client/res/PBRVoxelAlpha.xml
@@ -3,9 +3,17 @@
      cut out, and with culling off so that a water surface is there from under
      it -- see VoxelUnlitAlpha.xml, which is the same trade in the unlit path.
 
-     One pass: an additive light pass over a blended one would draw the
-     translucent surface's light twice. -->
+     The blended pass is the ambient one; litalpha is the sun on top of it,
+     which is what puts a highlight on water. Urho3D runs the pair the way it
+     runs base and light on an opaque surface, so the light is added once and
+     not drawn twice.
+
+     No shadow pass, so water, glass and ice cast none. That is the right
+     default -- a transparent thing casting an opaque shadow looks worse than
+     it casting none -- and it does mean a glass roof lets full sun through. -->
 <technique vs="luanti_client/res/PBRVoxel" ps="luanti_client/res/PBRVoxel"
-        psdefines="DIFFMAP PBR METALLIC VOXELNORMALMAP VOXELIBL VOXELSPOTS VOXELTRANSLUCENCY">
+        vsdefines="VOXELSUNGATE"
+        psdefines="DIFFMAP PBR METALLIC VOXELNORMALMAP VOXELIBL VOXELSPOTS VOXELTRANSLUCENCY VOXELSUNGATE">
     <pass name="alpha" blend="alpha" depthwrite="false" cull="none" />
+    <pass name="litalpha" blend="addalpha" depthwrite="false" cull="none" />
 </technique>

--- a/extensions/luanti_client/surface.lua
+++ b/extensions/luanti_client/surface.lua
@@ -19,6 +19,14 @@
 --   spots          animated sparkle: moving highlights, for water
 --   static_spots   the same but standing still: facets in sand, snow, ore
 --
+-- The two spot fractions are how much of a surface is a spot at any one
+-- moment, and they want to be small: a spot reflects at full strength
+-- whatever the rest of the surface does, so a few per cent reads as a surface
+-- catching the light and a tenth of it reads as glitter paint. These are
+-- scaled to the numbers games/voxel_lighting arrived at, which is the same
+-- shader with the same constants behind it: grass 0.012, leaves 0.03, water
+-- 0.05, rock 0.04 standing still.
+--
 -- Not here: metalness. The spec map's four channels are full and cMetallic is
 -- per material, so metal nodes read as very glossy dielectrics.
 
@@ -54,16 +62,16 @@ local DEFAULT = {
 -- dozen patterns; the groups win where there are any.
 local BY_NAME = {
 	{"water", {roughness = 0.25, spec_strength = 0.9, bumpiness = 0,
-			spots = 0.10}},
+			spots = 0.05}},
 	{"lava", {roughness = 0.6, spec_strength = 0.3, bumpiness = 0.2}},
 	{"ice", {roughness = 0.10, spec_strength = 1.0, bumpiness = 0.1,
-			static_spots = 0.15}},
+			static_spots = 0.05}},
 	{"glass", {roughness = 0.10, spec_strength = 1.0, bumpiness = 0}},
 	{"crystal", {roughness = 0.15, spec_strength = 0.9, bumpiness = 0.1,
-			static_spots = 0.25}},
-	{"gem", {roughness = 0.15, spec_strength = 0.9, static_spots = 0.25}},
-	{"diamond", {roughness = 0.12, spec_strength = 1.0, static_spots = 0.3}},
-	{"mese", {roughness = 0.2, spec_strength = 0.8, static_spots = 0.25}},
+			static_spots = 0.06}},
+	{"gem", {roughness = 0.15, spec_strength = 0.9, static_spots = 0.06}},
+	{"diamond", {roughness = 0.12, spec_strength = 1.0, static_spots = 0.07}},
+	{"mese", {roughness = 0.2, spec_strength = 0.8, static_spots = 0.06}},
 	{"metal", {roughness = 0.35, spec_strength = 0.8, bumpiness = 0.1}},
 	{"steel", {roughness = 0.35, spec_strength = 0.8, bumpiness = 0.1}},
 	{"copper", {roughness = 0.40, spec_strength = 0.7, bumpiness = 0.1}},
@@ -71,10 +79,10 @@ local BY_NAME = {
 	{"tin", {roughness = 0.35, spec_strength = 0.8, bumpiness = 0.1}},
 	{"gold", {roughness = 0.30, spec_strength = 0.9, bumpiness = 0.1}},
 	{"snow", {roughness = 0.85, spec_strength = 0.35, bumpiness = 0.2,
-			static_spots = 0.30}},
+			static_spots = 0.06}},
 	{"sand", {roughness = 1.0, spec_strength = 0.15, bumpiness = 0.6,
-			static_spots = 0.20}},
-	{"ore", {static_spots = 0.20, spec_strength = 0.5, roughness = 0.6}},
+			static_spots = 0.04}},
+	{"ore", {static_spots = 0.05, spec_strength = 0.5, roughness = 0.6}},
 }
 
 local function copy(t)
@@ -106,7 +114,7 @@ function M.for_node(def)
 		-- A liquid's highlights move because the liquid does; lava is the one
 		-- that does not want them, and its name is what says so
 		out = copy({roughness = 0.25, spec_strength = 0.9, bumpiness = 0,
-				spots = 0.10})
+				spots = 0.05})
 	elseif drawtype == DRAWTYPE_PLANTLIKE or
 			drawtype == DRAWTYPE_PLANTLIKE_ROOTED or
 			drawtype == DRAWTYPE_ALLFACES or
@@ -114,12 +122,12 @@ function M.for_node(def)
 		-- Leaves and plants: lit from behind as much as from in front, which
 		-- is the whole of what makes a canopy read as a canopy
 		out = copy({roughness = 0.8, spec_strength = 0.25, bumpiness = 0.2,
-				translucency = 0.65, spots = 0.15})
+				translucency = 0.12, spots = 0.03})
 	elseif drawtype == DRAWTYPE_GLASSLIKE or
 			drawtype == DRAWTYPE_GLASSLIKE_FRAMED or
 			drawtype == DRAWTYPE_GLASSLIKE_FRAMED_OPTIONAL or blend then
 		out = copy({roughness = 0.10, spec_strength = 1.0, bumpiness = 0,
-				static_spots = 0.10})
+				static_spots = 0.03})
 	elseif group(def, "crumbly") > 0 then
 		-- Dirt, sand, gravel: matte, and rough enough that the texture's own
 		-- luminance is worth reading as relief
@@ -182,7 +190,7 @@ do
 	assert(water.spots > 0 and water.roughness < 0.4, "surface: water")
 	local leaves = M.for_node({name = "default:leaves", drawtype = 5,
 			waving = 2, groups = {snappy = 3}})
-	assert(leaves.translucency > 0.3, "surface: leaves")
+	assert(leaves.translucency > 0.05, "surface: leaves")
 	local dirt = M.for_node({name = "default:dirt", drawtype = 0,
 			groups = {crumbly = 3}})
 	assert(dirt.bumpiness > 0.5 and dirt.spec_strength < 0.2, "surface: dirt")

--- a/extensions/luanti_client/surface.lua
+++ b/extensions/luanti_client/surface.lua
@@ -1,0 +1,203 @@
+-- Buildat: extension/luanti_client/surface.lua
+-- http://www.apache.org/licenses/LICENSE-2.0
+-- Copyright 2026 Perttu Ahola <celeron55@gmail.com>
+--
+-- What a node's surface is made of, guessed from its definition.
+--
+-- The atlas derives a normal map and a spec map from six numbers per texture
+-- segment (see src/interface/atlas.h), and the PBR voxel shader reads them.
+-- Luanti says nothing about any of them: a node definition knows its drawtype,
+-- its groups and whether it waves, and that is what there is to go on. So this
+-- is a guess, and it is in a file of its own so that it can be argued with
+-- without touching the world.
+--
+-- The numbers:
+--   roughness      0 = mirror, 1 = chalk
+--   spec_strength  how much light the surface returns at all
+--   bumpiness      how much the texture's own luminance becomes relief
+--   translucency   how much light comes through from behind
+--   spots          animated sparkle: moving highlights, for water
+--   static_spots   the same but standing still: facets in sand, snow, ore
+--
+-- Not here: metalness. The spec map's four channels are full and cMetallic is
+-- per material, so metal nodes read as very glossy dielectrics.
+
+local M = {}
+
+-- Luanti's NodeDrawType; nodedef.lua has the whole list
+local DRAWTYPE_LIQUID = 2
+local DRAWTYPE_FLOWINGLIQUID = 3
+local DRAWTYPE_GLASSLIKE = 4
+local DRAWTYPE_ALLFACES = 5
+local DRAWTYPE_ALLFACES_OPTIONAL = 6
+local DRAWTYPE_PLANTLIKE = 9
+local DRAWTYPE_FIRELIKE = 14
+local DRAWTYPE_GLASSLIKE_FRAMED = 13
+local DRAWTYPE_GLASSLIKE_FRAMED_OPTIONAL = 15
+local DRAWTYPE_PLANTLIKE_ROOTED = 17
+
+local NODEDEF_ALPHAMODE_BLEND = 0
+
+-- What everything is before anything is known about it: a painted texture with
+-- a wide, weak highlight, which is what these textures are painted as
+local DEFAULT = {
+	roughness = 0.95,
+	spec_strength = 0.2,
+	bumpiness = 0.3,
+	translucency = 0,
+	spots = 0,
+	static_spots = 0,
+}
+
+-- A name that says what a node is made of when its groups do not. Games whose
+-- nodes carry no groups worth reading are common enough that this is worth the
+-- dozen patterns; the groups win where there are any.
+local BY_NAME = {
+	{"water", {roughness = 0.25, spec_strength = 0.9, bumpiness = 0,
+			spots = 0.10}},
+	{"lava", {roughness = 0.6, spec_strength = 0.3, bumpiness = 0.2}},
+	{"ice", {roughness = 0.10, spec_strength = 1.0, bumpiness = 0.1,
+			static_spots = 0.15}},
+	{"glass", {roughness = 0.10, spec_strength = 1.0, bumpiness = 0}},
+	{"crystal", {roughness = 0.15, spec_strength = 0.9, bumpiness = 0.1,
+			static_spots = 0.25}},
+	{"gem", {roughness = 0.15, spec_strength = 0.9, static_spots = 0.25}},
+	{"diamond", {roughness = 0.12, spec_strength = 1.0, static_spots = 0.3}},
+	{"mese", {roughness = 0.2, spec_strength = 0.8, static_spots = 0.25}},
+	{"metal", {roughness = 0.35, spec_strength = 0.8, bumpiness = 0.1}},
+	{"steel", {roughness = 0.35, spec_strength = 0.8, bumpiness = 0.1}},
+	{"copper", {roughness = 0.40, spec_strength = 0.7, bumpiness = 0.1}},
+	{"bronze", {roughness = 0.40, spec_strength = 0.7, bumpiness = 0.1}},
+	{"tin", {roughness = 0.35, spec_strength = 0.8, bumpiness = 0.1}},
+	{"gold", {roughness = 0.30, spec_strength = 0.9, bumpiness = 0.1}},
+	{"snow", {roughness = 0.85, spec_strength = 0.35, bumpiness = 0.2,
+			static_spots = 0.30}},
+	{"sand", {roughness = 1.0, spec_strength = 0.15, bumpiness = 0.6,
+			static_spots = 0.20}},
+	{"ore", {static_spots = 0.20, spec_strength = 0.5, roughness = 0.6}},
+}
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(DEFAULT) do
+		out[k] = v
+	end
+	for k, v in pairs(t or {}) do
+		out[k] = v
+	end
+	return out
+end
+
+local function group(def, name)
+	return (def.groups or {})[name] or 0
+end
+
+-- What a node's surface is: a table of the six numbers. def is what
+-- nodedef.parse() returned.
+function M.for_node(def)
+	if not def then
+		return copy(nil)
+	end
+	local drawtype = def.drawtype or 0
+	local blend = def.alpha_mode == NODEDEF_ALPHAMODE_BLEND
+	local out
+
+	if drawtype == DRAWTYPE_LIQUID or drawtype == DRAWTYPE_FLOWINGLIQUID then
+		-- A liquid's highlights move because the liquid does; lava is the one
+		-- that does not want them, and its name is what says so
+		out = copy({roughness = 0.25, spec_strength = 0.9, bumpiness = 0,
+				spots = 0.10})
+	elseif drawtype == DRAWTYPE_PLANTLIKE or
+			drawtype == DRAWTYPE_PLANTLIKE_ROOTED or
+			drawtype == DRAWTYPE_ALLFACES or
+			drawtype == DRAWTYPE_ALLFACES_OPTIONAL then
+		-- Leaves and plants: lit from behind as much as from in front, which
+		-- is the whole of what makes a canopy read as a canopy
+		out = copy({roughness = 0.8, spec_strength = 0.25, bumpiness = 0.2,
+				translucency = 0.65, spots = 0.15})
+	elseif drawtype == DRAWTYPE_GLASSLIKE or
+			drawtype == DRAWTYPE_GLASSLIKE_FRAMED or
+			drawtype == DRAWTYPE_GLASSLIKE_FRAMED_OPTIONAL or blend then
+		out = copy({roughness = 0.10, spec_strength = 1.0, bumpiness = 0,
+				static_spots = 0.10})
+	elseif group(def, "crumbly") > 0 then
+		-- Dirt, sand, gravel: matte, and rough enough that the texture's own
+		-- luminance is worth reading as relief
+		out = copy({roughness = 1.0, spec_strength = 0.1, bumpiness = 0.7})
+	elseif group(def, "cracky") > 0 then
+		out = copy({roughness = 0.7, spec_strength = 0.4, bumpiness = 0.35})
+	elseif group(def, "snappy") > 0 or group(def, "fleshy") > 0 then
+		out = copy({roughness = 1.0, spec_strength = 0.05, bumpiness = 0.15})
+	elseif group(def, "choppy") > 0 then
+		-- Wood: a little sheen along the grain, and the grain itself
+		out = copy({roughness = 0.85, spec_strength = 0.2, bumpiness = 0.4})
+	else
+		out = copy(nil)
+	end
+
+	-- A name that says what it is overrides what its drawtype guessed, because
+	-- "stone with an ore in it" and "stone" are the same drawtype and the same
+	-- group and are not the same surface. Liquids keep what the drawtype gave
+	-- them apart from lava, which is why this runs after and not before.
+	local name = def.name or ""
+	for _, entry in ipairs(BY_NAME) do
+		if string.find(name, entry[1], 1, true) then
+			for k, v in pairs(entry[2]) do
+				out[k] = v
+			end
+			break
+		end
+	end
+
+	-- Something that gives off light is lit by itself and not by the sun, and
+	-- a highlight crawling over a torch reads as a mistake
+	if (def.light_source or 0) > 0 then
+		out.spots = 0
+		out.static_spots = 0
+		out.spec_strength = math.min(out.spec_strength, 0.1)
+	end
+
+	-- What waves is moving, so its sparkle moves with it; what does not, does
+	-- not. waving is 1 for plants and 2 for leaves.
+	if (def.waving or 0) == 0 and out.spots > 0 and
+			drawtype ~= DRAWTYPE_LIQUID and
+			drawtype ~= DRAWTYPE_FLOWINGLIQUID then
+		out.static_spots = math.max(out.static_spots, out.spots)
+		out.spots = 0
+	end
+
+	-- Fire is drawn as light, not as a surface
+	if drawtype == DRAWTYPE_FIRELIKE then
+		out.spec_strength = 0
+		out.spots = 0
+		out.static_spots = 0
+	end
+	return out
+end
+
+-- What the guessing has to hold, checked at load: the cases the table above is
+-- written for actually come out of it.
+do
+	local water = M.for_node({name = "default:water_source", drawtype = 2})
+	assert(water.spots > 0 and water.roughness < 0.4, "surface: water")
+	local leaves = M.for_node({name = "default:leaves", drawtype = 5,
+			waving = 2, groups = {snappy = 3}})
+	assert(leaves.translucency > 0.3, "surface: leaves")
+	local dirt = M.for_node({name = "default:dirt", drawtype = 0,
+			groups = {crumbly = 3}})
+	assert(dirt.bumpiness > 0.5 and dirt.spec_strength < 0.2, "surface: dirt")
+	local sand = M.for_node({name = "default:sand", drawtype = 0,
+			groups = {crumbly = 3}})
+	assert(sand.static_spots > 0, "surface: sand")
+	local torch = M.for_node({name = "default:torch", drawtype = 7,
+			light_source = 14})
+	assert(torch.static_spots == 0 and torch.spots == 0, "surface: torch")
+	local glass = M.for_node({name = "default:glass", drawtype = 4})
+	assert(glass.roughness < 0.2 and glass.spec_strength > 0.9,
+			"surface: glass")
+	local plain = M.for_node(nil)
+	assert(plain.roughness == 0.95 and plain.spots == 0, "surface: default")
+end
+
+return M
+-- vim: set noet ts=4 sw=4:

--- a/extensions/luanti_client/test.lua
+++ b/extensions/luanti_client/test.lua
@@ -28,6 +28,9 @@ local serialize = dofile(dir.."/serialize.lua")
 local connection = dofile(dir.."/connection.lua")
 local player = dofile(dir.."/player.lua")
 local texmod = dofile(dir.."/texmod.lua")
+-- Its own checks run when it loads; loading it here is what runs them outside
+-- a client
+dofile(dir.."/surface.lua")
 local inventory = dofile(dir.."/inventory.lua")
 local formspec = dofile(dir.."/formspec.lua")
 local objects = dofile(dir.."/objects.lua")

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -2308,9 +2308,31 @@ function M.new(magic, buildat, log, options)
 	-- entities of this game are drawn unlit in Luanti's own client too, and
 	-- their textures are full of holes -- so what stands in for the light is
 	-- a colour the shader multiplies the texture by, worked out the same way
-	-- the mesher works out a face's ambient: the sunlight colour times how
-	-- much of the sky the voxel the object is in sees, plus its lamplight.
-	-- Without this a mob is as bright at midnight as at noon.
+	-- the voxel around it is lit. Without this a mob is as bright at midnight
+	-- as at noon.
+	--
+	-- Which way that is worked out depends on the path, because the two light
+	-- a voxel differently and an object beside one has to agree with it. The
+	-- vanilla path bakes the sunlight colour into the vertices and that is
+	-- all there is; the PBR path has a sky for an ambient and a sun of its
+	-- own on top, so an object gets both. There is no normal to take a real
+	-- share of the sun by -- that is what unlit means -- so it gets a fixed
+	-- one, which is what a thing standing in the sun shows on average.
+	-- How much of the sun an object shows. One number has to serve for both
+	-- a mob in the open and one under a tree, because an unlit thing has no
+	-- normal to shadow: measured on the ground it stands on, sunlit grass
+	-- renders at about twelve times the same grass in a shadow, and what is
+	-- picked here lands an object between the two. It is the number to move
+	-- if mobs read as glowing in a wood or as cut out in a field.
+	local OBJECT_SUN = 1.0
+	-- What something in the pitch dark is worth, so that it is a silhouette
+	-- rather than nothing. Small, because the ambient it is added to is small
+	-- at night and a mob that glows is worse than one that is hard to see.
+	local OBJECT_DARK_FLOOR = 0.01
+	-- What the sun is worth to an object now: its colour and how much of it
+	-- there is, kept by apply_daylight() because that is where it is known
+	local object_sun = nil
+
 	local function object_color(x, y, z)
 		local p1 = param1_at(math.floor(x + 0.5), math.floor(y + 0.5),
 				math.floor(z + 0.5))
@@ -2321,9 +2343,26 @@ function M.new(magic, buildat, log, options)
 		local night = math.floor(p1 / 16)
 		local sky = (day > night and day - night or 0) / 15
 		local lamp = night / 15
-		local sun = sunlight_color(daylight)
 		-- A floor of a few percent, so that something in the pitch dark is a
 		-- silhouette rather than nothing at all
+		if pbr then
+			local amb = zone.ambientColor
+			local sun = object_sun
+			local sr, sg, sb = 0, 0, 0
+			if sun then
+				sr = sun.r * sun.a * OBJECT_SUN
+				sg = sun.g * sun.a * OBJECT_SUN
+				sb = sun.b * sun.a * OBJECT_SUN
+			end
+			-- Not clipped at one: the frame is tone mapped and a voxel in
+			-- the sun is well past it, so an object beside one has to be able
+			-- to be as well
+			return magic.Color(
+					(amb.r + sr) * sky + lamp + OBJECT_DARK_FLOOR,
+					(amb.g + sg) * sky + lamp + OBJECT_DARK_FLOOR,
+					(amb.b + sb) * sky + lamp + OBJECT_DARK_FLOOR)
+		end
+		local sun = sunlight_color(daylight)
 		return magic.Color(
 				math.min(1, sun.r * sky + lamp + 0.03),
 				math.min(1, sun.g * sky + lamp + 0.03),
@@ -3830,10 +3869,11 @@ function M.new(magic, buildat, log, options)
 			local up = sun_amount(daylight_time) * above_horizon(smooth_sy) *
 					through_cloud * body_is_up(sky_bodies.sun)
 			sun_node.enabled = up > 0
+			local sun_color = sun_light_color(daylight_time)
 			if up > 0 then
 				sun_node.direction = magic.Vector3(-sx, -sy, -sz)
 				sun_light.brightness = SUN_BRIGHTNESS * up
-				sun_light.color = sun_light_color(daylight_time)
+				sun_light.color = sun_color
 			end
 			local moon_up = moon_amount(daylight_time) *
 					above_horizon(-smooth_sy) * through_cloud *
@@ -3843,6 +3883,12 @@ function M.new(magic, buildat, log, options)
 				moon_node.direction = magic.Vector3(sx, sy, sz)
 				moon_light.brightness = MOON_BRIGHTNESS * moon_up
 			end
+			-- What the two are worth to something drawn unlit, which has no
+			-- normal to take a share of them by: the colour of whichever is
+			-- up, and in the alpha how much of it there is, the moon counted
+			-- at what it is worth against the sun
+			object_sun = magic.Color(sun_color.r, sun_color.g, sun_color.b,
+					up + moon_up * MOON_BRIGHTNESS / SUN_BRIGHTNESS)
 		end
 
 		if sky_material then

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -3526,6 +3526,16 @@ function M.new(magic, buildat, log, options)
 				clouds.color_bright)
 	end
 
+	-- A game that hides a body has said the plainest thing it can say about
+	-- it: VoxeLibre turns the sun, the moon and the stars off together when
+	-- the weather turns, before it darkens a single colour, and a dimension
+	-- with no sky turns them off for good. Something that cannot be seen
+	-- casts no light, so this is a gate rather than a dimming; what is left
+	-- is the sky, which is what an overcast day is lit by.
+	local function body_is_up(body)
+		return (body and body.visible ~= false) and 1 or 0
+	end
+
 	-- What the sun shines with now: its own colour, going the colour of the
 	-- horizon as it comes down to it, which is the handover the sky shader
 	-- does to the disc. Zero at night, when the light left is the sky's.
@@ -3625,7 +3635,7 @@ function M.new(magic, buildat, log, options)
 			local sx, sy, sz = sun_direction(daylight_time)
 			local through_cloud = 1 - CLOUD_DIM * cloud_cover()
 			local up = sun_amount(daylight_time) * above_horizon(sy) *
-					through_cloud
+					through_cloud * body_is_up(sky_bodies.sun)
 			sun_node.enabled = up > 0
 			if up > 0 then
 				sun_node.direction = magic.Vector3(-sx, -sy, -sz)
@@ -3633,7 +3643,7 @@ function M.new(magic, buildat, log, options)
 				sun_light.color = sun_light_color(daylight_time)
 			end
 			local moon_up = moon_amount(daylight_time) * above_horizon(-sy) *
-					through_cloud
+					through_cloud * body_is_up(sky_bodies.moon)
 			moon_node.enabled = moon_up > 0
 			if moon_up > 0 then
 				moon_node.direction = magic.Vector3(sx, sy, sz)

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -572,9 +572,12 @@ function M.new(magic, buildat, log, options)
 	-- light that switches off in one frame is a light that pops.
 	local HORIZON_FADE = 0.05    -- sine of the angle, so about three degrees
 
+	local function clamp01(v)
+		return v < 0 and 0 or (v > 1 and 1 or v)
+	end
+
 	local function above_horizon(sine_of_elevation)
-		local t = sine_of_elevation / HORIZON_FADE
-		return t < 0 and 0 or (t > 1 and 1 or t)
+		return clamp01(sine_of_elevation / HORIZON_FADE)
 	end
 
 	-- 0 before the rise, 1 between the rise and the set, 0 after it, and the
@@ -3464,6 +3467,65 @@ function M.new(magic, buildat, log, options)
 		return factor ^ 2.2
 	end
 
+	-- How much of the sun and the moon the clouds keep. A directional light
+	-- does not know there is a layer of cloud between it and the ground; the
+	-- ambient does, because a game darkens the sky colours it sends when the
+	-- weather turns, and only the direct light is left saying it is a clear
+	-- day.
+	--
+	-- Two things say overcast and a game uses one or the other. Density is
+	-- how much of the sky is cloud, and 0.4 is what every game gets whether
+	-- or not it asks, so only what is above that is weather. The other is the
+	-- colour: VoxeLibre never touches the density and says it with the cloud
+	-- colour instead, #FFF0F0 for a clear sky against #5D5D5F for rain and
+	-- #3D3D3F for a thunderstorm. Reading both is what makes this work on a
+	-- game that has not been looked at.
+	local CLOUD_DIM = 0.8          -- what a full overcast takes from the sun
+	local CLOUD_SHADE_GAIN = 1.3   -- a cloud need not be black to be opaque
+
+	local function cloud_cover_of(density, color_bright)
+		-- Whether there is a layer there at all, which is what the colour
+		-- has to be weighed by: a black cloud that covers nothing shades
+		-- nothing
+		local have = clamp01(density / CLOUD_DENSITY_DEFAULT)
+		local dense = clamp01((density - CLOUD_DENSITY_DEFAULT) /
+				(1 - CLOUD_DENSITY_DEFAULT))
+		local shade = 0
+		local c = color_bright
+		if c then
+			local luma = (0.2126 * c[1] + 0.7152 * c[2] + 0.0722 * c[3]) / 255
+			shade = clamp01((1 - luma) * CLOUD_SHADE_GAIN * have)
+		end
+		-- Two ways of covering the sky, neither of which excuses the other
+		return 1 - (1 - dense) * (1 - shade)
+	end
+
+	-- What the weather has to come out as, checked at load against what a
+	-- VoxeLibre server actually sends: it leaves the density at Luanti's own
+	-- 0.4 throughout and says the weather in the colour alone.
+	do
+		local clear = cloud_cover_of(0.4, {255, 240, 240})
+		local rain = cloud_cover_of(0.4, {93, 93, 95})
+		local thunder = cloud_cover_of(0.4, {61, 61, 63})
+		assert(clear < 0.1, "a clear sky keeps the sun")
+		assert(rain > 0.6 and rain < thunder, "rain takes most of it")
+		assert(thunder > 0.9, "a thunderstorm takes nearly all of it")
+		-- And a game that says it the other way, with the density
+		assert(cloud_cover_of(1.0, {255, 255, 255}) > 0.9,
+				"a sky full of cloud covers it whatever colour the cloud is")
+		assert(cloud_cover_of(0.0, {0, 0, 0}) == 0,
+				"a cloud that is not there covers nothing")
+	end
+
+	local function cloud_cover()
+		if sky and sky.clouds == false then
+			return 0
+		end
+		local clouds = sky_bodies.clouds or {}
+		return cloud_cover_of(clouds.density or CLOUD_DENSITY_DEFAULT,
+				clouds.color_bright)
+	end
+
 	-- What the sun shines with now: its own colour, going the colour of the
 	-- horizon as it comes down to it, which is the handover the sky shader
 	-- does to the disc. Zero at night, when the light left is the sky's.
@@ -3561,14 +3623,17 @@ function M.new(magic, buildat, log, options)
 			-- everything and puts the night's sparkle on the wrong side of
 			-- the sky.
 			local sx, sy, sz = sun_direction(daylight_time)
-			local up = sun_amount(daylight_time) * above_horizon(sy)
+			local through_cloud = 1 - CLOUD_DIM * cloud_cover()
+			local up = sun_amount(daylight_time) * above_horizon(sy) *
+					through_cloud
 			sun_node.enabled = up > 0
 			if up > 0 then
 				sun_node.direction = magic.Vector3(-sx, -sy, -sz)
 				sun_light.brightness = SUN_BRIGHTNESS * up
 				sun_light.color = sun_light_color(daylight_time)
 			end
-			local moon_up = moon_amount(daylight_time) * above_horizon(-sy)
+			local moon_up = moon_amount(daylight_time) * above_horizon(-sy) *
+					through_cloud
 			moon_node.enabled = moon_up > 0
 			if moon_up > 0 then
 				moon_node.direction = magic.Vector3(sx, sy, sz)

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -565,6 +565,18 @@ function M.new(magic, buildat, log, options)
 	local MOON_FADE_IN = 18500   -- and comes back from here
 	local MOON_IN = 19500        -- to full here
 
+	-- Nothing above the horizon shines from under it. The clocks above are
+	-- where the fade is shaped; this is the line itself, taken from where the
+	-- body actually is, so that neither can light the undersides of the world
+	-- whatever the clock says. A couple of degrees of softness, because a
+	-- light that switches off in one frame is a light that pops.
+	local HORIZON_FADE = 0.05    -- sine of the angle, so about three degrees
+
+	local function above_horizon(sine_of_elevation)
+		local t = sine_of_elevation / HORIZON_FADE
+		return t < 0 and 0 or (t > 1 and 1 or t)
+	end
+
 	-- 0 before the rise, 1 between the rise and the set, 0 after it, and the
 	-- way across each ramp in between
 	local function up_between(time_of_day, rise_from, rise_to,
@@ -596,6 +608,8 @@ function M.new(magic, buildat, log, options)
 	-- sky empty between them, and the moon is out of the way by the time the
 	-- sun is worth anything.
 	do
+		assert(above_horizon(-1) == 0 and above_horizon(0) == 0 and
+				above_horizon(1) == 1, "the horizon line")
 		assert(sun_amount(12000) == 1 and moon_amount(12000) == 0, "noon")
 		assert(sun_amount(0) == 0 and moon_amount(0) == 1, "midnight")
 		assert(moon_amount(SUN_RISE) > 0.4, "the moon is still up at sunrise")
@@ -3465,6 +3479,21 @@ function M.new(magic, buildat, log, options)
 				SUN_COLOR[3] * (1 - low) + tint.b * low)
 	end
 
+	-- That the clock and the horizon agree, checked here rather than where
+	-- the clocks are written because sun_direction() is defined between the
+	-- two: the sun's ramp begins where the sun is level with the horizon and
+	-- ends where it is level again, so neither rule has to fight the other.
+	do
+		local function elevation(t)
+			local _, sy = sun_direction(t)
+			return sy
+		end
+		assert(math.abs(elevation(SUN_RISE)) < 0.02, "the sun rises at 05:00")
+		assert(math.abs(elevation(SUN_DOWN)) < 0.02, "the sun sets at 19:00")
+		assert(elevation(12000) > 0.9, "the sun is overhead at noon")
+		assert(elevation(0) < -0.9, "the sun is under the world at midnight")
+	end
+
 	function self:set_daylight(factor, time_of_day)
 		daylight = factor
 		daylight_time = time_of_day or daylight_time
@@ -3532,14 +3561,14 @@ function M.new(magic, buildat, log, options)
 			-- everything and puts the night's sparkle on the wrong side of
 			-- the sky.
 			local sx, sy, sz = sun_direction(daylight_time)
-			local up = sun_amount(daylight_time)
+			local up = sun_amount(daylight_time) * above_horizon(sy)
 			sun_node.enabled = up > 0
 			if up > 0 then
 				sun_node.direction = magic.Vector3(-sx, -sy, -sz)
 				sun_light.brightness = SUN_BRIGHTNESS * up
 				sun_light.color = sun_light_color(daylight_time)
 			end
-			local moon_up = moon_amount(daylight_time)
+			local moon_up = moon_amount(daylight_time) * above_horizon(-sy)
 			moon_node.enabled = moon_up > 0
 			if moon_up > 0 then
 				moon_node.direction = magic.Vector3(sx, sy, sz)

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -579,6 +579,16 @@ function M.new(magic, buildat, log, options)
 		return v < 0 and 0 or (v > 1 and 1 or v)
 	end
 
+	-- 0 below low, 1 above high, and a smooth ride between them
+	local function smoothstep01(v, low, high)
+		local t = clamp01((v - low) / (high - low))
+		return t * t * (3 - 2 * t)
+	end
+
+	local function luminance(rgb)
+		return 0.2126 * rgb[1] + 0.7152 * rgb[2] + 0.0722 * rgb[3]
+	end
+
 	local function above_horizon(sine_of_elevation)
 		return clamp01(sine_of_elevation / HORIZON_FADE)
 	end
@@ -3492,6 +3502,12 @@ function M.new(magic, buildat, log, options)
 	-- lit by nothing else and the sun is lighting it from below, where the
 	-- ground is lit by the sky as well.
 	local CLOUD_SUN_TINT = 0.75
+	-- How far past white a cloud in full sun is drawn, and the band of the
+	-- game's own cloud colour over which that is given: a white cloud gets
+	-- all of it, a rain cloud none, and nothing in between jumps
+	local CLOUD_DAY_GAIN = 2.0
+	local CLOUD_WHITE_LOW = 0.5
+	local CLOUD_WHITE_HIGH = 0.9
 
 	-- One of the game's colours, or Luanti's default for it, as 0...1
 	local function sky_color(name, brightness)
@@ -3559,6 +3575,18 @@ function M.new(magic, buildat, log, options)
 				"a sky full of cloud covers it whatever colour the cloud is")
 		assert(cloud_cover_of(0.0, {0, 0, 0}) == 0,
 				"a cloud that is not there covers nothing")
+
+		-- And which of those the sun is allowed to whiten
+		local function white_of(c)
+			return smoothstep01(luminance({c[1] / 255, c[2] / 255,
+					c[3] / 255}), CLOUD_WHITE_LOW, CLOUD_WHITE_HIGH)
+		end
+		assert(white_of({255, 240, 240}) == 1, "a white cloud takes the sun")
+		assert(white_of({93, 93, 95}) == 0, "a rain cloud is left grey")
+		assert(white_of({61, 61, 63}) == 0, "and a thunderhead darker still")
+		assert(white_of({173, 173, 173}) > 0.1 and
+				white_of({173, 173, 173}) < 0.9,
+				"and what is between them is between them")
 	end
 
 	local function cloud_cover()
@@ -3720,20 +3748,38 @@ function M.new(magic, buildat, log, options)
 			-- sunrise a sunrise rather than a sky that has got brighter.
 			local sun_now = sun_light_color(daylight_time)
 			local lit = low_sun(daylight_time) * CLOUD_SUN_TINT
-			local function cloud_channel(own, from_sun)
-				return (own * (1 - lit) + from_sun * lit) * brightness
-			end
 			local cloud = sky_bodies.clouds.color_bright
+			local own = cloud and
+					{cloud[1] / 255, cloud[2] / 255, cloud[3] / 255} or
+					{0.9, 0.92, 0.95}
+			-- A cloud in the sun is not a light grey thing, it is a white
+			-- one, and on the PBR path the tone curve is between it and the
+			-- screen: a colour that arrives at one leaves it at about nine
+			-- tenths and reads as grey. So it is given some room to be
+			-- clipped out of, while the sun is up to do it -- ramped with the
+			-- sun's own hour at each end of the day -- and only as far as the
+			-- game's own colour says it is a white cloud. A game that wants
+			-- grey clouds, which is how VoxeLibre says it is raining, is
+			-- taken at its word and left alone.
+			local day = pbr and sun_amount(daylight_time) * above_horizon(sy) *
+					body_is_up(sky_bodies.sun) or 0
+			local white = smoothstep01(luminance(own), CLOUD_WHITE_LOW,
+					CLOUD_WHITE_HIGH)
+			local gain = 1 + (CLOUD_DAY_GAIN - 1) * day * white
+			local function cloud_channel(i, from_sun)
+				return (own[i] * (1 - lit) + from_sun * lit) *
+						brightness * gain
+			end
 			if cloud then
 				sky_material:SetShaderParameter("CloudColor", magic.Color(
-						cloud_channel(cloud[1] / 255, sun_now.r),
-						cloud_channel(cloud[2] / 255, sun_now.g),
-						cloud_channel(cloud[3] / 255, sun_now.b)))
+						cloud_channel(1, sun_now.r),
+						cloud_channel(2, sun_now.g),
+						cloud_channel(3, sun_now.b)))
 			else
 				sky_material:SetShaderParameter("CloudColor", magic.Color(
-						cloud_channel(0.9, sun_now.r) + 0.05,
-						cloud_channel(0.92, sun_now.g) + 0.05,
-						cloud_channel(0.95, sun_now.b) + 0.06))
+						cloud_channel(1, sun_now.r) + 0.05,
+						cloud_channel(2, sun_now.g) + 0.05,
+						cloud_channel(3, sun_now.b) + 0.06))
 			end
 			-- The stars come out as the sky goes dark, and a game can say
 			-- they are out in the day as well

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -612,6 +612,23 @@ function M.new(magic, buildat, log, options)
 		return up_between(time_of_day, SUN_RISE, SUN_UP, SUN_SET, SUN_DOWN)
 	end
 
+	-- Where the sun is for the purpose of casting a shadow, which is not
+	-- quite where it is. A shadow map is rasterized afresh every frame, and a
+	-- light that has turned a little between two of them rasterizes it
+	-- differently, so the edges crawl -- which is what a sun that moves as
+	-- smoothly as this one now does made visible. Holding the direction still
+	-- for a step at a time trades the crawl for a small jump, which is far
+	-- easier not to see. The step is in Luanti's own units of the day, so it
+	-- is a fixed angle of sun however fast the game's clock runs: a hundred
+	-- of them is a degree and a half, and about five seconds at Luanti's own
+	-- default speed.
+	local SUN_STEP = 100
+
+	local function stepped_time(time_of_day)
+		local t = time_of_day or 12000
+		return math.floor(t / SUN_STEP + 0.5) * SUN_STEP
+	end
+
 	-- The half hour either side of the sun crossing the horizon, at each end
 	-- of the day, as 0 outside and 1 at the crossing itself. This is the
 	-- window dawn and dusk happen in: what the sun is red in, and what the
@@ -3505,7 +3522,10 @@ function M.new(magic, buildat, log, options)
 	-- How far past white a cloud in full sun is drawn, and the band of the
 	-- game's own cloud colour over which that is given: a white cloud gets
 	-- all of it, a rain cloud none, and nothing in between jumps
-	local CLOUD_DAY_GAIN = 2.0
+	-- Enough room to come out white rather than grey, and not so much that a
+	-- cloud is as bright as the sun is: the disc is drawn at six times its
+	-- colour, and after the tone curve this lands about a tenth under it
+	local CLOUD_DAY_GAIN = 1.4
 	local CLOUD_WHITE_LOW = 0.5
 	local CLOUD_WHITE_HIGH = 0.9
 
@@ -3787,9 +3807,13 @@ function M.new(magic, buildat, log, options)
 			-- about the horizon, and one below it lights the undersides of
 			-- everything and puts the night's sparkle on the wrong side of
 			-- the sky.
-			local sx, sy, sz = sun_direction(daylight_time)
+			-- Where they are is stepped; whether they are up, how bright
+			-- and what colour is not, so nothing about the light itself
+			-- steps, only the direction the shadow is cast from
+			local sx, sy, sz = sun_direction(stepped_time(daylight_time))
+			local _, smooth_sy = sun_direction(daylight_time)
 			local through_cloud = 1 - CLOUD_DIM * cloud_cover()
-			local up = sun_amount(daylight_time) * above_horizon(sy) *
+			local up = sun_amount(daylight_time) * above_horizon(smooth_sy) *
 					through_cloud * body_is_up(sky_bodies.sun)
 			sun_node.enabled = up > 0
 			if up > 0 then
@@ -3797,8 +3821,9 @@ function M.new(magic, buildat, log, options)
 				sun_light.brightness = SUN_BRIGHTNESS * up
 				sun_light.color = sun_light_color(daylight_time)
 			end
-			local moon_up = moon_amount(daylight_time) * above_horizon(-sy) *
-					through_cloud * body_is_up(sky_bodies.moon)
+			local moon_up = moon_amount(daylight_time) *
+					above_horizon(-smooth_sy) * through_cloud *
+					body_is_up(sky_bodies.moon)
 			moon_node.enabled = moon_up > 0
 			if moon_up > 0 then
 				moon_node.direction = magic.Vector3(sx, sy, sz)

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -688,14 +688,27 @@ function M.new(magic, buildat, log, options)
 	-- overhead -- so what reaches it is far less blue than what is up there.
 	local AMBIENT_DESATURATE = 0.55
 	local AMBIENT_FROM_SKY = 0.6
+	-- And a floor under it while the sun is down. The sky is the only ambient
+	-- there is on this path, and a game's night sky can be black -- VoxeLibre
+	-- paints one -- which leaves a moon shadow with nothing in it at all now
+	-- that the moon casts one. This is what is in it: the moon's own cold
+	-- colour, at little enough that what the moon lights is still brighter
+	-- than what it does not.
+	local AMBIENT_NIGHT_FLOOR = 0.015
+	local AMBIENT_NIGHT_COLOR = {0.55, 0.68, 1.0}
 
-	local function ambient_from_sky(sky)
+	-- night is 1 while the sun is down and 0 while it is up, across its own
+	-- hour at each end
+	local function ambient_from_sky(sky, night)
 		local luma = 0.2126 * sky.r + 0.7152 * sky.g + 0.0722 * sky.b
 		local k = AMBIENT_DESATURATE
-		return magic.Color(
-				(sky.r * (1 - k) + luma * k) * AMBIENT_FROM_SKY,
-				(sky.g * (1 - k) + luma * k) * AMBIENT_FROM_SKY,
-				(sky.b * (1 - k) + luma * k) * AMBIENT_FROM_SKY)
+		local floor = AMBIENT_NIGHT_FLOOR * (night or 0)
+		local function channel(v, i)
+			return math.max((v * (1 - k) + luma * k) * AMBIENT_FROM_SKY,
+					AMBIENT_NIGHT_COLOR[i] * floor)
+		end
+		return magic.Color(channel(sky.r, 1), channel(sky.g, 2),
+				channel(sky.b, 3))
 	end
 	local sun_node = nil
 	local sun_light = nil
@@ -3787,7 +3800,8 @@ function M.new(magic, buildat, log, options)
 		-- cave is only the warm rgb the torches baked in. That is the three
 		-- tints -- sun, shade, cave -- and it costs this one line.
 		if pbr then
-			zone.ambientColor = ambient_from_sky(top)
+			zone.ambientColor = ambient_from_sky(top,
+					1 - sun_amount(daylight_time))
 		end
 
 		-- What the PBR path's reflections are worth now: the cube map beside

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -523,23 +523,25 @@ function M.new(magic, buildat, log, options)
 	local SHADOW_NEAR = 24    -- nodes; the first cascade
 	local SHADOW_FAR = 96     -- and the second, which is the shadow distance
 	-- What a lit face gets from the sun, against the sky as the ambient. The
-	-- number is large because Urho's PBR divides direct light by pi, the
-	-- albedo it multiplies is well under 1, and nothing tone maps afterwards:
-	-- measured on a grass field, a brightness of 6 put about as much light on
-	-- a lit face as the ambient already had, which is a sun nobody can see
-	-- and a shadow nobody can see either. This lands a lit face at about two
-	-- and a half times a shadowed one.
-	local SUN_BRIGHTNESS = 18.0
+	-- number is large because Urho's PBR direct lighting is normalized -- the
+	-- BRDF is divided by pi and so is the diffuse term inside it -- and
+	-- because the frame is tone mapped, so a sun well past white is what
+	-- white is for. games/voxel_lighting arrived at the same number for the
+	-- same reasons.
+	local SUN_BRIGHTNESS = 50.0
+	-- How far past the tone curve's middle the frame is exposed
+	local TONEMAP_EXPOSURE = 1.6
+	-- What the sun's disc is drawn at, in the same units: well past white, so
+	-- that the tone curve leaves it white and the bloom finds it
+	local SUN_DISC_OVEREXPOSURE = 6.0
 
 	-- What the sky is worth as a light, against that. Two numbers, because
 	-- the sky's own colour is the wrong one to light a world with: it is the
 	-- colour of the zenith, and a surface sees the whole dome -- the pale
 	-- band along the horizon and the glare around the sun as much as the blue
 	-- overhead -- so what reaches it is far less blue than what is up there.
-	-- And at full strength the sky puts nearly as much light on a sunlit face
-	-- as the sun does, which reads as a world under water.
 	local AMBIENT_DESATURATE = 0.55
-	local AMBIENT_FROM_SKY = 0.7
+	local AMBIENT_FROM_SKY = 0.6
 
 	local function ambient_from_sky(sky)
 		local luma = 0.2126 * sky.r + 0.7152 * sky.g + 0.0722 * sky.b
@@ -663,6 +665,33 @@ function M.new(magic, buildat, log, options)
 	local viewport = magic.Viewport:new(scene, camera)
 	self.viewport = viewport
 	magic.renderer:SetViewport(0, viewport)
+
+	-- On the PBR path the frame is rendered in HDR and tone mapped, the way
+	-- games/voxel_lighting does it. Nothing else makes the sun read as the
+	-- sun: in a frame that clips at one, a sun strong enough to put a real
+	-- shadow on the ground flattens every lit surface to white, and one weak
+	-- enough not to do that is a sun whose colour and whose shadow are both
+	-- invisible under the sky's. With the curve in, the sun can be fifty
+	-- times the sky, which is about what it is, and what a lit surface gets
+	-- is the sun's own colour rather than a mixture with the sky's; the same
+	-- curve lifts the shadows, so a shadow under full skylight reads as shade
+	-- rather than as a hole.
+	if pbr then
+		magic.renderer.HDRRendering = true
+		local rp = viewport.renderPath:Clone()
+		rp:Append(magic.cache:GetResource("XMLFile",
+				"PostProcess/BloomHDR.xml"))
+		rp:Append(magic.cache:GetResource("XMLFile",
+				"PostProcess/Tonemap.xml"))
+		rp:Append(magic.cache:GetResource("XMLFile",
+				"PostProcess/GammaCorrection.xml"))
+		-- Tonemap.xml ships with Reinhard on; Uncharted2 keeps more contrast
+		-- in the shadows, which on a world lit by one sun is most of it
+		rp:SetEnabled("TonemapReinhardEq3", false)
+		rp:SetEnabled("TonemapUncharted2", true)
+		rp:SetShaderParameter("TonemapExposureBias", TONEMAP_EXPOSURE)
+		viewport.renderPath = rp
+	end
 
 	-- The sounds the server asked for. A sound at a position is a node in
 	-- the scene and the listener rides the camera, which is what makes it
@@ -3307,7 +3336,7 @@ function M.new(magic, buildat, log, options)
 	-- because together is the only way Luanti has them; on the PBR path the
 	-- sky is a light of its own, so what is left for the sun is what the sun
 	-- is. The same numbers res/LuantiSky.glsl draws the disc with.
-	local SUN_COLOR = {1.0, 0.97, 0.86}
+	local SUN_COLOR = {1.0, 0.92, 0.78}
 
 	-- One of the game's colours, or Luanti's default for it, as 0...1
 	local function sky_color(name, brightness)
@@ -3461,6 +3490,12 @@ function M.new(magic, buildat, log, options)
 					sun_texture and 1 or 0)
 			sky_material:SetShaderParameter("MoonTextured",
 					moon_texture and 1 or 0)
+			-- How far past white the disc is drawn. On the PBR path the
+			-- frame is tone mapped, so this is a real multiplier and what
+			-- the bloom around the sun comes from; on the vanilla path the
+			-- frame clips at one and a little past it is all that is wanted.
+			sky_material:SetShaderParameter("SunOverexposure",
+					pbr and SUN_DISC_OVEREXPOSURE or 1.5)
 			sky_material:SetShaderParameter("SunSize",
 					sun.visible and SUN_HALF * (sun.scale or 1) or 0)
 			sky_material:SetShaderParameter("MoonSize",
@@ -3980,6 +4015,10 @@ function M.new(magic, buildat, log, options)
 		-- Dropping the viewport rather than replacing it: there is nothing
 		-- else to show, and SetViewport() takes no nil
 		magic.renderer.numViewports = 0
+		-- HDR and the render path are the renderer's, not the viewport's, so
+		-- a world that has gone has to hand them back or the menu after it is
+		-- drawn through a tone curve with nothing to tone map
+		magic.renderer.HDRRendering = false
 	end
 
 	function self:block_count()

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -535,6 +535,38 @@ function M.new(magic, buildat, log, options)
 	-- that the tone curve leaves it white and the bloom finds it
 	local SUN_DISC_OVEREXPOSURE = 6.0
 
+	-- What the moon is worth, in the same units. Not a measurement of
+	-- anything -- real moonlight is a millionth of sunlight and would render
+	-- as nothing -- but a night that is lit from where the moon is, dimly and
+	-- coldly, rather than one that is lit from under the world by a sun that
+	-- has set.
+	local MOON_BRIGHTNESS = 1.0
+	local MOON_COLOR = {0.55, 0.68, 1.0}
+
+	-- When the sun is in the scene and when the moon is, in Luanti's
+	-- 0...24000. Below the horizon a directional light shines up through the
+	-- world, and its specular -- the sparkle surface.lua asks for on water,
+	-- on snow and on ore -- is then the brightest thing in a night frame and
+	-- is coming from the wrong side of the sky. So the sun is taken out of
+	-- the scene for the night and the moon is put in, each fading over the
+	-- hour on either side of when the sun is level with the horizon.
+	local SUN_RISE = 5000     -- nothing before this
+	local SUN_UP = 6000       -- full sun from here
+	local SUN_SET = 18000     -- full sun until here
+	local SUN_DOWN = 19000    -- nothing after this
+
+	local function sun_amount(time_of_day)
+		local t = (time_of_day or 12000) % 24000
+		if t <= SUN_RISE or t >= SUN_DOWN then
+			return 0
+		elseif t < SUN_UP then
+			return (t - SUN_RISE) / (SUN_UP - SUN_RISE)
+		elseif t <= SUN_SET then
+			return 1
+		end
+		return (SUN_DOWN - t) / (SUN_DOWN - SUN_SET)
+	end
+
 	-- What the sky is worth as a light, against that. Two numbers, because
 	-- the sky's own colour is the wrong one to light a world with: it is the
 	-- colour of the zenith, and a surface sees the whole dome -- the pale
@@ -553,6 +585,8 @@ function M.new(magic, buildat, log, options)
 	end
 	local sun_node = nil
 	local sun_light = nil
+	local moon_node = nil
+	local moon_light = nil
 	if pbr then
 		sun_node = scene:CreateChild("Sun")
 		sun_light = sun_node:CreateComponent("Light")
@@ -568,6 +602,20 @@ function M.new(magic, buildat, log, options)
 		sun_light.shadowBias = magic.BiasParameters(0.00005, 0.8, 0.002)
 		sun_light.shadowCascade = magic.CascadeParameters(
 				SHADOW_NEAR, SHADOW_FAR, 0, 0, 0.8)
+		-- The moon, which is the same light from the other side of the sky.
+		-- No shadow map of its own: at this brightness a moon shadow is
+		-- below what the frame can show, and the pair of them overlap for
+		-- the hour either side of dusk and dawn, where two shadow maps is
+		-- twice the cost of one for nothing anybody can see.
+		moon_node = scene:CreateChild("Moon")
+		moon_light = moon_node:CreateComponent("Light")
+		moon_light.lightType = magic.LIGHT_DIRECTIONAL
+		moon_light.castShadows = false
+		moon_light.brightness = MOON_BRIGHTNESS
+		moon_light.specularIntensity = 1.0
+		moon_light.color = magic.Color(MOON_COLOR[1], MOON_COLOR[2],
+				MOON_COLOR[3])
+
 		-- Past the far cascade the world is ambient-lit, which at that range
 		-- reads as haze rather than as a missing shadow
 		magic.renderer.shadowMapSize = 1024
@@ -3359,15 +3407,15 @@ function M.new(magic, buildat, log, options)
 	-- What the sun shines with now: its own colour, going the colour of the
 	-- horizon as it comes down to it, which is the handover the sky shader
 	-- does to the disc. Zero at night, when the light left is the sky's.
-	local function sun_light_color(factor, time_of_day)
+	local function sun_light_color(time_of_day)
 		local _, sy = sun_direction(time_of_day)
 		local low = 1 - math.abs(sy) * 2.5
 		low = low < 0 and 0 or (low > 1 and 1 or low)
 		local tint = sky_color("sun_tint", 1)
 		return magic.Color(
-				(SUN_COLOR[1] * (1 - low) + tint.r * low) * factor,
-				(SUN_COLOR[2] * (1 - low) + tint.g * low) * factor,
-				(SUN_COLOR[3] * (1 - low) + tint.b * low) * factor)
+				SUN_COLOR[1] * (1 - low) + tint.r * low,
+				SUN_COLOR[2] * (1 - low) + tint.g * low,
+				SUN_COLOR[3] * (1 - low) + tint.b * low)
 	end
 
 	function self:set_daylight(factor, time_of_day)
@@ -3430,11 +3478,25 @@ function M.new(magic, buildat, log, options)
 
 		if sun_light then
 			-- The light travels the other way from the body it comes from,
-			-- and sun_direction() covers the whole day: after dusk it is the
-			-- moon that is up there, dim and blue, through the same gate.
+			-- and the moon is opposite the sun, so one direction gives both.
+			-- Whichever of the two is under the world is taken out of the
+			-- scene rather than dimmed: a directional light does not know
+			-- about the horizon, and one below it lights the undersides of
+			-- everything and puts the night's sparkle on the wrong side of
+			-- the sky.
 			local sx, sy, sz = sun_direction(daylight_time)
-			sun_node.direction = magic.Vector3(-sx, -sy, -sz)
-			sun_light.color = sun_light_color(factor, daylight_time)
+			local up = sun_amount(daylight_time)
+			sun_node.enabled = up > 0
+			if up > 0 then
+				sun_node.direction = magic.Vector3(-sx, -sy, -sz)
+				sun_light.brightness = SUN_BRIGHTNESS * up
+				sun_light.color = sun_light_color(daylight_time)
+			end
+			moon_node.enabled = up < 1
+			if up < 1 then
+				moon_node.direction = magic.Vector3(sx, sy, sz)
+				moon_light.brightness = MOON_BRIGHTNESS * (1 - up)
+			end
 		end
 
 		if sky_material then

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -433,7 +433,6 @@ function M.new(magic, buildat, log, options)
 	local CLOUD_SPEED_DEFAULT = {0, -2}
 	local CLOUD_WIND_PER_NODE = 0.0054
 	local CLOUD_DENSITY_DEFAULT = 0.4
-	local CLOUD_COVERAGE_DEFAULT = 0.34
 
 	-- What the game says is in the sky, out of SET_SUN, SET_MOON, SET_STARS
 	-- and CLOUD_PARAMS. What is here to begin with is what Luanti has before
@@ -3726,11 +3725,22 @@ function M.new(magic, buildat, log, options)
 			sky_material:SetShaderParameter("CloudWind", magic.Vector2(
 					wind[1] * CLOUD_WIND_PER_NODE,
 					wind[2] * CLOUD_WIND_PER_NODE))
+			-- The density goes to the shader as it came. Luanti fills a
+			-- cloud cell where its own 0...1 noise falls below the density,
+			-- so the number is a quantile of that noise; the shader beside
+			-- this file fills where its noise rises above one minus the
+			-- coverage, which is a quantile of its own. Both are value noise
+			-- of much the same shape and both are even about a half, so the
+			-- quantile carries straight across and the coverage is the
+			-- density. Sampled over two hundred thousand points, what
+			-- Luanti's client covers and what this one covers agree to within
+			-- two parts in a hundred the whole way from nothing to a full
+			-- sky. What was here before scaled the density by 0.85 first,
+			-- which at Luanti's own default covered a sixth of the sky where
+			-- Luanti covers a quarter.
 			sky_material:SetShaderParameter("CloudCoverage",
 					(sky and sky.clouds == false) and 0 or
-					CLOUD_COVERAGE_DEFAULT *
-					(sky_bodies.clouds.density or CLOUD_DENSITY_DEFAULT) /
-					CLOUD_DENSITY_DEFAULT)
+					(sky_bodies.clouds.density or CLOUD_DENSITY_DEFAULT))
 		end
 	end
 

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -27,6 +27,8 @@ local light_flood = dofile(__buildat_extension_path("luanti_client")..
 		"/light.lua")
 local skyvis = dofile(__buildat_extension_path("luanti_client")..
 		"/skyvis.lua")
+local surface = dofile(__buildat_extension_path("luanti_client")..
+		"/surface.lua")
 
 local M = {}
 
@@ -120,6 +122,53 @@ local LIGHT_MAP = (function()
 	end
 	return table.concat(out)
 end)()
+
+-- The same, for the PBR path, whose skylight means something else.
+--
+-- There the sun is a real light with a shadow map, and the shadow map is what
+-- darkens what is under a tree. So node lighting is left to answer the one
+-- question a shadow map cannot -- "am I underground" -- and nothing else: the
+-- curve holds at full until the light has fallen far enough that it can only
+-- be rock overhead, and then drops away. A canopy reads 11..14 and stays fully
+-- lit; a cave reads 0..2 and goes dark; a doorway is the band between.
+--
+-- The knee is the tuning knob. Lower it and cave mouths brighten; raise it and
+-- overhangs start being darkened twice, once here and once by the shadow map.
+local PBR_SKY_KNEE_LOW = 2
+local PBR_SKY_KNEE_HIGH = 11
+
+local PBR_LIGHT_MAP = (function()
+	local out = {}
+	for p = 0, 255 do
+		local day = p % 16
+		local night = math.floor(p / 16)
+		local sky = day > night and day - night or 0
+		local t = (sky - PBR_SKY_KNEE_LOW) /
+				(PBR_SKY_KNEE_HIGH - PBR_SKY_KNEE_LOW)
+		t = t < 0 and 0 or (t > 1 and 1 or t)
+		local smooth = t * t * (3 - 2 * t)
+		out[p + 1] = string.char(night * 16 + math.floor(15 * smooth + 0.5))
+	end
+	return table.concat(out)
+end)()
+
+-- What the curve has to hold, checked at load: full sun outdoors, nothing in
+-- rock, and a canopy left for the shadow map to darken. The lamp nibble rides
+-- through untouched, because the two are separate lights.
+do
+	local function sky_of(day, night)
+		return string.byte(PBR_LIGHT_MAP, night * 16 + day + 1) % 16
+	end
+	local function lamp_of(day, night)
+		return math.floor(string.byte(PBR_LIGHT_MAP, night * 16 + day + 1) / 16)
+	end
+	assert(sky_of(15, 0) == 15, "pbr light curve: open sky")
+	assert(sky_of(PBR_SKY_KNEE_HIGH, 0) == 15, "pbr light curve: canopy")
+	assert(sky_of(PBR_SKY_KNEE_LOW, 0) == 0, "pbr light curve: rock")
+	assert(sky_of(0, 0) == 0, "pbr light curve: dark")
+	assert(sky_of(8, 8) == 0, "pbr light curve: lamp is not sky")
+	assert(lamp_of(15, 7) == 7, "pbr light curve: lamp nibble kept")
+end
 
 -- What the volume is before the block and its neighbours are copied into it:
 -- air that sees the full sky. A face against a neighbour that has not arrived
@@ -459,6 +508,52 @@ function M.new(magic, buildat, log, options)
 				"luanti_client/res/VoxelSky.xml")
 	end
 
+	-- The sun, on the PBR path only. The vanilla path has no light in the
+	-- scene at all: the mesher bakes what a node is lit by into the vertex
+	-- colours, and a directional light on top of that would light everything
+	-- twice. The PBR path keeps the vertex colours as its ambient and adds
+	-- the sun, and what stops the double is the light curve: PBR_LIGHT_MAP
+	-- reads as "am I underground" and nothing else, and the shader gates the
+	-- sun by it. A leaf canopy is then darkened by the shadow map, which is
+	-- the thing a shadow map is good at and a baked light value is not.
+	--
+	-- Biased for performance, because there are no graphics settings beyond
+	-- the PBR checkbox: two cascades rather than four, a small map, and the
+	-- single-tap filter.
+	local SHADOW_NEAR = 24    -- nodes; the first cascade
+	local SHADOW_FAR = 96     -- and the second, which is the shadow distance
+	-- What a lit face gets from the sun, against the sky's own colour as the
+	-- ambient. The number is large because Urho's PBR divides direct light by
+	-- pi, the albedo it multiplies is well under 1, and nothing tone maps
+	-- afterwards: measured on a grass field, a brightness of 6 put about as
+	-- much light on a lit face as the ambient already had, which is a sun
+	-- nobody can see and a shadow nobody can see either. This lands a lit
+	-- face at about two and a half times a shadowed one.
+	local SUN_BRIGHTNESS = 18.0
+	local sun_node = nil
+	local sun_light = nil
+	if pbr then
+		sun_node = scene:CreateChild("Sun")
+		sun_light = sun_node:CreateComponent("Light")
+		sun_light.lightType = magic.LIGHT_DIRECTIONAL
+		sun_light.castShadows = true
+		sun_light.brightness = SUN_BRIGHTNESS
+		sun_light.specularIntensity = 1.0
+		-- Voxel faces at a grazing sun angle are the classic shadow acne
+		-- case: a whole flat face falls inside one shadow texel and shadows
+		-- itself in stripes. A slope-scaled bias on top of the automatic one,
+		-- and a normal offset, which is the one that works on a face that is
+		-- flat and wide.
+		sun_light.shadowBias = magic.BiasParameters(0.00005, 0.8, 0.002)
+		sun_light.shadowCascade = magic.CascadeParameters(
+				SHADOW_NEAR, SHADOW_FAR, 0, 0, 0.8)
+		-- Past the far cascade the world is ambient-lit, which at that range
+		-- reads as haze rather than as a missing shadow
+		magic.renderer.shadowMapSize = 1024
+		magic.renderer.shadowQuality = magic.SHADOWQUALITY_SIMPLE_16BIT
+		magic.renderer.drawShadows = true
+	end
+
 	-- The mesher sets no technique on skylit geometry -- only the game knows
 	-- which shader reads what it packed -- so every block's materials get
 	-- this one once they exist.
@@ -466,6 +561,10 @@ function M.new(magic, buildat, log, options)
 		if not cg then
 			return
 		end
+		-- Urho3D's drawables cast no shadow unless told to, one by one. On
+		-- the vanilla path there is no light to cast one from; on the PBR
+		-- path this is what puts the world in the sun's shadow map.
+		cg.castShadows = pbr
 		local i = 0
 		while true do
 			local m = cg:GetMaterial(i)
@@ -817,9 +916,12 @@ function M.new(magic, buildat, log, options)
 	-- where it is zero is a game where they did not.
 	local extras_built = 0
 
+	-- surf is what surface.lua guessed the node is made of, or nil for the
+	-- placeholder and anything else with no definition behind it
 	local function add_cube(voxel_reg, name, resources, kind, shape,
 			double_sided, turns, liquid_group, connect, masked, variants,
-			blend, solid_base)
+			blend, solid_base, surf)
+		surf = surf or surface.for_node(nil)
 		local vdef = buildat.VoxelDefinition()
 		vdef.name.block_name = name
 		vdef.handler_module = ""
@@ -829,11 +931,12 @@ function M.new(magic, buildat, log, options)
 			seg.resource_name = resources[i]
 			seg.total_segments = magic.IntVector2(1, 1)
 			seg.select_segment = magic.IntVector2(0, 0)
-			-- A game's textures are painted, not photographed; a wide, weak
-			-- highlight keeps them looking like what they are painted as
-			seg.roughness = 0.95
-			seg.spec_strength = 0.2
-			seg.bumpiness = 0.3
+			seg.roughness = surf.roughness
+			seg.spec_strength = surf.spec_strength
+			seg.bumpiness = surf.bumpiness
+			seg.translucency = surf.translucency
+			seg.spots = surf.spots
+			seg.static_spots = surf.static_spots
 			textures[i] = seg
 		end
 		vdef.textures = textures
@@ -847,9 +950,12 @@ function M.new(magic, buildat, log, options)
 			seg.resource_name = resources[i]
 			seg.total_segments = magic.IntVector2(1, 1)
 			seg.select_segment = magic.IntVector2(0, 0)
-			seg.roughness = 0.95
-			seg.spec_strength = 0.2
-			seg.bumpiness = 0.3
+			seg.roughness = surf.roughness
+			seg.spec_strength = surf.spec_strength
+			seg.bumpiness = surf.bumpiness
+			seg.translucency = surf.translucency
+			seg.spots = surf.spots
+			seg.static_spots = surf.static_spots
 			extras[#extras + 1] = seg
 			i = i + 1
 		end
@@ -1011,6 +1117,11 @@ function M.new(magic, buildat, log, options)
 	-- in the same two maps. The ids are ours to pick; the versions say when a
 	-- map has changed. See doc/client_api.txt.
 	local MAP_ID_NODE, MAP_ID_PAIR, MAP_ID_LIGHT = 1, 2, 3
+	-- The PBR path's curve is a different table and so needs an id of its own;
+	-- the compiled maps are cached by id
+	local MAP_ID_LIGHT_PBR = 4
+	local light_map = pbr and PBR_LIGHT_MAP or LIGHT_MAP
+	local light_map_id = pbr and MAP_ID_LIGHT_PBR or MAP_ID_LIGHT
 	self.node_map_version = 1
 	self.pair_map_version = 1
 	self.use_skylight = true
@@ -1135,8 +1246,8 @@ function M.new(magic, buildat, log, options)
 			sources[#sources + 1] = {
 				data = block.param1, format = "u8",
 				source_size = {BLOCKSIZE, BLOCKSIZE, BLOCKSIZE},
-				at = {0, 0, 0}, map = LIGHT_MAP, field = "light",
-				map_id = MAP_ID_LIGHT, map_version = 1,
+				at = {0, 0, 0}, map = light_map, field = "light",
+				map_id = light_map_id, map_version = 1,
 			}
 		end
 		for _, d in ipairs(NEIGHBOURS) do
@@ -1190,8 +1301,8 @@ function M.new(magic, buildat, log, options)
 						data = n.param1, format = "u8",
 						source_size = {BLOCKSIZE, BLOCKSIZE, BLOCKSIZE},
 						from = from, size = size, at = at,
-						map = LIGHT_MAP, field = "light",
-						map_id = MAP_ID_LIGHT, map_version = 1,
+						map = light_map, field = "light",
+						map_id = light_map_id, map_version = 1,
 					}
 				end
 			end
@@ -3193,7 +3304,9 @@ function M.new(magic, buildat, log, options)
 	function self:set_daylight(factor, time_of_day)
 		daylight = factor
 		daylight_time = time_of_day or daylight_time
-		zone.ambientColor = sunlight_color(factor)
+		if not pbr then
+			zone.ambientColor = sunlight_color(factor)
+		end
 
 		local brightness = brightness_of(factor)
 		-- Which set of colours, by the same bands Luanti's Sky::update()
@@ -3226,6 +3339,17 @@ function M.new(magic, buildat, log, options)
 		-- the sky is drawn with, so the two meet
 		zone.fogColor = horizon
 
+		-- On the PBR path the ambient light is the sky itself rather than the
+		-- colour of sunlight. The shader's ambient is
+		-- cAmbientColor.rgb * color.a + color.rgb, so what a surface gets is
+		-- the sky in proportion to how much of it it can see: open ground is
+		-- sky-blue-white, under an overhang is the same blue but dimmer, and a
+		-- cave is only the warm rgb the torches baked in. That is the three
+		-- tints -- sun, shade, cave -- and it costs this one line.
+		if pbr then
+			zone.ambientColor = top
+		end
+
 		-- What the PBR path's reflections are worth now: the cube map beside
 		-- the shader is one static noon gradient and this is the colour it is
 		-- multiplied by, so a sunset reflects orange and a night reflects
@@ -3233,6 +3357,15 @@ function M.new(magic, buildat, log, options)
 		-- surface pointed upwards reflects.
 		if vis then
 			vis:set_param("SkyColor", magic.Vector3(top.r, top.g, top.b))
+		end
+
+		if sun_light then
+			-- The light travels the other way from the body it comes from,
+			-- and sun_direction() covers the whole day: after dusk it is the
+			-- moon that is up there, dim and blue, through the same gate.
+			local sx, sy, sz = sun_direction(daylight_time)
+			sun_node.direction = magic.Vector3(-sx, -sy, -sz)
+			sun_light.color = sunlight_color(factor)
 		end
 
 		if sky_material then
@@ -3439,7 +3572,8 @@ function M.new(magic, buildat, log, options)
 			end
 			return add_cube(reg, name or def.name, resources, kind, shape,
 					double_sided, nil, group, connect, masked, variants,
-					def.alpha_mode == NODEDEF_ALPHAMODE_BLEND, solid_base)
+					def.alpha_mode == NODEDEF_ALPHAMODE_BLEND, solid_base,
+					surface.for_node(def))
 		end
 		if not kind then
 			return nil
@@ -3453,7 +3587,8 @@ function M.new(magic, buildat, log, options)
 		end
 		return add_cube(reg, name or def.name, resources, kind, nil, nil,
 				nil, group, connect, nil, variants,
-				def.alpha_mode == NODEDEF_ALPHAMODE_BLEND)
+				def.alpha_mode == NODEDEF_ALPHAMODE_BLEND, nil,
+				surface.for_node(def))
 	end
 
 	-- Builds the registry for a set of node definitions a slice at a time.

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -522,14 +522,33 @@ function M.new(magic, buildat, log, options)
 	-- single-tap filter.
 	local SHADOW_NEAR = 24    -- nodes; the first cascade
 	local SHADOW_FAR = 96     -- and the second, which is the shadow distance
-	-- What a lit face gets from the sun, against the sky's own colour as the
-	-- ambient. The number is large because Urho's PBR divides direct light by
-	-- pi, the albedo it multiplies is well under 1, and nothing tone maps
-	-- afterwards: measured on a grass field, a brightness of 6 put about as
-	-- much light on a lit face as the ambient already had, which is a sun
-	-- nobody can see and a shadow nobody can see either. This lands a lit
-	-- face at about two and a half times a shadowed one.
+	-- What a lit face gets from the sun, against the sky as the ambient. The
+	-- number is large because Urho's PBR divides direct light by pi, the
+	-- albedo it multiplies is well under 1, and nothing tone maps afterwards:
+	-- measured on a grass field, a brightness of 6 put about as much light on
+	-- a lit face as the ambient already had, which is a sun nobody can see
+	-- and a shadow nobody can see either. This lands a lit face at about two
+	-- and a half times a shadowed one.
 	local SUN_BRIGHTNESS = 18.0
+
+	-- What the sky is worth as a light, against that. Two numbers, because
+	-- the sky's own colour is the wrong one to light a world with: it is the
+	-- colour of the zenith, and a surface sees the whole dome -- the pale
+	-- band along the horizon and the glare around the sun as much as the blue
+	-- overhead -- so what reaches it is far less blue than what is up there.
+	-- And at full strength the sky puts nearly as much light on a sunlit face
+	-- as the sun does, which reads as a world under water.
+	local AMBIENT_DESATURATE = 0.55
+	local AMBIENT_FROM_SKY = 0.7
+
+	local function ambient_from_sky(sky)
+		local luma = 0.2126 * sky.r + 0.7152 * sky.g + 0.0722 * sky.b
+		local k = AMBIENT_DESATURATE
+		return magic.Color(
+				(sky.r * (1 - k) + luma * k) * AMBIENT_FROM_SKY,
+				(sky.g * (1 - k) + luma * k) * AMBIENT_FROM_SKY,
+				(sky.b * (1 - k) + luma * k) * AMBIENT_FROM_SKY)
+	end
 	local sun_node = nil
 	local sun_light = nil
 	if pbr then
@@ -3283,6 +3302,13 @@ function M.new(magic, buildat, log, options)
 		return math.cos(a), math.sin(a), 0
 	end
 
+	-- The sun's own colour at noon, which is warm. Luanti's
+	-- sunlight_color() is the colour of the sun and the sky together,
+	-- because together is the only way Luanti has them; on the PBR path the
+	-- sky is a light of its own, so what is left for the sun is what the sun
+	-- is. The same numbers res/LuantiSky.glsl draws the disc with.
+	local SUN_COLOR = {1.0, 0.97, 0.86}
+
 	-- One of the game's colours, or Luanti's default for it, as 0...1
 	local function sky_color(name, brightness)
 		local c = (sky and sky[name]) or SKY_DEFAULT[name]
@@ -3299,6 +3325,20 @@ function M.new(magic, buildat, log, options)
 	-- bottoms out at comes to about 0.02.
 	local function brightness_of(factor)
 		return factor ^ 2.2
+	end
+
+	-- What the sun shines with now: its own colour, going the colour of the
+	-- horizon as it comes down to it, which is the handover the sky shader
+	-- does to the disc. Zero at night, when the light left is the sky's.
+	local function sun_light_color(factor, time_of_day)
+		local _, sy = sun_direction(time_of_day)
+		local low = 1 - math.abs(sy) * 2.5
+		low = low < 0 and 0 or (low > 1 and 1 or low)
+		local tint = sky_color("sun_tint", 1)
+		return magic.Color(
+				(SUN_COLOR[1] * (1 - low) + tint.r * low) * factor,
+				(SUN_COLOR[2] * (1 - low) + tint.g * low) * factor,
+				(SUN_COLOR[3] * (1 - low) + tint.b * low) * factor)
 	end
 
 	function self:set_daylight(factor, time_of_day)
@@ -3347,7 +3387,7 @@ function M.new(magic, buildat, log, options)
 		-- cave is only the warm rgb the torches baked in. That is the three
 		-- tints -- sun, shade, cave -- and it costs this one line.
 		if pbr then
-			zone.ambientColor = top
+			zone.ambientColor = ambient_from_sky(top)
 		end
 
 		-- What the PBR path's reflections are worth now: the cube map beside
@@ -3365,7 +3405,7 @@ function M.new(magic, buildat, log, options)
 			-- moon that is up there, dim and blue, through the same gate.
 			local sx, sy, sz = sun_direction(daylight_time)
 			sun_node.direction = magic.Vector3(-sx, -sy, -sz)
-			sun_light.color = sunlight_color(factor)
+			sun_light.color = sun_light_color(factor, daylight_time)
 		end
 
 		if sky_material then

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -602,6 +602,23 @@ function M.new(magic, buildat, log, options)
 		return up_between(time_of_day, SUN_RISE, SUN_UP, SUN_SET, SUN_DOWN)
 	end
 
+	-- The half hour either side of the sun crossing the horizon, at each end
+	-- of the day, as 0 outside and 1 at the crossing itself. This is the
+	-- window dawn and dusk happen in: what the sun is red in, and what the
+	-- clouds take their colour from. Smooth at both ends, because a tint that
+	-- switches on is a tint you notice switching on.
+	local RED_HALF_WIDTH = 500
+
+	local function low_sun(time_of_day)
+		local t = (time_of_day or 12000) % 24000
+		local d = math.min(math.abs(t - SUN_RISE), math.abs(t - SUN_DOWN))
+		local u = 1 - d / RED_HALF_WIDTH
+		if u <= 0 then
+			return 0
+		end
+		return u * u * (3 - 2 * u)
+	end
+
 	-- What is up while the day is not: the same shape, read the other way
 	-- round, so that the four numbers above say when the moon is out rather
 	-- than being the sun's turned inside out
@@ -623,6 +640,18 @@ function M.new(magic, buildat, log, options)
 				"the sun has the sky to itself once the moon is gone")
 		assert(sun_amount(SUN_DOWN) == 0 and moon_amount(SUN_DOWN) > 0.4,
 				"the moon is up by the time the sun is gone")
+		-- Dawn and dusk are a window around the crossings and nowhere else
+		assert(low_sun(SUN_RISE) == 1 and low_sun(SUN_DOWN) == 1,
+				"reddest as the sun crosses")
+		assert(low_sun(SUN_RISE - RED_HALF_WIDTH) == 0 and
+				low_sun(SUN_RISE + RED_HALF_WIDTH) == 0 and
+				low_sun(SUN_DOWN - RED_HALF_WIDTH) == 0 and
+				low_sun(SUN_DOWN + RED_HALF_WIDTH) == 0,
+				"and back to nothing half an hour either side")
+		assert(low_sun(12000) == 0 and low_sun(0) == 0,
+				"nothing of it at noon or at midnight")
+		assert(low_sun(SUN_RISE - 250) > 0.4 and low_sun(SUN_RISE - 250) < 0.6,
+				"and the way across it in between")
 	end
 
 	-- What the sky is worth as a light, against that. Two numbers, because
@@ -3450,7 +3479,12 @@ function M.new(magic, buildat, log, options)
 	-- How much of the horizon's own tint the light takes when the sun is down
 	-- among it. Not all of it: sun_tint is the colour a band of sky is
 	-- painted, which is deeper than the light that paints it.
-	local SUN_TINT_SHARE = 0.5
+	local SUN_TINT_SHARE = 0.6
+	-- And how much of the sun's colour the clouds take while it is down
+	-- there. More than the light itself takes, because a cloud at dawn is
+	-- lit by nothing else and the sun is lighting it from below, where the
+	-- ground is lit by the sky as well.
+	local CLOUD_SUN_TINT = 0.75
 
 	-- One of the game's colours, or Luanti's default for it, as 0...1
 	local function sky_color(name, brightness)
@@ -3540,14 +3574,11 @@ function M.new(magic, buildat, log, options)
 	end
 
 	-- What the sun shines with now: its own colour, going the colour of the
-	-- horizon as it comes down to it, which is the handover the sky shader
-	-- does to the disc. Zero at night, when the light left is the sky's.
+	-- horizon over the hour it is crossing it, which is where that colour
+	-- belongs and is the same handover the sky shader does to the disc.
 	local function sun_light_color(time_of_day)
-		local _, sy = sun_direction(time_of_day)
-		local low = 1 - math.abs(sy) * 2.5
-		low = low < 0 and 0 or (low > 1 and 1 or low)
 		local tint = sky_color("sun_tint", 1)
-		low = low * SUN_TINT_SHARE
+		local low = low_sun(time_of_day) * SUN_TINT_SHARE
 		return magic.Color(
 				SUN_COLOR[1] * (1 - low) + tint.r * low,
 				SUN_COLOR[2] * (1 - low) + tint.g * low,
@@ -3665,17 +3696,27 @@ function M.new(magic, buildat, log, options)
 			sky_material:SetShaderParameter("SunTint",
 					sky_color("sun_tint", 0.35 + brightness * 0.65))
 			-- Luanti's clouds are the daylight's own colour, unless the
-			-- game gave them one; either way they go dark with the day.
+			-- game gave them one; either way they go dark with the day. And
+			-- over the hour the sun spends crossing the horizon they take its
+			-- colour, because at that hour the sun is what is lighting them
+			-- and it is lighting them from underneath: that is what makes a
+			-- sunrise a sunrise rather than a sky that has got brighter.
+			local sun_now = sun_light_color(daylight_time)
+			local lit = low_sun(daylight_time) * CLOUD_SUN_TINT
+			local function cloud_channel(own, from_sun)
+				return (own * (1 - lit) + from_sun * lit) * brightness
+			end
 			local cloud = sky_bodies.clouds.color_bright
 			if cloud then
 				sky_material:SetShaderParameter("CloudColor", magic.Color(
-						cloud[1] / 255 * brightness,
-						cloud[2] / 255 * brightness,
-						cloud[3] / 255 * brightness))
+						cloud_channel(cloud[1] / 255, sun_now.r),
+						cloud_channel(cloud[2] / 255, sun_now.g),
+						cloud_channel(cloud[3] / 255, sun_now.b)))
 			else
 				sky_material:SetShaderParameter("CloudColor", magic.Color(
-						0.9 * brightness + 0.05, 0.92 * brightness + 0.05,
-						0.95 * brightness + 0.06))
+						cloud_channel(0.9, sun_now.r) + 0.05,
+						cloud_channel(0.92, sun_now.g) + 0.05,
+						cloud_channel(0.95, sun_now.b) + 0.06))
 			end
 			-- The stars come out as the sky goes dark, and a game can say
 			-- they are out in the day as well

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -537,10 +537,10 @@ function M.new(magic, buildat, log, options)
 
 	-- What the moon is worth, in the same units. Not a measurement of
 	-- anything -- real moonlight is a millionth of sunlight and would render
-	-- as nothing -- but a night that is lit from where the moon is, dimly and
-	-- coldly, rather than one that is lit from under the world by a sun that
-	-- has set.
-	local MOON_BRIGHTNESS = 1.0
+	-- as nothing -- but a night lit from where the moon is, coldly and far
+	-- enough above the sky's own light that the moon casts a shadow and a wet
+	-- or glassy surface glints under it. A tenth of the sun.
+	local MOON_BRIGHTNESS = 5.0
 	local MOON_COLOR = {0.55, 0.68, 1.0}
 
 	-- When the sun is in the scene and when the moon is, in Luanti's
@@ -602,17 +602,19 @@ function M.new(magic, buildat, log, options)
 		sun_light.shadowBias = magic.BiasParameters(0.00005, 0.8, 0.002)
 		sun_light.shadowCascade = magic.CascadeParameters(
 				SHADOW_NEAR, SHADOW_FAR, 0, 0, 0.8)
-		-- The moon, which is the same light from the other side of the sky.
-		-- No shadow map of its own: at this brightness a moon shadow is
-		-- below what the frame can show, and the pair of them overlap for
-		-- the hour either side of dusk and dawn, where two shadow maps is
-		-- twice the cost of one for nothing anybody can see.
+		-- The moon, which is the same light from the other side of the sky,
+		-- with the same shadow map settings. The two are both in the scene
+		-- for the hour either side of dusk and dawn, which is two shadow maps
+		-- for that hour and one for the rest of the day.
 		moon_node = scene:CreateChild("Moon")
 		moon_light = moon_node:CreateComponent("Light")
 		moon_light.lightType = magic.LIGHT_DIRECTIONAL
-		moon_light.castShadows = false
+		moon_light.castShadows = true
 		moon_light.brightness = MOON_BRIGHTNESS
 		moon_light.specularIntensity = 1.0
+		moon_light.shadowBias = magic.BiasParameters(0.00005, 0.8, 0.002)
+		moon_light.shadowCascade = magic.CascadeParameters(
+				SHADOW_NEAR, SHADOW_FAR, 0, 0, 0.8)
 		moon_light.color = magic.Color(MOON_COLOR[1], MOON_COLOR[2],
 				MOON_COLOR[3])
 
@@ -3379,12 +3381,18 @@ function M.new(magic, buildat, log, options)
 		return math.cos(a), math.sin(a), 0
 	end
 
-	-- The sun's own colour at noon, which is warm. Luanti's
-	-- sunlight_color() is the colour of the sun and the sky together,
-	-- because together is the only way Luanti has them; on the PBR path the
-	-- sky is a light of its own, so what is left for the sun is what the sun
-	-- is. The same numbers res/LuantiSky.glsl draws the disc with.
-	local SUN_COLOR = {1.0, 0.92, 0.78}
+	-- The sun's own colour at noon. Luanti's sunlight_color() is the colour
+	-- of the sun and the sky together, because together is the only way
+	-- Luanti has them; on the PBR path the sky is a light of its own, so what
+	-- is left for the sun is what the sun is. Only a little warm: what makes
+	-- sunlight read as golden is the blue ambient beside it, and a light
+	-- warmer than this shows up undisguised in what a glint reflects.
+	-- games/voxel_lighting's sun is the same colour.
+	local SUN_COLOR = {1.0, 0.96, 0.88}
+	-- How much of the horizon's own tint the light takes when the sun is down
+	-- among it. Not all of it: sun_tint is the colour a band of sky is
+	-- painted, which is deeper than the light that paints it.
+	local SUN_TINT_SHARE = 0.5
 
 	-- One of the game's colours, or Luanti's default for it, as 0...1
 	local function sky_color(name, brightness)
@@ -3412,6 +3420,7 @@ function M.new(magic, buildat, log, options)
 		local low = 1 - math.abs(sy) * 2.5
 		low = low < 0 and 0 or (low > 1 and 1 or low)
 		local tint = sky_color("sun_tint", 1)
+		low = low * SUN_TINT_SHARE
 		return magic.Color(
 				SUN_COLOR[1] * (1 - low) + tint.r * low,
 				SUN_COLOR[2] * (1 - low) + tint.g * low,

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -537,10 +537,10 @@ function M.new(magic, buildat, log, options)
 
 	-- What the moon is worth, in the same units. Not a measurement of
 	-- anything -- real moonlight is a millionth of sunlight and would render
-	-- as nothing -- but a night lit from where the moon is, coldly and far
-	-- enough above the sky's own light that the moon casts a shadow and a wet
-	-- or glassy surface glints under it. A tenth of the sun.
-	local MOON_BRIGHTNESS = 5.0
+	-- as nothing -- but a night lit from where the moon is, coldly, and far
+	-- enough above the sky's own light that the moon casts a shadow. A
+	-- fiftieth of the sun.
+	local MOON_BRIGHTNESS = 1.0
 	local MOON_COLOR = {0.55, 0.68, 1.0}
 
 	-- When the sun is in the scene and when the moon is, in Luanti's
@@ -555,16 +555,54 @@ function M.new(magic, buildat, log, options)
 	local SUN_SET = 18000     -- full sun until here
 	local SUN_DOWN = 19000    -- nothing after this
 
-	local function sun_amount(time_of_day)
+	-- The moon's day is a little longer than the sun's night: it is going
+	-- before the sun arrives and does not come back until the sun is well
+	-- gone. That leaves it nine hours at full against the sun's twelve, which
+	-- is one more way of saying which of the two is the dim one, and it means
+	-- that by the time the sun is making any real light the moon has stopped.
+	local MOON_FADE_OUT = 4500   -- the moon starts going here
+	local MOON_OUT = 5500        -- and is gone here, the sun then half up
+	local MOON_FADE_IN = 18500   -- and comes back from here
+	local MOON_IN = 19500        -- to full here
+
+	-- 0 before the rise, 1 between the rise and the set, 0 after it, and the
+	-- way across each ramp in between
+	local function up_between(time_of_day, rise_from, rise_to,
+			set_from, set_to)
 		local t = (time_of_day or 12000) % 24000
-		if t <= SUN_RISE or t >= SUN_DOWN then
+		if t <= rise_from or t >= set_to then
 			return 0
-		elseif t < SUN_UP then
-			return (t - SUN_RISE) / (SUN_UP - SUN_RISE)
-		elseif t <= SUN_SET then
+		elseif t < rise_to then
+			return (t - rise_from) / (rise_to - rise_from)
+		elseif t <= set_from then
 			return 1
 		end
-		return (SUN_DOWN - t) / (SUN_DOWN - SUN_SET)
+		return (set_to - t) / (set_to - set_from)
+	end
+
+	local function sun_amount(time_of_day)
+		return up_between(time_of_day, SUN_RISE, SUN_UP, SUN_SET, SUN_DOWN)
+	end
+
+	-- What is up while the day is not: the same shape, read the other way
+	-- round, so that the four numbers above say when the moon is out rather
+	-- than being the sun's turned inside out
+	local function moon_amount(time_of_day)
+		return 1 - up_between(time_of_day, MOON_FADE_OUT, MOON_OUT,
+				MOON_FADE_IN, MOON_IN)
+	end
+
+	-- What the schedule has to hold, checked at load: the two never leave the
+	-- sky empty between them, and the moon is out of the way by the time the
+	-- sun is worth anything.
+	do
+		assert(sun_amount(12000) == 1 and moon_amount(12000) == 0, "noon")
+		assert(sun_amount(0) == 0 and moon_amount(0) == 1, "midnight")
+		assert(moon_amount(SUN_RISE) > 0.4, "the moon is still up at sunrise")
+		assert(moon_amount(MOON_OUT) == 0 and sun_amount(MOON_OUT) > 0.4,
+				"the sun has the sky to itself once the moon is gone")
+		assert(sun_amount(SUN_DOWN) == 0 and moon_amount(SUN_DOWN) > 0.4,
+				"the moon is up by the time the sun is gone")
 	end
 
 	-- What the sky is worth as a light, against that. Two numbers, because
@@ -3501,10 +3539,11 @@ function M.new(magic, buildat, log, options)
 				sun_light.brightness = SUN_BRIGHTNESS * up
 				sun_light.color = sun_light_color(daylight_time)
 			end
-			moon_node.enabled = up < 1
-			if up < 1 then
+			local moon_up = moon_amount(daylight_time)
+			moon_node.enabled = moon_up > 0
+			if moon_up > 0 then
 				moon_node.direction = magic.Vector3(sx, sy, sz)
-				moon_light.brightness = MOON_BRIGHTNESS * (1 - up)
+				moon_light.brightness = MOON_BRIGHTNESS * moon_up
 			end
 		end
 

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -433,6 +433,10 @@ function M.new(magic, buildat, log, options)
 	local CLOUD_SPEED_DEFAULT = {0, -2}
 	local CLOUD_WIND_PER_NODE = 0.0054
 	local CLOUD_DENSITY_DEFAULT = 0.4
+	-- Luanti's own default cloud colour is 229 of 255 opaque, and a game that
+	-- names a colour without an alpha gets a full one; either way the layer
+	-- is drawn at what the colour says rather than solid
+	local CLOUD_ALPHA_DEFAULT = 229 / 255
 
 	-- What the game says is in the sky, out of SET_SUN, SET_MOON, SET_STARS
 	-- and CLOUD_PARAMS. What is here to begin with is what Luanti has before
@@ -3738,6 +3742,10 @@ function M.new(magic, buildat, log, options)
 			-- sky. What was here before scaled the density by 0.85 first,
 			-- which at Luanti's own default covered a sixth of the sky where
 			-- Luanti covers a quarter.
+			local cloud_color = sky_bodies.clouds.color_bright
+			sky_material:SetShaderParameter("CloudAlpha",
+					(cloud_color and cloud_color[4] and
+					cloud_color[4] / 255) or CLOUD_ALPHA_DEFAULT)
 			sky_material:SetShaderParameter("CloudCoverage",
 					(sky and sky.clouds == false) and 0 or
 					(sky_bodies.clouds.density or CLOUD_DENSITY_DEFAULT))

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -3479,7 +3479,14 @@ function M.new(magic, buildat, log, options)
 	-- How much of the horizon's own tint the light takes when the sun is down
 	-- among it. Not all of it: sun_tint is the colour a band of sky is
 	-- painted, which is deeper than the light that paints it.
-	local SUN_TINT_SHARE = 0.6
+	-- How much of the horizon's colour the light takes at the reddest of it.
+	-- The window above says when; this says how much, and it is weighted
+	-- towards the crossing itself -- squared from the far end -- so that it
+	-- comes on gently at the edge of the window and is most of the way there
+	-- by the quarter hour. A sun a quarter of an hour off the horizon is
+	-- already red, and a share that only rose with the window was still a
+	-- warm white there.
+	local SUN_TINT_SHARE = 0.9
 	-- And how much of the sun's colour the clouds take while it is down
 	-- there. More than the light itself takes, because a cloud at dawn is
 	-- lit by nothing else and the sun is lighting it from below, where the
@@ -3578,7 +3585,8 @@ function M.new(magic, buildat, log, options)
 	-- belongs and is the same handover the sky shader does to the disc.
 	local function sun_light_color(time_of_day)
 		local tint = sky_color("sun_tint", 1)
-		local low = low_sun(time_of_day) * SUN_TINT_SHARE
+		local low = low_sun(time_of_day)
+		low = (1 - (1 - low) * (1 - low)) * SUN_TINT_SHARE
 		return magic.Color(
 				SUN_COLOR[1] * (1 - low) + tint.r * low,
 				SUN_COLOR[2] * (1 - low) + tint.g * low,
@@ -3598,6 +3606,15 @@ function M.new(magic, buildat, log, options)
 		assert(math.abs(elevation(SUN_DOWN)) < 0.02, "the sun sets at 19:00")
 		assert(elevation(12000) > 0.9, "the sun is overhead at noon")
 		assert(elevation(0) < -0.9, "the sun is under the world at midnight")
+		-- And that a quarter of an hour off the horizon the light is red
+		-- rather than a warm white, which is the whole of what the window is
+		-- for
+		local setting = sun_light_color(SUN_DOWN - 250)
+		assert(setting.r - setting.b > 0.5, "a quarter hour from setting")
+		local rising = sun_light_color(SUN_RISE + 250)
+		assert(rising.r - rising.b > 0.5, "and a quarter hour after rising")
+		local noon = sun_light_color(12000)
+		assert(noon.r - noon.b < 0.15, "and its own colour the rest of the day")
 	end
 
 	function self:set_daylight(factor, time_of_day)

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -3645,39 +3645,115 @@ function M.new(magic, buildat, log, options)
 		assert(noon.r - noon.b < 0.15, "and its own colour the rest of the day")
 	end
 
-	function self:set_daylight(factor, time_of_day)
-		daylight = factor
-		daylight_time = time_of_day or daylight_time
+	-- Luanti eases the sky rather than setting it: Sky::update() keeps the
+	-- colours and the brightness it is drawing and moves each a fixed share
+	-- of the way to the target every frame, so a band changing under it comes
+	-- out as a minute of sunrise instead of a jump. The same thing here, with
+	-- the share worked out from the frame's own length so that it does not
+	-- depend on how fast the frames come, and with a jump too big to be the
+	-- day moving -- a game setting its clock, or a sky arriving -- taken at
+	-- once rather than eased, which is Luanti's rule as well.
+	local SKY_EASE_SECONDS = 0.8
+	local SKY_EASE_SNAP = 0.35
+
+	local sky_eased = {}
+
+	local function sky_share(dtime)
+		if dtime <= 0 then
+			return 1
+		end
+		-- 1 - e^-t/tau, but without exp: this is within a few per cent of it
+		-- over a frame and cannot overshoot
+		return clamp01(dtime / (SKY_EASE_SECONDS + dtime))
+	end
+
+	local function sky_ease(dtime, key, target)
+		local at = sky_eased[key]
+		if at == nil or math.abs(target - at) > SKY_EASE_SNAP then
+			sky_eased[key] = target
+			return target
+		end
+		at = at + (target - at) * sky_share(dtime)
+		sky_eased[key] = at
+		return at
+	end
+
+	-- The same for a colour, eased in the band's own full-strength colours
+	-- and scaled by the brightness afterwards, so that what is being eased is
+	-- which sky it is rather than how dark it is
+	local function sky_ease_color(dtime, key, target, brightness)
+		local at = sky_eased[key]
+		if at == nil or math.abs(target.r - at[1]) > SKY_EASE_SNAP or
+				math.abs(target.g - at[2]) > SKY_EASE_SNAP or
+				math.abs(target.b - at[3]) > SKY_EASE_SNAP then
+			at = {target.r, target.g, target.b}
+			sky_eased[key] = at
+		else
+			local k = sky_share(dtime)
+			at[1] = at[1] + (target.r - at[1]) * k
+			at[2] = at[2] + (target.g - at[2]) * k
+			at[3] = at[3] + (target.b - at[3]) * k
+		end
+		return magic.Color(at[1] * brightness, at[2] * brightness,
+				at[3] * brightness)
+	end
+
+	-- What the easing has to do, checked at load: arrive where it was sent,
+	-- take its time getting there, and not take its time over a jump that is
+	-- a game setting its clock rather than the day passing.
+	do
+		assert(sky_ease(0.1, "check", 0.5) == 0.5, "the first is where it is")
+		local half = sky_ease(SKY_EASE_SECONDS, "check", 0.7)
+		assert(half > 0.58 and half < 0.62,
+				"a tau of it is about half the way")
+		for _ = 1, 200 do
+			sky_ease(0.05, "check", 0.7)
+		end
+		assert(math.abs(sky_ease(0.05, "check", 0.7) - 0.7) < 0.001,
+				"and it arrives")
+		assert(sky_ease(0.05, "check", 0.0) == 0.0, "a jump is taken at once")
+		sky_eased.check = nil
+	end
+
+	local function apply_daylight(dtime)
+		local factor = daylight
 		if not pbr then
 			zone.ambientColor = sunlight_color(factor)
 		end
 
 		local brightness = brightness_of(factor)
 		-- Which set of colours, by the same bands Luanti's Sky::update()
-		-- uses: night, dawn, or the day's own.
+		-- uses: night, dawn, or the day's own. The set changes at a step,
+		-- there as here; what makes the change not read as one is that
+		-- nothing below is the target, it is where the sky has got to on its
+		-- way there. See sky_ease() above.
 		--
-		-- simplified: Luanti eases from one set to the next over a second or
-		-- so of its own frames rather than switching between them, and it
-		-- has a fourth set for a player who cannot see the sky at all. Here
-		-- the brightness is what carries dawn into day, and the set changes
-		-- when the band does.
+		-- simplified: Luanti has a fourth set for a player who cannot see the
+		-- sky at all, which is not read here.
 		local band = "day"
 		if brightness < 0.13 then
 			band = "night"
 		elseif brightness >= 0.20 and brightness < 0.35 then
 			band = "dawn"
 		end
-		local top = sky_color(band.."_sky", brightness)
-		local horizon = sky_color(band.."_horizon", brightness)
+		local top = sky_color(band.."_sky", 1)
+		local horizon = sky_color(band.."_horizon", 1)
 		if sky and sky.type == "skybox" then
 			-- A game that gave its own textures gets its bgcolor, which is
 			-- the one thing of its sky that is understood here
-			top = sky_color("bgcolor", brightness)
+			top = sky_color("bgcolor", 1)
 			horizon = top
 		elseif sky and not sky.day_sky and sky.bgcolor then
-			top = sky_color("bgcolor", brightness)
+			top = sky_color("bgcolor", 1)
 			horizon = top
 		end
+
+		-- Where the sky has actually got to, which is what everything below
+		-- is drawn from. The brightness the band is scaled by is eased too,
+		-- so a sunrise is a sunrise and not a set of colours being swapped.
+		brightness = sky_ease(dtime, "brightness", brightness)
+		top = sky_ease_color(dtime, "top", top, brightness)
+		horizon = sky_ease_color(dtime, "horizon", horizon, brightness)
 
 		-- What is behind the world, which the fog fades into: the horizon
 		-- the sky is drawn with, so the two meet
@@ -3856,9 +3932,16 @@ function M.new(magic, buildat, log, options)
 		end
 	end
 
+	-- What the light and the time are now. Nothing is drawn from here: the
+	-- sky is drawn every frame by apply_daylight(), easing towards whatever
+	-- this last said, which is what makes the day pass rather than step.
+	function self:set_daylight(factor, time_of_day)
+		daylight = factor
+		daylight_time = time_of_day or daylight_time
+	end
+
 	function self:set_sky(new_sky)
 		sky = new_sky
-		self:set_daylight(daylight, daylight_time)
 	end
 
 	-- What the game says is in the sky, each out of its own packet. The
@@ -3871,7 +3954,6 @@ function M.new(magic, buildat, log, options)
 		for key, value in pairs(what) do
 			sky_bodies[which][key] = value
 		end
-		self:set_daylight(daylight, daylight_time)
 	end
 
 	-- Builds the voxel registry from Luanti's node definitions.
@@ -4262,6 +4344,10 @@ function M.new(magic, buildat, log, options)
 	-- session -- and the first blocks it sends are the ones around the
 	-- player, which is exactly where a hole is worst.
 	function self:update(dtime, drop_distance)
+		-- Every frame, because easing towards a target is what it is for
+		if daylight then
+			apply_daylight(dtime)
+		end
 		local p = camera_node.position
 		-- Which lights are the nearest changes as the player walks, but not
 		-- so fast that it is worth working out every frame

--- a/extensions/urho3d/safe_classes.lua
+++ b/extensions/urho3d/safe_classes.lua
@@ -391,10 +391,16 @@ function M.define(dst, util)
 	})
 
 	util.wc("BiasParameters", {
-		unsafe_constructor = util.wrap_function({"number", "number"},
-		function(constant_bias, slope_scaled_bias)
+		-- The third one is Urho3D's normal offset, which moves the lookup
+		-- along the surface normal instead of along the light: it is what
+		-- keeps a large flat face out of its own shadow without pushing the
+		-- shadow off the foot of what casts it
+		unsafe_constructor = util.wrap_function(
+		{"number", "number", {"number", "__nil"}},
+		function(constant_bias, slope_scaled_bias, normal_offset)
 			return util.wrap_instance("BiasParameters",
-					BiasParameters(constant_bias, slope_scaled_bias))
+					BiasParameters(constant_bias, slope_scaled_bias,
+							normal_offset or 0.0))
 		end),
 	})
 
@@ -943,6 +949,12 @@ function M.define(dst, util)
 		properties = {
 			HDRRendering = util.simple_property("boolean"),
 			numViewports = util.simple_property("number"),
+			-- Shadows are a renderer-wide setting and not a light's: how big
+			-- the shadow map is, how it is filtered (Urho3D's ShadowQuality),
+			-- and whether any are drawn at all
+			shadowMapSize = util.simple_property("number"),
+			shadowQuality = util.simple_property("number"),
+			drawShadows = util.simple_property("boolean"),
 		},
 	})
 


### PR DESCRIPTION
Section 7c of `tmp/luanti_voxels_plan.md`, and then what testing it turned up.
All of it is behind the connect dialog's "Enable PBR"; the vanilla path is
untouched except where noted.

## What the PBR path is now

**Per-node surfaces.** `surface.lua` guesses the six numbers the atlas turns
into normal and spec maps — roughness, specular strength, bumpiness,
translucency, moving and standing sparkle — from a node's draw type, groups,
name and whether it waves. Before this every node in every game got the same
three constants, so water was as matte as dirt.

**An HDR, tone-mapped frame.** Bloom, the Uncharted2 curve and gamma, the
chain `games/voxel_lighting` already uses. Nothing else makes the sun read as
the sun: in a frame that clips at one there is no sun brightness that is both
visible and not flattening, so the sky's blue stayed half the light on a lit
face. With the curve in, the sun is about fifty times the sky, which is about
what it is.

**A sun and a moon.** Real directional lights with shadow maps, in the scene
only while they are above the horizon — a schedule, and separately the horizon
itself, taken from where the body actually is so neither can shine from under
the world whatever the clock says. The moon is a fiftieth of the sun on a day
of its own, three hours shorter than the sun's, so the two are never both
making much light. For the half hour either side of each crossing the sun's
light takes the horizon's colour, weighted towards the crossing, and the
clouds take most of the sun's — at that hour the sun is the only thing
lighting them and it is lighting them from below.

**A sky that moves.** The client carries the clock on between the server's
word for it, as Luanti's own does, so the day passes rather than arriving
every few seconds; and the sky is eased towards its target rather than set, so
the step where a game's colour band changes comes out as a minute of sunrise.
Where the sun is *for casting a shadow* is stepped instead, a degree and a
half at a time: a shadow map rasterized afresh under a turning light has
crawling edges, and a small jump is easier not to see.

**Weather.** A game that hides the sun has said there is no sun, which
VoxeLibre does the moment it rains; short of that the sun and moon are dimmed
by how much cloud there is, read from both the density and the cloud colour,
because a game uses one or the other. The clouds themselves cover as much sky
as the server asks for — the density is already a coverage, and was being
scaled by 0.85 on the way in — are drawn at the alpha the game gives them, and
thin into the sky at their edges rather than going grey.

**Ambient and objects.** The ambient is the sky rather than the colour of
sunlight, desaturated and dimmed, so open ground, shade and a cave differ in
tint and not only in brightness, with a floor under it at night so that a moon
shadow has something in it. An object is still drawn unlit, but the colour
that stands in for its light is now this path's own ambient plus a share of
whichever body is up, so a mob goes dark at night along with the ground it
stands on.

**Stars** turn with the day, about the axis the sun goes round and by the same
angle, on a grid laid over a cube around the viewer rather than over a plane
overhead.

## The shader is a fork now, not a copy

`res/PBRVoxel.glsl` started as a copy of `builtin/voxel_shading`'s with two
lines of its own, kept in step by hand. That held while the differences were
mechanism and stopped holding the moment the constants were tuned: a good half
of that file decides how something looks, and a Luanti world — ground that is
plants the whole way across, every one of them able to hold a spot — wants
different numbers from the sample game's few sparsely spotted surfaces. Tuning
one retuned the other, which is how `voxel_lighting`'s rock quietly lost its
speckle.

So the built-in one is back to exactly what it was, byte for byte, and each
file says at the top what the other is, what differs and why: a fix to the
machinery is carried across by hand, a number that decides how something looks
is not.

## Engine-side

Chunk geometry is told to cast shadows where it is given its technique — Urho
drawables cast none unless asked, one by one, which is why the shadow map was
rendering nothing at first. `Renderer`'s `shadowMapSize` / `shadowQuality` /
`drawShadows` and `BiasParameters`' normal offset join the sandbox whitelist.
`BUILDAT_LUANTI_PBR` starts the connect dialog with the checkbox ticked, so a
scripted run need not click it by pixel coordinates and a miss cannot be
mistaken for the shader failing.

## Checked

`lua extensions/luanti_client/test.lua` still passes, and now also runs
`surface.lua`'s own assertions. `world.lua` gained load-time checks for the
things that are arithmetic rather than arrangement: the light curve's knee,
the sun and moon schedules and that they agree with the horizon, the weather
reading against the three colours a VoxeLibre server actually sends, which
clouds the sun is allowed to whiten, the dawn window, and the easing.

`games/voxel_lighting/check.txt` renders the same images it did before this
branch — eight of the fourteen byte for byte, the rest within the noise its
sky sampling and its water make between runs.

The rest was checked by eye against a VoxeLibre server at a fixed viewpoint
across the day: dawn, noon, dusk and night, clear and raining, looking at the
ground, at the sky and at the sun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
