### PR TITLE
Quiet the compiler probe, and correct the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ Buildat Linux How-To
 Install dependencies
 ----------------------
 
-	$ # Dependencies for Urho3D
-	$ sudo apt-get install libx11-dev libxrandr-dev libasound2-dev libgl1-mesa-dev
-	$ sudo yum install libX11-devel libXrandr-devel alsa-lib-devel
+	$ # A compiler and cmake, plus the X, sound and GL headers Urho3D needs
+	$ sudo apt-get install build-essential cmake \
+	        libx11-dev libxrandr-dev libasound2-dev libgl1-mesa-dev
+	$ sudo dnf install gcc-c++ cmake \
+	        libX11-devel libXrandr-devel alsa-lib-devel mesa-libGL-devel
+
+The server also needs a C++ compiler at run time, not just at build time: it
+compiles game modules as it loads them. It looks for `c++` in PATH.
 
 Build
 -------
@@ -40,8 +45,12 @@ required for the module interface.
     $ cd $wherever_buildat_is
     $ mkdir Build  # Capital B is a good idea so it stays out of the way in tabcomplete
     $ cd Build
-    $ cmake .. -DCMAKE_BUILD_TYPE=Debug  # Add -DURHO3D_64BIT=true on 64-bit systems
+    $ cmake .. -DCMAKE_BUILD_TYPE=Debug
     $ make -j4
+
+The bundled Urho3D is built by a sub-build that uses every core regardless of
+the `-j` given here, which is where the `-j0 forced in submake` warning comes
+from.
 
 You can use -DBUILD_SERVER=false or -DBUILD_CLIENT=false if you don't need the
 server or the client, respectively.

--- a/src/boot/autodetect.cpp
+++ b/src/boot/autodetect.cpp
@@ -45,7 +45,18 @@ static bool check_runnable(const ss_ &command)
 	if(m_valid_commands.count(command))
 		return true;
 
-	int exit_status = interface::process::shell_exec(command);
+	// Probing a path that does not exist is the normal case -- the compiler
+	// is looked for in a couple of places before PATH -- so neither the
+	// shell's complaint about it nor the version banner of the one that
+	// works is news. Only the shell_exec() on Linux runs the command through
+	// a shell; the Windows one hands it to CreateProcess, where a redirection
+	// would be an argument to the program instead.
+#ifndef _WIN32
+	ss_ run = command + " >/dev/null 2>&1";
+#else
+	ss_ run = command;
+#endif
+	int exit_status = interface::process::shell_exec(run);
 	if(exit_status != 0){
 		log_d(MODULE, "Command failed: [%s]", cs(command));
 		return false;
@@ -263,8 +274,14 @@ static bool detect_compiler_bin_paths(core::Config &config)
 {
 	sv_<ss_> roots;
 	generate_compiler_binary_dir_alternatives(roots);
-	return detect_paths(config, roots, compiler_bin_paths,
-			"Compiler binary directory");
+	if(!detect_paths(config, roots, compiler_bin_paths,
+			"Compiler binary directory"))
+		return false;
+	// Said out loud because the probe is silent now, and which compiler is
+	// going to build the runtime-compiled modules is worth knowing
+	log_i(MODULE, "Compiler command: [%s]",
+			cs(config.get<ss_>("compiler_command")));
+	return true;
 }
 
 // Client-only paths


### PR DESCRIPTION
A clean checkout of master was cloned into a directory outside the working
tree and built and run, to see whether it works for someone who has never
had this tree before. It does: Debug, Release, `-DBUILD_CLIENT=false` and
`-DBUILD_SERVER=false` all configure and build; the bundled Urho3D builds
into `3rdparty/Urho3D/Build` and the binaries link against that one and not
against any other tree's; the launch menu draws; and `buildat_server -m
../games/minigame` plus a client connecting, compiling the game's module at
runtime and screenshotting it works from both the Debug and the Release
build.

So this is not a fix for a broken build. It is the two things that looked
broken while checking.

**The compiler probe.** `check_runnable()` runs `<root>c++ --version`
through the shell for each candidate directory, and both streams were left
connected, so a server start opened with

    sh: line 1: .../Build/compiler/bin/c++: No such file or directory
    sh: line 1: .../compiler/bin/c++: No such file or directory
    c++ (GCC) 15.2.1 ...

Those two paths are never expected to exist -- they are looked at before
PATH -- so the complaint is not news, and neither is the version banner of
the one that works. The probe is redirected now and the compiler that was
chosen is logged instead, which is the part actually worth knowing. The
redirection is guarded for Linux: the Windows `shell_exec()` hands the
command to `CreateProcess` rather than to a shell, where a redirection would
become an argument to the program.

**The README.** `-DURHO3D_64BIT=true on 64-bit systems` is no longer needed;
the clean build never got the flag. The dependency lists named the X, sound
and GL libraries Urho3D wants but not cmake, a C++ compiler or the GL headers
themselves, and did not mention that the server needs a compiler at run time
as well. How short the lists still are is not established beyond this
machine, which has every dev package installed already -- the honest check is
a container, and that is worth doing separately. The `-j0 forced in submake`
warning now has a sentence explaining it: the bundled Urho3D sub-build is
`cmake --build --parallel` with no number, so it uses every core whatever the
outer `-j` said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)