### PR TITLE
client: a look command that aims the camera and waits for it

### DIFF
--- a/doc/client_commands.txt
+++ b/doc/client_commands.txt
@@ -40,7 +40,9 @@ swap.
 The OS mouse is never captured or grabbed in -c mode, even if the game calls
 SetMouseVisible(false). Use mouse_move for look (GetMouseMove); that is
 relative and does not use a cursor position. mouse_pos is for a visible UI
-cursor.
+cursor. look does the same pushing for you and waits for the camera to arrive,
+which is what to use when the aim is what the shot is of rather than the
+turning.
 
 Real mouse and keyboard events are dropped for the duration of the sequence, so
 neither the physical mouse nor typing aimed at another window can perturb a
@@ -85,6 +87,26 @@ mouse_click <button>
 mouse_wheel <delta>
     Wheel ticks. Positive is away from the user.
 
+look <yaw> <pitch>
+look_dir <x> <y> <z>
+    Aim the camera and wait until it is aimed. Degrees: yaw from +Z towards
+    +X, pitch positive upwards; look_dir takes a direction and works out the
+    same two angles.
+
+    Nothing here knows what game is running. The camera is turned by injecting
+    mouse movement and watching what the camera of viewport 0 does about it:
+    how far a pixel turns it, and which way round, is measured from what the
+    last frame's push actually did, so a game with its own sensitivity or its
+    mouse look inverted is aimed as well as any other. A push that changes
+    nothing is tried the other way before it is believed.
+
+    The command ends when the camera is there, which is usually three or four
+    frames. An axis that has moved and then stops answering in both directions
+    is against a limit the game keeps -- a pitch clamp, most of the time -- and
+    the command ends with a warning naming where it stopped. A camera that
+    never moves at all, or a viewport with no camera on it, is not a game this
+    can aim: the sequence fails and the client exits non-zero.
+
 text <string>
     SDL text input (UI text fields). Rest of the line is the string.
 
@@ -101,6 +123,12 @@ Wait for the launch menu, screenshot it, click a point, wait, screenshot again:
     mouse_click left
     delay 1000
     screenshot /tmp/buildat_after_click.png
+
+Take the same shot every run, whatever the camera was left pointing at:
+
+    delay 3000
+    look 275 -15
+    screenshot /tmp/buildat_view.png
 
 Hold W for half a second while connected to a local server:
 

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -68,6 +68,69 @@ static const float UI_SNAP_OVER = 0.12f;
 static const int MIN_WINDOW_W = 640;
 static const int MIN_WINDOW_H = 360;
 
+// The look command. How far off the camera may be left, how far it is allowed
+// to be asked to turn in one frame, how much of a turn counts as having moved
+// at all, how many frames of not moving mean the game does not do mouse look,
+// and how many frames of trying mean it is not going to arrive. The first
+// guess is only what the first step is taken with; the second step onwards
+// uses what the first one actually did.
+static const float LOOK_TOLERANCE_DEG = 0.4f;
+static const float LOOK_MAX_STEP_DEG = 60.0f;
+static const float LOOK_MOVED_DEG = 0.002f;
+static const float LOOK_FIRST_GUESS_DEG_PER_PX = 0.15f;
+static const int LOOK_FLIP_FRAMES = 4;
+static const int LOOK_STILL_FRAMES = 30;
+static const int LOOK_MAX_FRAMES = 300;
+
+// One axis of the aiming loop: what it has learned about how a pixel of mouse
+// movement turns this game's camera, and whether the camera has stopped
+// answering it. Learning the sign from what a push actually did is what lets
+// this work on a game whose mouse look runs the other way; a push that changes
+// nothing, tried in both directions, is an axis against a limit of its own.
+struct LookAxis
+{
+	float deg_per_px = LOOK_FIRST_GUESS_DEG_PER_PX;
+	int pushed = 0;
+	int stall = 0;
+	int flips = 0;
+	bool stuck = false;
+	bool moved_ever = false;
+
+	// A new look command on the same client: what the axis has learned about
+	// the game is still true, so only what is about this one command is
+	// cleared. The second aim of a run then costs no frames finding the sign
+	// again.
+	void restart()
+	{
+		pushed = 0;
+		stall = 0;
+		flips = 0;
+		stuck = false;
+	}
+
+	void observe(float delta)
+	{
+		if(pushed == 0)
+			return;
+		if(fabsf(delta) > LOOK_MOVED_DEG){
+			deg_per_px = delta / (float)pushed;
+			stall = 0;
+			flips = 0;
+			stuck = false;
+			moved_ever = true;
+			return;
+		}
+		// Not at once: a push takes a frame or two to come back around
+		// through SDL and the game's own update
+		if(++stall < LOOK_FLIP_FRAMES)
+			return;
+		stall = 0;
+		deg_per_px = -deg_per_px;
+		if(++flips >= 2)
+			stuck = true;
+	}
+};
+
 extern client::Config g_client_config;
 extern volatile sig_atomic_t g_shutdown_signal;
 
@@ -448,6 +511,22 @@ struct CApp: public App, public magic::Application
 	bool m_command_seq_stdin_eof = false;
 	bool m_command_seq_failed = false;
 	bool m_command_seq_extra_frame = false;
+
+	// The look command, which aims the camera by injecting mouse movement
+	// and watching what the camera does about it. Nothing here knows what
+	// game is running: how far a pixel turns the camera, and which way, is
+	// measured from the last frame's injection rather than assumed.
+	// What the command log line has already been written for, so that a
+	// command that takes several frames is announced once
+	int m_command_logged_index = -1;
+	bool m_look_running = false;
+	LookAxis m_look_x;
+	LookAxis m_look_y;
+	float m_look_last_yaw = 0.0f;
+	float m_look_last_pitch = 0.0f;
+	bool m_look_had_angles = false;
+	int m_look_frames = 0;
+	int m_look_no_camera_frames = 0;
 
 	magic::SharedPtr<magic::Scene> m_scene;
 	magic::SharedPtr<magic::Node> m_camera_node;
@@ -883,6 +962,167 @@ struct CApp: public App, public magic::Application
 			client::command_seq::absorb_mouse_move_suppression(input);
 	}
 
+	// Where the camera of the first viewport points: yaw from +Z towards +X
+	// and pitch upwards, both in degrees. False when there is no camera --
+	// a game that has not made one yet, or a menu.
+	bool camera_angles(float *yaw, float *pitch)
+	{
+		auto *renderer = GetSubsystem<magic::Renderer>();
+		if(!renderer || renderer->GetNumViewports() < 1)
+			return false;
+		magic::Viewport *viewport = renderer->GetViewport(0);
+		if(!viewport)
+			return false;
+		magic::Camera *camera = viewport->GetCamera();
+		if(!camera || !camera->GetNode())
+			return false;
+		magic::Vector3 d = camera->GetNode()->GetWorldDirection();
+		if(d.LengthSquared() < 1e-12f)
+			return false;
+		d.Normalize();
+		*yaw = magic::Atan2(d.x_, d.z_);
+		*pitch = magic::Asin(d.y_);
+		return true;
+	}
+
+	static float wrap_degrees(float a)
+	{
+		while(a > 180.0f)
+			a -= 360.0f;
+		while(a < -180.0f)
+			a += 360.0f;
+		return a;
+	}
+
+	// How many pixels to ask for on one axis this frame. Never more than a
+	// LOOK_MAX_STEP_DEG turn, because a game that smooths its mouse look
+	// rings if it is asked to cross the sky at once, and never zero while
+	// there is still an error to close, because a rounded-down step would
+	// stall the loop short of the target.
+	static int look_step_px(float err, float deg_per_px, float tolerance)
+	{
+		if(fabsf(err) <= tolerance)
+			return 0;
+		if(fabsf(deg_per_px) < 1e-6f)
+			return err > 0.0f ? 1 : -1;
+		float px = err / deg_per_px;
+		float limit = LOOK_MAX_STEP_DEG / fabsf(deg_per_px);
+		if(px > limit)
+			px = limit;
+		if(px < -limit)
+			px = -limit;
+		int i = (int)(px >= 0.0f ? px + 0.5f : px - 0.5f);
+		if(i == 0)
+			i = px >= 0.0f ? 1 : -1;
+		return i;
+	}
+
+	// One frame of the look command. True when the camera has arrived; on
+	// failure it calls command_seq_fail(), which shuts the client down.
+	bool command_seq_look(const client::command_seq::Command &c)
+	{
+		float yaw = 0.0f, pitch = 0.0f;
+		bool have = camera_angles(&yaw, &pitch);
+
+		if(!m_look_running){
+			m_look_running = true;
+			m_look_frames = 0;
+			m_look_no_camera_frames = 0;
+			m_look_had_angles = false;
+			m_look_x.restart();
+			m_look_y.restart();
+		}
+
+		if(!have){
+			// Nothing to steer by. A game that has not made its camera yet
+			// gets a few frames; one that never does is not aimable.
+			if(++m_look_no_camera_frames >= LOOK_STILL_FRAMES){
+				m_look_running = false;
+				command_seq_fail("look: there is no camera on viewport 0");
+				return false;
+			}
+			m_look_had_angles = false;
+			return false;
+		}
+		m_look_no_camera_frames = 0;
+
+		// What the last frame's push did, which is the only thing here that
+		// knows anything about the game running
+		if(m_look_had_angles){
+			m_look_x.observe(wrap_degrees(yaw - m_look_last_yaw));
+			m_look_y.observe(pitch - m_look_last_pitch);
+		}
+
+		if(m_look_x.stuck && m_look_y.stuck &&
+				!m_look_x.moved_ever && !m_look_y.moved_ever){
+			m_look_running = false;
+			command_seq_fail(ss_()+"look: the camera does not follow the "
+					"mouse; it stayed at yaw "+ftos(yaw)+" pitch "+
+					ftos(pitch)+" however it was pushed");
+			return false;
+		}
+
+		// A game whose mouse look is coarse cannot be aimed finer than one
+		// pixel of it, so the tolerance gives way to that rather than the
+		// loop hunting for something it cannot hit
+		float tol_x = fmaxf(LOOK_TOLERANCE_DEG,
+				0.75f * fabsf(m_look_x.deg_per_px));
+		float tol_y = fmaxf(LOOK_TOLERANCE_DEG,
+				0.75f * fabsf(m_look_y.deg_per_px));
+		float err_yaw = wrap_degrees((float)c.yaw - yaw);
+		float err_pitch = (float)c.pitch - pitch;
+		// An axis that has moved and then stopped answering in either
+		// direction is against a limit the game keeps -- a pitch clamp, most
+		// of the time -- and is as arrived as it is going to get
+		bool done_x = fabsf(err_yaw) <= tol_x || m_look_x.stuck;
+		bool done_y = fabsf(err_pitch) <= tol_y || m_look_y.stuck;
+		if(done_x && done_y){
+			m_look_running = false;
+			if(fabsf(err_yaw) > tol_x || fabsf(err_pitch) > tol_y)
+				log_w(MODULE, "look: the camera stops at yaw %.1f pitch %.1f; "
+						"asked for yaw %.1f pitch %.1f",
+						yaw, pitch, (float)c.yaw, (float)c.pitch);
+			else
+				log_v(MODULE, "look: arrived at yaw %.1f pitch %.1f in %i "
+						"frames", yaw, pitch, m_look_frames);
+			return true;
+		}
+
+		m_look_x.pushed = m_look_x.stuck ? 0 :
+				look_step_px(err_yaw, m_look_x.deg_per_px, tol_x);
+		m_look_y.pushed = m_look_y.stuck ? 0 :
+				look_step_px(err_pitch, m_look_y.deg_per_px, tol_y);
+		m_look_last_yaw = yaw;
+		m_look_last_pitch = pitch;
+		m_look_had_angles = true;
+
+		log_v(MODULE, "look: at yaw %.2f pitch %.2f, pushing %i,%i at "
+				"%.4f,%.4f deg/px", yaw, pitch,
+				m_look_x.pushed, m_look_y.pushed,
+				m_look_x.deg_per_px, m_look_y.deg_per_px);
+
+		if(m_look_x.pushed != 0 || m_look_y.pushed != 0){
+			ss_ err;
+			if(!client::command_seq::inject_mouse_move(
+					GetSubsystem<magic::Input>(),
+					m_look_x.pushed, m_look_y.pushed, &err)){
+				m_look_running = false;
+				command_seq_fail(err);
+				return false;
+			}
+		}
+
+		if(++m_look_frames >= LOOK_MAX_FRAMES){
+			m_look_running = false;
+			command_seq_fail(ss_()+"look: the camera did not arrive in "+
+					itos(LOOK_MAX_FRAMES)+" frames; it is at yaw "+
+					ftos(yaw)+" pitch "+ftos(pitch)+" and was asked for yaw "+
+					ftos((float)c.yaw)+" pitch "+ftos((float)c.pitch));
+			return false;
+		}
+		return false;
+	}
+
 	bool command_seq_exec(const client::command_seq::Command &c)
 	{
 		using client::command_seq::Type;
@@ -926,6 +1166,7 @@ struct CApp: public App, public magic::Application
 		case Type::Quit:
 		case Type::Delay:
 		case Type::Screenshot:
+		case Type::Look:
 			return true;
 		}
 		if(!ok)
@@ -971,8 +1212,11 @@ struct CApp: public App, public magic::Application
 		while(m_command_index < m_commands.size()){
 			const client::command_seq::Command &c =
 					m_commands[m_command_index];
-			log_i(MODULE, "command: %s",
-					cs(client::command_seq::dump_command(c)));
+			if(m_command_logged_index != (int)m_command_index){
+				m_command_logged_index = (int)m_command_index;
+				log_i(MODULE, "command: %s",
+						cs(client::command_seq::dump_command(c)));
+			}
 			if(c.type == Type::Delay){
 				m_command_wait_until_us = now + c.n * 1000;
 				m_command_index++;
@@ -982,6 +1226,14 @@ struct CApp: public App, public magic::Application
 				m_pending_screenshot = c.s;
 				m_command_index++;
 				return;
+			}
+			if(c.type == Type::Look){
+				// One step a frame, so that what the last one did can be
+				// seen before the next one is decided
+				if(!command_seq_look(c))
+					return;
+				m_command_index++;
+				continue;
 			}
 			if(c.type == Type::Quit){
 				m_command_index = m_commands.size();

--- a/src/client/command_seq.cpp
+++ b/src/client/command_seq.cpp
@@ -13,6 +13,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <cmath>
 #include <climits>
 #include <fcntl.h>
 #include <unistd.h>
@@ -48,6 +49,19 @@ static bool parse_int(const ss_ &s, int *out)
 	if(v < (int64_t)INT_MIN || v > (int64_t)INT_MAX)
 		return false;
 	*out = (int)v;
+	return true;
+}
+
+static bool parse_f64(const ss_ &s, double *out)
+{
+	if(s.empty())
+		return false;
+	errno = 0;
+	char *end = nullptr;
+	double v = strtod(s.c_str(), &end);
+	if(errno || end == s.c_str() || *end != '\0' || v != v)
+		return false;
+	*out = v;
 	return true;
 }
 
@@ -105,6 +119,44 @@ static bool parse_xy(const ss_ &rest, int *x, int *y, ss_ *error)
 		*error = "Expected two integers";
 		return false;
 	}
+	return true;
+}
+
+// "10 -20" -> yaw, pitch in degrees
+static bool parse_angles(const ss_ &rest, double *yaw, double *pitch,
+		ss_ *error)
+{
+	c55::Strfnd f(rest);
+	ss_ a = trim_copy(f.next(" "));
+	ss_ b = trim_copy(f.next(""));
+	if(a.empty() || b.empty() || !parse_f64(a, yaw) || !parse_f64(b, pitch)){
+		*error = "Expected two numbers";
+		return false;
+	}
+	return true;
+}
+
+// "0 0 1" -> the same two angles: yaw from +Z towards +X, pitch upwards
+static bool parse_direction(const ss_ &rest, double *yaw, double *pitch,
+		ss_ *error)
+{
+	c55::Strfnd f(rest);
+	ss_ xs = trim_copy(f.next(" "));
+	ss_ ys = trim_copy(f.next(" "));
+	ss_ zs = trim_copy(f.next(""));
+	double x = 0, y = 0, z = 0;
+	if(xs.empty() || ys.empty() || zs.empty() ||
+			!parse_f64(xs, &x) || !parse_f64(ys, &y) || !parse_f64(zs, &z)){
+		*error = "Expected three numbers";
+		return false;
+	}
+	double len = sqrt(x * x + y * y + z * z);
+	if(len < 1e-9){
+		*error = "The direction has no length";
+		return false;
+	}
+	*yaw = atan2(x, z) * 180.0 / M_PI;
+	*pitch = asin(y / len) * 180.0 / M_PI;
 	return true;
 }
 
@@ -194,6 +246,14 @@ static bool parse_body(const ss_ &text, sv_<Command> *out, ss_ *error)
 			c.s = rest;
 			if(c.s.empty())
 				return fail("text <string>");
+		} else if(cmd == "look"){
+			c.type = Type::Look;
+			if(!parse_angles(rest, &c.yaw, &c.pitch, error))
+				return fail(*error+"; look <yaw> <pitch>, in degrees");
+		} else if(cmd == "look_dir"){
+			c.type = Type::Look;
+			if(!parse_direction(rest, &c.yaw, &c.pitch, error))
+				return fail(*error+"; look_dir <x> <y> <z>");
 		} else if(cmd == "quit"){
 			c.type = Type::Quit;
 			if(!rest.empty())
@@ -276,10 +336,12 @@ static void self_check()
 			"mouse_wheel 3\n"
 			"text hello\n"
 			"screenshot /tmp/x.png\n"
+			"look 10 -20\n"
+			"look_dir 1 0 0\n"
 			"quit\n";
 	if(!parse_body(sample, &cs, &err))
 		throw Exception(ss_()+"command_seq self_check parse: "+err);
-	if(cs.size() != 13)
+	if(cs.size() != 15)
 		throw Exception("command_seq self_check count "+itos(cs.size()));
 	if(cs[0].type != Type::Delay || cs[0].n != 100)
 		throw Exception("command_seq self_check delay");
@@ -287,6 +349,12 @@ static void self_check()
 		throw Exception("command_seq self_check mouse_move");
 	if(cs[6].x != SDL_BUTTON_LEFT || cs[8].x != SDL_BUTTON_RIGHT)
 		throw Exception("command_seq self_check buttons");
+	if(cs[12].type != Type::Look || cs[12].yaw != 10.0 || cs[12].pitch != -20.0)
+		throw Exception("command_seq self_check look");
+	// Straight along +X is a quarter turn from +Z, and level
+	if(cs[13].type != Type::Look || fabs(cs[13].yaw - 90.0) > 1e-9 ||
+			fabs(cs[13].pitch) > 1e-9)
+		throw Exception("command_seq self_check look_dir");
 	if(!parse_body("nope 1\n", &cs, &err) && err.find("unknown command") != ss_::npos)
 		return;
 	throw Exception("command_seq self_check unknown command");
@@ -342,6 +410,12 @@ ss_ dump_command(const Command &c)
 		return "text "+c.s;
 	case Type::Quit:
 		return "quit";
+	case Type::Look:
+		{
+			char buf[64];
+			snprintf(buf, sizeof buf, "look %g %g", c.yaw, c.pitch);
+			return buf;
+		}
 	}
 	return "?";
 }

--- a/src/client/command_seq.h
+++ b/src/client/command_seq.h
@@ -27,6 +27,7 @@ namespace command_seq
 		MouseWheel,
 		Text,
 		Quit,
+		Look,
 	};
 
 	struct Command
@@ -36,6 +37,11 @@ namespace command_seq
 		int x = 0;
 		int y = 0;
 		ss_ s;
+		// Look only: where the camera is to point, in degrees. yaw is
+		// measured from +Z towards +X and pitch is positive upwards, which
+		// is what a direction vector (x, y, z) comes out as.
+		double yaw = 0.0;
+		double pitch = 0.0;
 	};
 
 	// One command per line. Empty lines and '#' comments are ignored.


### PR DESCRIPTION
Independent of the `aggregate-ux` → `luanti-pbr-2` → `luanti-module` stack;
touches only `src/client/` and its doc.

Aiming a camera in a `-c` command sequence meant pushing `mouse_move` by a
pixel count worked out from the game's own sensitivity and then guessing how
many frames it needs. A script written that way is written against one game,
and wrong again as soon as that game's mouse look changes.

    look <yaw> <pitch>
    look_dir <x> <y> <z>

aim the camera and end when it is aimed. Degrees: yaw from +Z towards +X,
pitch positive upwards.

Nothing in it knows what game is running. It injects mouse movement and
watches what the camera of viewport 0 does about it, so how far a pixel turns
the camera — and which way round — is measured from what the last push
actually did rather than assumed. A push that changes nothing is tried the
other way before it is believed, which is what happens on the first aim of a
run when the guessed sign is wrong or the camera starts against its pitch
clamp. It arrives in three or four frames, and what it learns is kept for the
next `look` in the same run.

An axis that has moved and then stops answering in both directions is against
a limit the game keeps — a pitch clamp, most of the time — and the command
ends with a warning naming where it stopped, rather than failing a whole run
over the degree between −89 and −90. A camera that never moves at all, and a
viewport with no camera on it, fail the sequence and exit the client non-zero,
which is what makes a script that aims at nothing loud instead of quietly
wrong.

Checked against `luanti_client` on a VoxeLibre server: `look 90 -20` from the
pitch clamp, `look -135 10`, and `look_dir 0 1 0.05` all arrive in three
frames; `look` with no world connected exits 1 with "there is no camera on
viewport 0"; `look abc 2` and `look_dir 0 0 0` are refused at parse time.
`command_seq`'s own self-check, which runs on every parse, covers both
spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)