### PR TITLE
Client preferences: undersampling, vsync, frame limiter, MSAA, volume and mute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ session.vim
 /build
 /Build
 /cache
+/user
 
 /tmp
 /local

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ Debug keys, in any game:
 * F9: on-screen profiler, render and resource stats
 * F10: sandbox test extension
 
+Preferences
+-----------
+
+What the user sets once and every game honours: `render_scale` (3D viewports
+drawn at a fraction of the window size, with the UI left at native
+resolution), `vsync`, `max_fps`, `multisampling`, `sound_volume` and
+`sound_mute`. They live in `user/preferences.json` beside the remembered
+window size, and there is no screen for them yet -- edit the file, or set them
+for one run with `-o`, which is not written back:
+
+    $ bin/buildat -o render_scale=0.5,vsync=0,sound_mute=1
+
+`user/` is where what the user made, chose or downloaded deliberately goes, as
+against `cache/`, which is what the program can recreate by itself. Both sit
+in the buildat directory; `-D` and `-C` move them.
+
+See [doc/client_api.txt](doc/client_api.txt) for what a game does to honour
+`render_scale`, and what the client does not get to decide.
+
 Server and client
 -----------------
 

--- a/client/api.lua
+++ b/client/api.lua
@@ -33,6 +33,10 @@ buildat.bignum = {
 }
 buildat.set_ui_scale      = __buildat_set_ui_scale
 buildat.get_ui_scale      = __buildat_get_ui_scale
+-- The fraction of the window size the user asked 3D viewports to be rendered
+-- at. magic.set_preferred_viewports() applies it; this is for a game that
+-- wants to know. 1.0 means no scaling at all.
+buildat.get_preferred_render_scale = __buildat_get_preferred_render_scale
 buildat.font_sans         = "Fonts/Overpass-Regular.ttf"
 buildat.font_mono         = "Fonts/OverpassMono-Regular.ttf"
 buildat.SpatialUpdateQueue = __buildat_SpatialUpdateQueue
@@ -50,6 +54,7 @@ buildat.read_image        = __buildat_read_image
 buildat.safe.disconnect    = __buildat_disconnect
 buildat.safe.set_ui_scale  = __buildat_set_ui_scale
 buildat.safe.get_ui_scale  = __buildat_get_ui_scale
+buildat.safe.get_preferred_render_scale = __buildat_get_preferred_render_scale
 buildat.safe.font_sans     = buildat.font_sans
 buildat.safe.font_mono     = buildat.font_mono
 buildat.safe.get_time_us   = __buildat_get_time_us

--- a/doc/client_api.txt
+++ b/doc/client_api.txt
@@ -41,6 +41,14 @@ buildat.unsub_packet(function)
 buildat.run_script_file(name)
 - Run script file gotten from server in sandbox environment
 
+buildat.get_preferred_render_scale() -> number
+- The fraction of the window size the user asked 3D viewports to be rendered
+  at. 1.0 means no scaling at all, which is the default.
+- magic.set_preferred_viewports() is what applies it; this is for a game that
+  wants to know, to show it on a settings screen of its own or to size
+  something of its own to match.
+- See "Client preferences" below.
+
 
 The extension environment
 =========================
@@ -192,6 +200,56 @@ render_scene_to_texture(scene, camera_node, w, h) -> Texture2D
 - The scene is drawn with its own viewport and no postprocessing, so a scene
   lit for the main viewport's HDR tonemapping comes out blown out. Light a
   thumbnail scene for the low dynamic range it is.
+
+set_preferred_viewports({viewport, ...})
+- The viewports the user's graphics preferences are applied to, as against the
+  raw renderer:SetViewport() ones, which are drawn the way the game says and
+  nothing else. That is what "preferred" means throughout this API: it honours
+  what the user asked for.
+- Use it instead of renderer:SetViewport(). The engine draws the scene at the
+  user's render_scale, under a UI that stays at native resolution, and the
+  viewport stays the game's own -- replacing renderPath afterwards, which most
+  games do, still works, and so does HDR.
+- The whole list at once, because Urho3D needs both a viewport per slot and a
+  count. An empty table is teardown: nothing is left on the screen.
+
+      magic.set_preferred_viewports({viewport})            -- one view
+      magic.set_preferred_viewports({vp_top, vp_bottom})   -- two
+      magic.set_preferred_viewports({})                    -- teardown
+
+- Declarative: this is what is on the screen now. A game that moves a viewport
+  rect -- games/bomber_drone splits the window in half -- calls it again after
+  setting the new rects, and the rects it reads are in window pixels whatever
+  the scale is, so nothing about screen-to-world maths or picking changes.
+- A game that does not call this is drawn at native resolution and keeps
+  working. The preference is a preference: the client owns how much the frame
+  costs, the game owns what is in it. That is the deal, not a gap to be closed
+  later.
+
+Client preferences
+------------------
+What the user sets once and every game honours: how much the frame costs and
+how loud it is, never what the art is. Kept in user/preferences.json, and
+overridden for one run by -o (see README.md).
+
+    render_scale    3D viewports drawn at this fraction of the window size;
+                    the UI stays at native resolution. 1.0 is a bypass.
+    vsync           present synchronised to the display
+    max_fps         frame limiter; 0 is unlimited
+    multisampling   MSAA samples: 1, 2, 4, 8 or 16
+    sound_volume    a gain every sound is multiplied by
+    sound_mute      that gain forced to zero
+
+render_scale is cooperative: it reaches a game's viewports only through
+set_preferred_viewports(), because a viewport belongs to the game that made
+it. The sound pair is enforced, because Urho3D already multiplies every sound
+type's gain by the "Master" one -- which is why Audio:SetMasterGain("Master")
+is refused in the sandbox. Games have "Effect", "Music", "Ambient" and
+"Voice", and their own mixing multiplies under the user's setting.
+
+Shadow quality, texture and material quality, filtering, FOV and draw distance
+are deliberately not here: each one changes what the game looks like or what a
+player can see, and the game is the one that should say.
 
 replicate
 ---------

--- a/doc/client_commands.txt
+++ b/doc/client_commands.txt
@@ -14,6 +14,15 @@ exits after the sequence finishes (exit status 1 if a command fails).
 -w WxH runs windowed at a fixed size without changing the size the client
 remembers between runs. Use it for anything that compares images between runs.
 
+-c ignores user/preferences.json entirely and runs on the built-in defaults,
+so a preference someone left at render_scale=0.5 can never change what a
+screenshot looks like, and a run never writes the file. A -c run is also muted
+unless -o says otherwise: nothing captures audio, and a driven run playing a
+game's music through whoever's speakers is a small recurring annoyance with no
+upside. -o still wins, which is how a preference itself gets tested:
+
+    $ bin/buildat -s localhost -w 1600x900 -o render_scale=0.5 -c @check.txt
+
 @path reads the commands from a file. Empty lines and lines starting with # are
 ignored.
 

--- a/extensions/luanti_client/world.lua
+++ b/extensions/luanti_client/world.lua
@@ -841,7 +841,7 @@ function M.new(magic, buildat, log, options)
 	-- Lua collects garbage
 	local viewport = magic.Viewport:new(scene, camera)
 	self.viewport = viewport
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	-- On the PBR path the frame is rendered in HDR and tone mapped, the way
 	-- games/voxel_lighting does it. Nothing else makes the sun read as the
@@ -4520,8 +4520,8 @@ function M.new(magic, buildat, log, options)
 			object_nodes[id] = nil
 		end
 		-- Dropping the viewport rather than replacing it: there is nothing
-		-- else to show, and SetViewport() takes no nil
-		magic.renderer.numViewports = 0
+		-- else to show
+		magic.set_preferred_viewports({})
 		-- HDR and the render path are the renderer's, not the viewport's, so
 		-- a world that has gone has to hand them back or the menu after it is
 		-- drawn through a tone curve with nothing to tone map

--- a/extensions/urho3d/init.lua
+++ b/extensions/urho3d/init.lua
@@ -337,6 +337,30 @@ Safe.render_scene_to_texture = wrap_function({"Scene", "Node", "number",
 			scene, camera_node, w, h))
 end)
 
+-- The viewports the user's graphics preferences are applied to, as against
+-- the raw renderer:SetViewport() ones which are drawn the way the game says
+-- and nothing else. Use this instead of renderer:SetViewport(): the engine
+-- draws the scene at the render_scale the user asked for, under a UI that
+-- stays at native resolution, and the viewport stays the game's own -- what
+-- it does to renderPath afterwards still works.
+--
+--     magic.set_preferred_viewports({viewport})            -- one view
+--     magic.set_preferred_viewports({vp_top, vp_bottom})   -- two
+--     magic.set_preferred_viewports({})                    -- teardown
+--
+-- A game that does not call this is drawn at native resolution and keeps
+-- working; the preference is a preference.
+function Safe.set_preferred_viewports(viewports)
+	if type(viewports) ~= 'table' then
+		error("set_preferred_viewports(): expected a table of Viewports")
+	end
+	local unsafe = {}
+	for i = 1, #viewports do
+		unsafe[i] = magic_sandbox.safe_to_unsafe(viewports[i], "Viewport")
+	end
+	__buildat_set_preferred_viewports(unsafe)
+end
+
 --
 -- Unsafe interface
 --

--- a/extensions/urho3d/safe_classes.lua
+++ b/extensions/urho3d/safe_classes.lua
@@ -1317,8 +1317,20 @@ function M.define(dst, util)
 
 	util.wc("Audio", {
 		instance = {
-			SetMasterGain = util.self_function(
-					"SetMasterGain", {}, {"Audio", "string", "number"}),
+			-- Urho3D multiplies a type's gain by the "Master" one, so the
+			-- master is the user's volume preference and not a game's to
+			-- write. "Effect", "Music", "Ambient" and "Voice" are what a
+			-- game's own mixing is for, and they multiply under it.
+			SetMasterGain = util.wrap_function(
+					{"Audio", "string", "number"},
+					function(self, type_name, gain)
+						if type_name == "Master" then
+							error("Audio:SetMasterGain(\"Master\") is the"..
+									" client's volume preference; use a sound"..
+									" type such as \"Effect\" or \"Music\"")
+						end
+						self:SetMasterGain(type_name, gain)
+					end),
 			Play = util.self_function("Play", {"boolean"}, {"Audio"}),
 			Stop = util.self_function("Stop", {}, {"Audio"}),
 		},

--- a/games/aggregate/main/client_lua/init.lua
+++ b/games/aggregate/main/client_lua/init.lua
@@ -415,7 +415,7 @@ do
 
 	-- And this thing so the camera is shown on the screen
 	local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	magic.renderer.HDRRendering = true
 	local rp = viewport.renderPath:Clone()

--- a/games/aggregate_look/main/client_lua/init.lua
+++ b/games/aggregate_look/main/client_lua/init.lua
@@ -77,7 +77,7 @@ do
 	camera.fov = CAMERA_FOV
 
 	local viewport = magic.Viewport:new(scene, camera)
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	magic.renderer.HDRRendering = true
 	local rp = viewport.renderPath:Clone()

--- a/games/bomber_drone/main/client_lua/init.lua
+++ b/games/bomber_drone/main/client_lua/init.lua
@@ -219,13 +219,16 @@ local function layout_viewports()
 	local half = math.floor(w / 2)
 	viewports[1]:SetRect(magic.IntRect(0, 0, half, h))
 	viewports[2]:SetRect(magic.IntRect(half, 0, w, h))
+	-- Declarative: this is what is on the screen now, at whatever the user's
+	-- render scale is. The rects are read again here, so a new layout has to
+	-- say so rather than being noticed
+	magic.set_preferred_viewports(viewports)
 end
 
 do
 	local function add_viewport(index, camera)
 		local viewport = magic.Viewport:new(scene, camera)
 		viewports[index + 1] = viewport
-		magic.renderer:SetViewport(index, viewport)
 		local rp = viewport.renderPath:Clone()
 		rp:Append(magic.cache:GetResource("XMLFile", "PostProcess/BloomHDR.xml"))
 		rp:Append(magic.cache:GetResource("XMLFile", "PostProcess/Tonemap.xml"))
@@ -236,10 +239,10 @@ do
 		rp:SetShaderParameter("TonemapExposureBias", EXPOSURE_BIAS)
 		viewport.renderPath = rp
 	end
-	magic.renderer.numViewports = 2
 	magic.renderer.HDRRendering = true
 	add_viewport(0, chase_camera)
 	add_viewport(1, nose_camera)
+	-- Puts both on the screen, since it is what sets their rects
 	layout_viewports()
 end
 

--- a/games/digger/main/client_lua/init.lua
+++ b/games/digger/main/client_lua/init.lua
@@ -254,7 +254,7 @@ do
 
 	-- And this thing so the camera is shown on the screen
 	local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	magic.renderer.HDRRendering = true
 	local rp = viewport.renderPath:Clone()

--- a/games/entitytest/main/client_lua/init.lua
+++ b/games/entitytest/main/client_lua/init.lua
@@ -18,7 +18,7 @@ camera_node:LookAt(magic.Vector3(0, 1, 0))
 
 -- And this thing so the camera is shown on the screen
 local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-magic.renderer:SetViewport(0, viewport)
+magic.set_preferred_viewports({viewport})
 
 -- Add some text
 local title_text = magic.ui.root:CreateChild("Text")

--- a/games/featuretest/main/client_lua/init.lua
+++ b/games/featuretest/main/client_lua/init.lua
@@ -179,7 +179,7 @@ do
 		magic.audio:SetMasterGain(magic.SOUND_MASTER, 0.7)
 	end
 	local viewport = magic.Viewport:new(scene, camera)
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 end
 
 do

--- a/games/geometry/main/client_lua/init.lua
+++ b/games/geometry/main/client_lua/init.lua
@@ -18,7 +18,7 @@ camera_node:LookAt(magic.Vector3(0, 1, 0))
 
 -- And this thing so the camera is shown on the screen
 local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-magic.renderer:SetViewport(0, viewport)
+magic.set_preferred_viewports({viewport})
 
 -- Add some text
 local title_text = magic.ui.root:CreateChild("Text")

--- a/games/geometry2/main/client_lua/init.lua
+++ b/games/geometry2/main/client_lua/init.lua
@@ -18,7 +18,7 @@ camera_node:LookAt(magic.Vector3(0, 1, 0))
 
 -- And this thing so the camera is shown on the screen
 local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-magic.renderer:SetViewport(0, viewport)
+magic.set_preferred_viewports({viewport})
 
 -- Add some text
 local title_text = magic.ui.root:CreateChild("Text")

--- a/games/infidigger/main/client_lua/init.lua
+++ b/games/infidigger/main/client_lua/init.lua
@@ -249,7 +249,7 @@ do
 
 	-- And this thing so the camera is shown on the screen
 	local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	magic.renderer.HDRRendering = true
 	local rp = viewport.renderPath:Clone()

--- a/games/minigame/main/client_lua/init.lua
+++ b/games/minigame/main/client_lua/init.lua
@@ -46,7 +46,7 @@ camera_node.position = magic.Vector3(7.0, 7.0, 7.0)
 camera_node:LookAt(magic.Vector3(0, 1, 0))
 -- And this thing so the camera is shown on the screen
 local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-magic.renderer:SetViewport(0, viewport)
+magic.set_preferred_viewports({viewport})
 
 -- Add some text
 local title_text = magic.ui.root:CreateChild("Text")

--- a/games/multisection_lighting/main/client_lua/init.lua
+++ b/games/multisection_lighting/main/client_lua/init.lua
@@ -144,7 +144,7 @@ do
 	camera.fov = CAMERA_FOV
 
 	local viewport = magic.Viewport:new(scene, camera)
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	magic.renderer.HDRRendering = true
 	local rp = viewport.renderPath:Clone()

--- a/games/test/test1/client_lua/init.lua
+++ b/games/test/test1/client_lua/init.lua
@@ -45,7 +45,7 @@ camera_node.position = magic.Vector3(7.0, 7.0, 7.0)
 camera_node:LookAt(magic.Vector3(0, 1, 0))
 -- And this thing so the camera is shown on the screen
 local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-magic.renderer:SetViewport(0, viewport)
+magic.set_preferred_viewports({viewport})
 
 -- Add some text
 local title_text = magic.ui.root:CreateChild("Text")

--- a/games/undermine/main/client_lua/init.lua
+++ b/games/undermine/main/client_lua/init.lua
@@ -325,7 +325,7 @@ do
 
 	-- And this thing so the camera is shown on the screen
 	local viewport = magic.Viewport:new(scene, camera_node:GetComponent("Camera"))
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	magic.renderer.HDRRendering = true
 	local rp = viewport.renderPath:Clone()

--- a/games/voxel_lighting/README.txt
+++ b/games/voxel_lighting/README.txt
@@ -489,6 +489,12 @@ the images come out the same size whatever the window was left at last time.
 It also shoots both benchmark edits, so a run is: all seven views of the scene
 as generated, then three of them after the shaft and after the slab.
 
+The same run at -o render_scale=0.5 and at 1.0 is the check that the client's
+undersampling preference is doing what it should: the same scene, one softer,
+and the UI text equally sharp in both. This game is a good one for it because
+it renders in HDR with a tonemap appended to the render path, which is what
+the preference must not disturb.
+
 NOTE: the server reads client_lua and client_data once at startup, so restart
 it after editing init.lua, the shader or a cube map, or the client will be
 served the previous version. That goes for the voxel_shading module's files as

--- a/games/voxel_lighting/main/client_lua/init.lua
+++ b/games/voxel_lighting/main/client_lua/init.lua
@@ -145,7 +145,7 @@ do
 	camera.fov = CAMERA_FOV
 
 	local viewport = magic.Viewport:new(scene, camera)
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	magic.renderer.HDRRendering = true
 	local rp = viewport.renderPath:Clone()

--- a/games/voxel_physics/main/client_lua/init.lua
+++ b/games/voxel_physics/main/client_lua/init.lua
@@ -93,7 +93,7 @@ do
 	camera.fov = CAMERA_FOV
 
 	local viewport = magic.Viewport:new(scene, camera)
-	magic.renderer:SetViewport(0, viewport)
+	magic.set_preferred_viewports({viewport})
 
 	magic.renderer.HDRRendering = true
 	local rp = viewport.renderPath:Clone()

--- a/src/boot/autodetect.cpp
+++ b/src/boot/autodetect.cpp
@@ -295,6 +295,13 @@ PathDefinition client_paths[] = {
 		"/cache",
 		"/write.test",
 		"Cache directory"},
+	// What the user made, chose or downloaded deliberately, as against what
+	// the program can recreate by itself. See local/world_persistence_plan.md;
+	// the platform paths and -DPORTABLE come with the saves.
+	{PD_WRITE, "user_path",
+		"/user",
+		"/write.test",
+		"User directory"},
 	{PD_END, "", "", "", ""},
 };
 

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -37,6 +37,7 @@
 #include <Viewport.h>
 #include <Camera.h>
 #include <Renderer.h>
+#include <Audio.h>
 #include <Octree.h>
 #include <FileSystem.h>
 #include <PhysicsWorld.h>
@@ -134,9 +135,94 @@ struct LookAxis
 extern client::Config g_client_config;
 extern volatile sig_atomic_t g_shutdown_signal;
 
-static ss_ window_state_path()
+static ss_ preferences_path()
 {
-	return g_client_config.get<ss_>("cache_path")+"/window.json";
+	return g_client_config.get<ss_>("user_path")+"/preferences.json";
+}
+
+namespace app {
+
+// Every preference -o and preferences.json can carry is listed here once, so
+// that the flag and the file cannot drift apart.
+bool parse_preference_options(const ss_ &s, Options *opt, ss_ *error)
+{
+	size_t i = 0;
+	while(i < s.size()){
+		size_t comma = s.find(',', i);
+		if(comma == ss_::npos)
+			comma = s.size();
+		ss_ item = s.substr(i, comma - i);
+		i = comma + 1;
+		if(item.empty())
+			continue;
+		size_t eq = item.find('=');
+		if(eq == ss_::npos){
+			*error = "\""+item+"\": expected key=value";
+			return false;
+		}
+		ss_ key = item.substr(0, eq);
+		ss_ value = item.substr(eq + 1);
+		char *end = nullptr;
+		double v = strtod(value.c_str(), &end);
+		if(value.empty() || *end != '\0'){
+			*error = key+": \""+value+"\" is not a number";
+			return false;
+		}
+		bool in_range = true;
+		if(key == "render_scale"){
+			// Below 2 is undersampling, which is the point; above it is
+			// supersampling, which the same code path gives away for free
+			in_range = (v >= 0.1 && v <= 2.0);
+			opt->graphics.render_scale = (float)v;
+		} else if(key == "vsync"){
+			opt->graphics.vsync = (v != 0);
+		} else if(key == "max_fps"){
+			in_range = (v >= 0 && v <= 1000);
+			opt->graphics.max_fps = (int)v;
+		} else if(key == "multisampling"){
+			in_range = (v == 1 || v == 2 || v == 4 || v == 8 || v == 16);
+			opt->graphics.multisampling = (int)v;
+		} else if(key == "sound_volume"){
+			in_range = (v >= 0.0 && v <= 1.0);
+			opt->sound_volume = (float)v;
+		} else if(key == "sound_mute"){
+			opt->sound_mute = (v != 0);
+		} else {
+			*error = "unknown preference \""+key+"\"";
+			return false;
+		}
+		if(!in_range){
+			*error = key+": "+value+" is out of range";
+			return false;
+		}
+	}
+	return true;
+}
+
+}
+
+static void check_parse_preference_options()
+{
+	app::Options o;
+	ss_ err;
+	if(!app::parse_preference_options(
+			"render_scale=0.5,vsync=0,sound_mute=1", &o, &err))
+		throw Exception("parse_preference_options: "+err);
+	if(o.graphics.render_scale != 0.5f || o.graphics.vsync || !o.sound_mute)
+		throw Exception("parse_preference_options: wrong values");
+	// What an item does not name is left alone
+	if(o.graphics.max_fps != app::Options().graphics.max_fps)
+		throw Exception("parse_preference_options: clobbered max_fps");
+	if(app::parse_preference_options("render_scale", &o, &err))
+		throw Exception("parse_preference_options: took a bare key");
+	if(app::parse_preference_options("render_scale=0.5x", &o, &err))
+		throw Exception("parse_preference_options: took a non-number");
+	if(app::parse_preference_options("render_scale=9", &o, &err))
+		throw Exception("parse_preference_options: took an out-of-range value");
+	if(app::parse_preference_options("multisampling=3", &o, &err))
+		throw Exception("parse_preference_options: took a bad sample count");
+	if(app::parse_preference_options("nonesuch=1", &o, &err))
+		throw Exception("parse_preference_options: took an unknown key");
 }
 
 static bool desktop_size(int *w, int *h)
@@ -225,12 +311,53 @@ static bool window_is_maximized(magic::Graphics *g)
 	return (SDL_GetWindowFlags(win) & SDL_WINDOW_MAXIMIZED) != 0;
 }
 
-static bool load_window_state(int desk_w, int desk_h, app::GraphicsOptions *opt)
+// Reads the saved preferences into *opt. A missing field keeps its default,
+// so a file written by an older build is read by a newer one; a field that is
+// present but out of range drops the whole set back to the defaults, because
+// a file that has been edited into nonsense is better answered with something
+// known than with half of it. The return value is about the window geometry
+// alone: it is the one thing that has somewhere else to come from.
+static bool load_preferences(int desk_w, int desk_h, app::Options *opt)
 {
 	json::json_error_t err;
-	json::Value o = json::load_file(window_state_path().c_str(), &err);
+	json::Value o = json::load_file(preferences_path().c_str(), &err);
 	if(!o.is_object())
 		return false;
+
+	ss_ pref_err;
+	const json::Value &jrs = o.get("render_scale");
+	const json::Value &jvs = o.get("vsync");
+	const json::Value &jmf = o.get("max_fps");
+	const json::Value &jms = o.get("multisampling");
+	const json::Value &jsv = o.get("sound_volume");
+	const json::Value &jsm = o.get("sound_mute");
+	// Through the same parser as -o, so that the range checks are written
+	// once and a hand-edited file is refused the same way a flag is
+	ss_ items;
+	if(jrs.is_number())
+		items += ss_()+(items.empty()?"":",")+"render_scale="+ftos(jrs.as_number());
+	if(jvs.is_boolean())
+		items += ss_()+(items.empty()?"":",")+"vsync="+(jvs.as_boolean()?"1":"0");
+	if(jmf.is_integer())
+		items += ss_()+(items.empty()?"":",")+"max_fps="+itos(jmf.as_integer());
+	if(jms.is_integer())
+		items += ss_()+(items.empty()?"":",")+"multisampling="+itos(jms.as_integer());
+	if(jsv.is_number())
+		items += ss_()+(items.empty()?"":",")+"sound_volume="+ftos(jsv.as_number());
+	if(jsm.is_boolean())
+		items += ss_()+(items.empty()?"":",")+"sound_mute="+(jsm.as_boolean()?"1":"0");
+	if(!items.empty()){
+		app::Options parsed = *opt;
+		if(!app::parse_preference_options(items, &parsed, &pref_err))
+			log_w(MODULE, "%s: %s; using defaults",
+					cs(preferences_path()), cs(pref_err));
+		else
+			*opt = parsed;
+	}
+
+	// -w said what the size is, so the file does not get to
+	if(opt->graphics.size_forced)
+		return true;
 	const json::Value &jw = o.get("width");
 	const json::Value &jh = o.get("height");
 	if(!jw.is_integer() || !jh.is_integer())
@@ -239,30 +366,40 @@ static bool load_window_state(int desk_w, int desk_h, app::GraphicsOptions *opt)
 	int rh = (int)jh.as_integer();
 	if(rw < MIN_WINDOW_W || rh < MIN_WINDOW_H || rw > desk_w || rh > desk_h)
 		return false;
-	opt->window_w = rw;
-	opt->window_h = rh;
+	opt->graphics.window_w = rw;
+	opt->graphics.window_h = rh;
 	const json::Value &jm = o.get("maximized");
 	const json::Value &jf = o.get("fullscreen");
-	opt->maximized = jm.is_boolean() && jm.as_boolean();
-	opt->fullscreen = jf.is_boolean() && jf.as_boolean();
+	opt->graphics.maximized = jm.is_boolean() && jm.as_boolean();
+	opt->graphics.fullscreen = jf.is_boolean() && jf.as_boolean();
 	return true;
 }
 
-static void save_window_state(const app::GraphicsOptions &opt)
+static void save_preferences(const app::Options &opt)
 {
-	if(opt.size_forced)
+	// Nothing that came from the command line is remembered: -w's size, -o's
+	// preferences, and a -c run's whole set of them
+	if(opt.preferences_disabled || !opt.preference_overrides.empty() ||
+			opt.graphics.size_forced)
 		return;
-	if(opt.window_w < MIN_WINDOW_W || opt.window_h < MIN_WINDOW_H)
+	if(opt.graphics.window_w < MIN_WINDOW_W ||
+			opt.graphics.window_h < MIN_WINDOW_H)
 		return;
 	json::Value o = json::object();
-	o.set("width", opt.window_w);
-	o.set("height", opt.window_h);
-	o.set("maximized", opt.maximized);
-	o.set("fullscreen", opt.fullscreen);
-	o.save_file(window_state_path().c_str());
+	o.set("width", opt.graphics.window_w);
+	o.set("height", opt.graphics.window_h);
+	o.set("maximized", opt.graphics.maximized);
+	o.set("fullscreen", opt.graphics.fullscreen);
+	o.set("render_scale", opt.graphics.render_scale);
+	o.set("vsync", opt.graphics.vsync);
+	o.set("max_fps", opt.graphics.max_fps);
+	o.set("multisampling", opt.graphics.multisampling);
+	o.set("sound_volume", opt.sound_volume);
+	o.set("sound_mute", opt.sound_mute);
+	o.save_file(preferences_path().c_str());
 }
 
-static void resolve_window_size(app::GraphicsOptions *opt)
+static void resolve_preferences(app::Options *opt)
 {
 	int desk_w = 0;
 	int desk_h = 0;
@@ -270,9 +407,12 @@ static void resolve_window_size(app::GraphicsOptions *opt)
 		desk_w = 1920;
 		desk_h = 1080;
 	}
-	if(load_window_state(desk_w, desk_h, opt))
-		return;
-	pick_default_window_size(desk_w, desk_h, &opt->window_w, &opt->window_h);
+	bool size_ok = false;
+	if(!opt->preferences_disabled)
+		size_ok = load_preferences(desk_w, desk_h, opt);
+	if(!size_ok)
+		pick_default_window_size(desk_w, desk_h,
+				&opt->graphics.window_w, &opt->graphics.window_h);
 }
 
 static bool valid_game_name(const ss_ &name)
@@ -543,13 +683,35 @@ struct CApp: public App, public magic::Application
 	{
 		log_v(MODULE, "constructor()");
 		check_pick_default_window_size();
-		if(m_options.graphics.window_w <= 0 || m_options.graphics.window_h <= 0){
-			resolve_window_size(&m_options.graphics);
+		check_parse_preference_options();
+		// A -c run is on the built-in defaults, and muted: nothing captures
+		// audio, and a driven run playing a game's music through the
+		// developer's speakers is a small recurring annoyance with no upside
+		m_options.preferences_disabled =
+				g_client_config.get<bool>("command_seq_enabled");
+		if(m_options.preferences_disabled)
+			m_options.sound_mute = true;
+		resolve_preferences(&m_options);
+		if(!m_options.preference_overrides.empty()){
+			// Already accepted once in main(), where a bad -o is a usage
+			// error rather than a startup failure
+			ss_ err;
+			if(!parse_preference_options(m_options.preference_overrides,
+					&m_options, &err))
+				throw AppStartupError("-o: "+err);
 		}
 		if(m_options.graphics.size_forced){
 			m_options.graphics.fullscreen = false;
 			m_options.graphics.maximized = false;
 		}
+		log_v(MODULE, "preferences: render_scale=%s vsync=%i max_fps=%i"
+				" multisampling=%i sound_volume=%s sound_mute=%i",
+				cs(ftos(m_options.graphics.render_scale)),
+				m_options.graphics.vsync ? 1 : 0,
+				m_options.graphics.max_fps,
+				m_options.graphics.multisampling,
+				cs(ftos(m_options.sound_volume)),
+				m_options.sound_mute ? 1 : 0);
 		m_restore_maximized = m_options.graphics.maximized;
 		log_v(MODULE, "window size: %ix%i maximized=%i fullscreen=%i",
 				m_options.graphics.window_w, m_options.graphics.window_h,
@@ -669,7 +831,7 @@ struct CApp: public App, public magic::Application
 			m_options.graphics.fullscreen = g->GetFullscreen();
 			if(!m_options.graphics.fullscreen)
 				m_options.graphics.maximized = window_is_maximized(g);
-			save_window_state(m_options.graphics);
+			save_preferences(m_options);
 		}
 
 		magic::Engine *engine = GetSubsystem<magic::Engine>();
@@ -792,12 +954,15 @@ struct CApp: public App, public magic::Application
 
 		apply_ui_scale();
 
+		GetSubsystem<magic::Engine>()->SetMaxFps(m_options.graphics.max_fps);
+		apply_sound_preferences();
+
 		if(!m_options.graphics.fullscreen && m_restore_maximized){
 			magic::Graphics *g = GetSubsystem<magic::Graphics>();
 			if(g){
 				g->Maximize();
 				m_options.graphics.maximized = true;
-				save_window_state(m_options.graphics);
+				save_preferences(m_options);
 			}
 			m_restore_maximized = false;
 		}
@@ -1349,6 +1514,20 @@ struct CApp: public App, public magic::Application
 		}
 	}
 
+	// Urho3D multiplies a sound type's gain by the "Master" one
+	// (Audio::GetSoundSourceMasterGain()), so setting the master here scales
+	// every sound in every game, under whatever mixing the game does of its
+	// own. The sandbox refuses "Master" to sandboxed code, which is what
+	// makes this enforcement rather than a default.
+	void apply_sound_preferences()
+	{
+		magic::Audio *audio = GetSubsystem<magic::Audio>();
+		if(!audio)
+			return;
+		audio->SetMasterGain("Master",
+				m_options.sound_mute ? 0.0f : m_options.sound_volume);
+	}
+
 	void on_screenmode(magic::StringHash event_type, magic::VariantMap &event_data)
 	{
 		magic::Graphics *magic_graphics = GetSubsystem<magic::Graphics>();
@@ -1375,7 +1554,7 @@ struct CApp: public App, public magic::Application
 				m_options.graphics.window_w, m_options.graphics.window_h,
 				m_options.graphics.maximized ? 1 : 0,
 				m_options.graphics.fullscreen ? 1 : 0);
-		save_window_state(m_options.graphics);
+		save_preferences(m_options);
 		apply_ui_scale();
 	}
 

--- a/src/client/app.cpp
+++ b/src/client/app.cpp
@@ -38,6 +38,9 @@
 #include <Camera.h>
 #include <Renderer.h>
 #include <Audio.h>
+#include <RenderSurface.h>
+#include <Texture2D.h>
+#include <BorderImage.h>
 #include <Octree.h>
 #include <FileSystem.h>
 #include <PhysicsWorld.h>
@@ -225,6 +228,47 @@ static void check_parse_preference_options()
 		throw Exception("parse_preference_options: took an unknown key");
 }
 
+// Rounded, and never zero: a window can be dragged small enough that a low
+// scale would otherwise ask for a zero-pixel texture.
+static int scaled_length(int px, float scale)
+{
+	int v = (int)(px * scale + 0.5f);
+	return v < 1 ? 1 : v;
+}
+
+// A viewport rect stays in window pixels from the game's point of view, so
+// this is the only place the scale is applied to one. IntRect::ZERO means the
+// whole target and has to stay that way.
+static magic::IntRect scaled_rect(const magic::IntRect &r, float scale)
+{
+	if(r == magic::IntRect::ZERO)
+		return r;
+	return magic::IntRect(
+			(int)(r.left_ * scale + 0.5f),
+			(int)(r.top_ * scale + 0.5f),
+			(int)(r.right_ * scale + 0.5f),
+			(int)(r.bottom_ * scale + 0.5f));
+}
+
+static void check_scaled_viewport_size()
+{
+	if(scaled_length(1280, 0.5f) != 640 || scaled_length(720, 0.5f) != 360)
+		throw Exception("scaled_length: even");
+	if(scaled_length(721, 0.5f) != 361)
+		throw Exception("scaled_length: rounding");
+	if(scaled_length(4, 0.1f) != 1)
+		throw Exception("scaled_length: minimum of one pixel");
+	if(scaled_length(1280, 1.5f) != 1920)
+		throw Exception("scaled_length: above one");
+	// games/bomber_drone's second viewport: the same factor, so the two
+	// halves still meet
+	magic::IntRect r = scaled_rect(magic::IntRect(0, 360, 1280, 720), 0.5f);
+	if(r.left_ != 0 || r.top_ != 180 || r.right_ != 640 || r.bottom_ != 360)
+		throw Exception("scaled_rect: rect");
+	if(scaled_rect(magic::IntRect::ZERO, 0.5f) != magic::IntRect::ZERO)
+		throw Exception("scaled_rect: whole target");
+}
+
 static bool desktop_size(int *w, int *h)
 {
 	if(!SDL_WasInit(SDL_INIT_VIDEO)){
@@ -407,9 +451,11 @@ static void resolve_preferences(app::Options *opt)
 		desk_w = 1920;
 		desk_h = 1080;
 	}
-	bool size_ok = false;
-	if(!opt->preferences_disabled)
-		size_ok = load_preferences(desk_w, desk_h, opt);
+	// -w says what the size is, so nothing else has to; -c reads no file at
+	// all, and then the size can only come from the default
+	bool size_ok = opt->graphics.size_forced;
+	if(!opt->preferences_disabled && load_preferences(desk_w, desk_h, opt))
+		size_ok = true;
 	if(!size_ok)
 		pick_default_window_size(desk_w, desk_h,
 				&opt->graphics.window_w, &opt->graphics.window_h);
@@ -671,6 +717,14 @@ struct CApp: public App, public magic::Application
 	magic::SharedPtr<magic::Scene> m_scene;
 	magic::SharedPtr<magic::Node> m_camera_node;
 
+	// What set_preferred_viewports() was last given, and the rects the game
+	// gave them in -- in window pixels, so that the scale can be applied
+	// again from scratch when the window changes size
+	sv_<magic::SharedPtr<magic::Viewport>> m_preferred_viewports;
+	sv_<magic::IntRect> m_preferred_rects;
+	magic::SharedPtr<magic::Texture2D> m_preferred_texture;
+	magic::SharedPtr<magic::BorderImage> m_preferred_image;
+
 	sp_<interface::thread_pool::ThreadPool> m_thread_pool;
 
 	CApp(magic::Context *context, const Options &options):
@@ -684,6 +738,7 @@ struct CApp: public App, public magic::Application
 		log_v(MODULE, "constructor()");
 		check_pick_default_window_size();
 		check_parse_preference_options();
+		check_scaled_viewport_size();
 		// A -c run is on the built-in defaults, and muted: nothing captures
 		// audio, and a driven run playing a game's music through the
 		// developer's speakers is a small recurring annoyance with no upside
@@ -1003,6 +1058,7 @@ struct CApp: public App, public magic::Application
 		DEF_BUILDAT_FUNC(extension_path)
 		DEF_BUILDAT_FUNC(set_ui_scale)
 		DEF_BUILDAT_FUNC(get_ui_scale)
+		DEF_BUILDAT_FUNC(get_preferred_render_scale)
 
 		// Create a scene that will be synchronized from the server
 		m_scene = new magic::Scene(context_);
@@ -1514,6 +1570,115 @@ struct CApp: public App, public magic::Application
 		}
 	}
 
+	void set_preferred_viewports(const sv_<magic::Viewport*> &viewports)
+	{
+		m_preferred_viewports.clear();
+		m_preferred_rects.clear();
+		for(magic::Viewport *vp : viewports){
+			m_preferred_viewports.push_back(magic::SharedPtr<magic::Viewport>(vp));
+			m_preferred_rects.push_back(vp->GetRect());
+		}
+		apply_preferred_viewports();
+	}
+
+	float get_preferred_render_scale()
+	{
+		return m_options.graphics.render_scale;
+	}
+
+	// The user's render_scale reaching viewports the games made themselves:
+	// they go onto an offscreen texture of the asked-for size, and that
+	// texture is drawn under the UI. Urho3D draws the UI to the backbuffer
+	// after the viewports, so the UI is never undersampled.
+	void apply_preferred_viewports()
+	{
+		magic::Renderer *renderer = GetSubsystem<magic::Renderer>();
+		magic::Graphics *graphics = GetSubsystem<magic::Graphics>();
+		if(!renderer || !graphics)
+			return;
+		unsigned n = m_preferred_viewports.size();
+		float scale = m_options.graphics.render_scale;
+		// 1.0 is a bypass and not a scale of one: no texture, no blit, the
+		// frame the client draws when nothing asked for anything
+		if(scale > 0.999f && scale < 1.001f){
+			drop_preferred_texture();
+			renderer->SetNumViewports(n);
+			for(unsigned i = 0; i < n; i++){
+				m_preferred_viewports[i]->SetRect(m_preferred_rects[i]);
+				renderer->SetViewport(i, m_preferred_viewports[i]);
+			}
+			return;
+		}
+		if(n == 0){
+			// Teardown has to leave nothing behind: a stale texture under
+			// the UI is last frame's world, still on the screen
+			drop_preferred_texture();
+			renderer->SetNumViewports(0);
+			return;
+		}
+
+		int tw = scaled_length(graphics->GetWidth(), scale);
+		int th = scaled_length(graphics->GetHeight(), scale);
+		if(!m_preferred_texture || m_preferred_texture->GetWidth() != tw ||
+				m_preferred_texture->GetHeight() != th){
+			m_preferred_texture = new magic::Texture2D(context_);
+			m_preferred_texture->SetSize(tw, th,
+					magic::Graphics::GetRGBFormat(), magic::TEXTURE_RENDERTARGET);
+			m_preferred_texture->SetFilterMode(magic::FILTER_BILINEAR);
+		}
+		magic::RenderSurface *surface = m_preferred_texture->GetRenderSurface();
+		if(!surface){
+			log_w(MODULE, "set_preferred_viewports(): no render surface;"
+					" drawing at native resolution");
+			drop_preferred_texture();
+			renderer->SetNumViewports(n);
+			for(unsigned i = 0; i < n; i++)
+				renderer->SetViewport(i, m_preferred_viewports[i]);
+			return;
+		}
+		surface->SetNumViewports(n);
+		for(unsigned i = 0; i < n; i++){
+			m_preferred_viewports[i]->SetRect(
+					scaled_rect(m_preferred_rects[i], scale));
+			surface->SetViewport(i, m_preferred_viewports[i]);
+		}
+		surface->SetUpdateMode(magic::SURFACE_UPDATEALWAYS);
+		renderer->SetNumViewports(0);
+
+		magic::UI *ui = GetSubsystem<magic::UI>();
+		if(!ui)
+			return;
+		if(!m_preferred_image){
+			m_preferred_image = new magic::BorderImage(context_);
+			m_preferred_image->SetName("buildat_preferred_viewports");
+			// Under whatever UI the game has, and never in the way of it:
+			// a disabled element takes no input
+			m_preferred_image->SetPriority(-10000);
+			m_preferred_image->SetEnabled(false);
+			ui->GetRoot()->AddChild(m_preferred_image);
+		}
+		m_preferred_image->SetTexture(m_preferred_texture);
+		m_preferred_image->SetImageRect(magic::IntRect(0, 0, tw, th));
+		// UI coordinates, which the UI scale has already divided down
+		m_preferred_image->SetPosition(0, 0);
+		m_preferred_image->SetSize(ui->GetRoot()->GetSize());
+	}
+
+	void drop_preferred_texture()
+	{
+		if(m_preferred_image){
+			m_preferred_image->Remove();
+			m_preferred_image.Reset();
+		}
+		if(m_preferred_texture){
+			magic::RenderSurface *surface =
+					m_preferred_texture->GetRenderSurface();
+			if(surface)
+				surface->SetNumViewports(0);
+			m_preferred_texture.Reset();
+		}
+	}
+
 	// Urho3D multiplies a sound type's gain by the "Master" one
 	// (Audio::GetSoundSourceMasterGain()), so setting the master here scales
 	// every sound in every game, under whatever mixing the game does of its
@@ -1556,6 +1721,9 @@ struct CApp: public App, public magic::Application
 				m_options.graphics.fullscreen ? 1 : 0);
 		save_preferences(m_options);
 		apply_ui_scale();
+		// The offscreen texture is a fraction of the window, so a new window
+		// size is a new texture
+		apply_preferred_viewports();
 	}
 
 	void on_logmessage(magic::StringHash event_type, magic::VariantMap &event_data)
@@ -1699,6 +1867,16 @@ struct CApp: public App, public magic::Application
 		lua_pop(L, 1);
 		magic::UI *ui = self->GetSubsystem<magic::UI>();
 		lua_pushnumber(L, ui ? ui->GetScale() : 1.0);
+		return 1;
+	}
+
+	// get_preferred_render_scale() -> number
+	static int l_get_preferred_render_scale(lua_State *L)
+	{
+		lua_getfield(L, LUA_REGISTRYINDEX, "__buildat_app");
+		CApp *self = (CApp*)lua_touserdata(L, -1);
+		lua_pop(L, 1);
+		lua_pushnumber(L, self->m_options.graphics.render_scale);
 		return 1;
 	}
 

--- a/src/client/app.h
+++ b/src/client/app.h
@@ -7,6 +7,7 @@ namespace Urho3D {
 	class Context;
 	class Graphics;
 	class Scene;
+	class Viewport;
 }
 namespace client {
 	struct State;
@@ -89,6 +90,14 @@ namespace app
 		virtual void handle_packet(const ss_ &name, const ss_ &data) = 0;
 		virtual void file_updated_in_cache(const ss_ &file_name,
 				const ss_ &file_hash, const ss_ &cached_path) = 0;
+		// The viewports the user's graphics preferences apply to: they are
+		// drawn at the render_scale the user asked for, under a UI that
+		// stays at native resolution. An empty list is teardown. A game that
+		// uses Renderer::SetViewport() instead is drawn at native
+		// resolution and keeps working.
+		virtual void set_preferred_viewports(
+				const sv_<Urho3D::Viewport*> &viewports) = 0;
+		virtual float get_preferred_render_scale() = 0;
 		virtual Urho3D::Scene* get_scene() = 0;
 		virtual interface::thread_pool::ThreadPool* get_thread_pool() = 0;
 		virtual lua_State* get_lua() = 0;

--- a/src/client/app.h
+++ b/src/client/app.h
@@ -44,6 +44,13 @@ namespace app
 		bool vsync = true;
 		bool triple_buffer = false;
 		int multisampling = 1; // 2 looks much better but is much heavier(?)
+		// 3D viewports a game asked the engine to draw are rendered at this
+		// fraction of the window size; the UI stays at native resolution.
+		// 1.0 is a bypass, not a scale of one.
+		float render_scale = 1.0f;
+		// Frame limiter. 200 is Urho3D's own desktop default, so leaving it
+		// alone changes nothing; 0 is unlimited.
+		int max_fps = 200;
 		// Set by -w: the size came from the command line, so it is not
 		// remembered across runs and the saved size is left alone
 		bool size_forced = false;
@@ -54,7 +61,22 @@ namespace app
 	struct Options
 	{
 		GraphicsOptions graphics;
+		// Beside the graphics rather than inside it: the file is the user's
+		// preferences, GraphicsOptions is a display mode
+		float sound_volume = 1.0f;
+		bool sound_mute = false;
+		// -o k=v,...: applied on top of the saved file, and never written
+		// back, the same rule -w already follows
+		ss_ preference_overrides;
+		// -c: the saved file is neither read nor written, so that a
+		// preference someone left behind cannot change a screenshot
+		bool preferences_disabled = false;
 	};
+
+	// Parses "k=v[,k=v...]" on top of whatever *opt already holds. Returns
+	// false and fills *error on a malformed item, an unknown key or a value
+	// out of range; *opt is then partially applied and should be discarded.
+	bool parse_preference_options(const ss_ &s, Options *opt, ss_ *error);
 
 	struct App
 	{

--- a/src/client/config.cpp
+++ b/src/client/config.cpp
@@ -14,6 +14,7 @@ Config::Config()
 	// Paths are filled in by autodetection
 	set_default("share_path", "");
 	set_default("cache_path", "");
+	set_default("user_path", "");
 	set_default("urho3d_path", "");
 
 	set_default("server_address", "");

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -55,19 +55,23 @@ int main(int argc, char *argv[])
 
 	client::Config &config = g_client_config;
 
-	const char opts[100] = "hs:P:C:U:l:L:m:u:w:c:";
+	const char opts[100] = "hs:P:C:D:U:l:L:m:u:w:o:c:";
 	const char usagefmt[1000] =
 			"Usage: %s [OPTION]...\n"
 			"  -h                   Show this help\n"
 			"  -s [address]         Specify server address\n"
 			"  -P [share_path]      Specify share/ path\n"
 			"  -C [cache_path]      Specify cache/ path\n"
+			"  -D [user_path]       Specify user/ path\n"
 			"  -U [urho3d_path]     Specify Urho3D path\n"
 			"  -l [level number]    Set maximum log level (0...5)\n"
 			"  -L [log file path]   Append log to a specified file\n"
 			"  -m [name]            Choose menu extension name\n"
 			"  -u [scale]           UI scale (0 = auto from short side / 1080)\n"
 			"  -w [WxH]             Windowed at this size; not remembered\n"
+			"  -o [k=v,...]         Set preferences; not remembered. Keys:\n"
+			"                       render_scale, vsync, max_fps,\n"
+			"                       multisampling, sound_volume, sound_mute\n"
 			"  -c [commands]        Run command sequence and exit\n"
 			"                       One command per line. @file reads a file,\n"
 			"                       - reads standard input as it arrives.\n"
@@ -75,6 +79,7 @@ int main(int argc, char *argv[])
 			;
 
 	int forced_w = 0, forced_h = 0;
+	ss_ preference_overrides;
 
 	int c;
 	while((c = c55_getopt(argc, argv, opts)) != -1)
@@ -95,6 +100,10 @@ int main(int argc, char *argv[])
 		case 'C':
 			log_i(MODULE, "config.cache_path: %s", c55_optarg);
 			config.set("cache_path", c55_optarg);
+			break;
+		case 'D':
+			log_i(MODULE, "config.user_path: %s", c55_optarg);
+			config.set("user_path", c55_optarg);
 			break;
 		case 'U':
 			log_i(MODULE, "config.urho3d_path: %s", c55_optarg);
@@ -122,6 +131,24 @@ int main(int argc, char *argv[])
 			}
 			log_i(MODULE, "window size: %ix%i", forced_w, forced_h);
 			break;
+		case 'o': {
+			// Repeatable, and later items win, so that a wrapper script's -o
+			// can be overridden on the command line after it
+			ss_ items = c55_optarg ? c55_optarg : "";
+			ss_ merged = preference_overrides.empty() ? items :
+					preference_overrides + "," + items;
+			// Accepted here so that a typo is a usage error rather than a
+			// startup failure; applied in the app, on top of the saved file
+			app::Options probe;
+			ss_ err;
+			if(!app::parse_preference_options(merged, &probe, &err)){
+				fprintf(stderr, "-o: %s\n", err.c_str());
+				return 1;
+			}
+			log_i(MODULE, "preferences: %s", merged.c_str());
+			preference_overrides = merged;
+			break;
+		}
 		case 'c': {
 			ss_ arg = c55_optarg ? c55_optarg : "";
 			ss_ text;
@@ -182,6 +209,7 @@ int main(int argc, char *argv[])
 	}
 
 	app::Options app_options;
+	app_options.preference_overrides = preference_overrides;
 	if(forced_w > 0){
 		app_options.graphics.window_w = forced_w;
 		app_options.graphics.window_h = forced_h;

--- a/src/lua_bindings/misc_urho3d.cpp
+++ b/src/lua_bindings/misc_urho3d.cpp
@@ -157,6 +157,31 @@ static int l_render_scene_to_texture(lua_State *L)
 	return 1;
 }
 
+// set_preferred_viewports({viewport, ...}). An empty table is teardown.
+// The engine draws these at the user's render_scale; see
+// CApp::apply_preferred_viewports() in src/client/app.cpp.
+static int l_set_preferred_viewports(lua_State *L)
+{
+	tolua_Error tolua_err;
+	if(!lua_istable(L, 1))
+		return luaL_error(L, "set_preferred_viewports(): expected a table");
+
+	sv_<Viewport*> viewports;
+	size_t n = lua_objlen(L, 1);
+	for(size_t i = 1; i <= n; i++){
+		lua_rawgeti(L, 1, i);
+		GET_TOLUA_STUFF(viewport, -1, Viewport);
+		lua_pop(L, 1);
+		viewports.push_back(viewport);
+	}
+
+	lua_getfield(L, LUA_REGISTRYINDEX, "__buildat_app");
+	app::App *buildat_app = (app::App*)lua_touserdata(L, -1);
+	lua_pop(L, 1);
+	buildat_app->set_preferred_viewports(viewports);
+	return 0;
+}
+
 void init_misc_urho3d(lua_State *L)
 {
 #define DEF_BUILDAT_FUNC(name){ \
@@ -167,6 +192,7 @@ void init_misc_urho3d(lua_State *L)
 	DEF_BUILDAT_FUNC(profiler_block_end);
 	DEF_BUILDAT_FUNC(add_resource_dir);
 	DEF_BUILDAT_FUNC(render_scene_to_texture);
+	DEF_BUILDAT_FUNC(set_preferred_viewports);
 }
 
 } // namespace lua_bindingss


### PR DESCRIPTION
What the user sets once and every game honours: how much the frame costs and
how loud it is, never what the art is.

`render_scale`, `vsync`, `max_fps`, `multisampling`, `sound_volume` and
`sound_mute`, kept in `user_path/preferences.json` -- which is what
`cache_path/window.json` becomes, since a preference is not cache and the file
now holds more than the window. `user_path` joins the other paths, defaulting
to `<root>/user` beside `<root>/cache`, with `-D` to override; `-DPORTABLE`
and the platform paths belong to the saves work and are not here.

`-o k=v,...` sets preferences for one run and is not written back, the same
rule `-w` already follows. A `-c` run ignores the saved file entirely and is
muted, so that a preference someone left behind can never change a screenshot
and a driven run never plays a game's music at whoever is in the room.

`render_scale` reaches the games cooperatively. They make their own viewports
in sandboxed Lua, so the engine offers one call they use instead of
`renderer:SetViewport()`:

    magic.set_preferred_viewports({viewport})            -- one view
    magic.set_preferred_viewports({vp_top, vp_bottom})   -- two
    magic.set_preferred_viewports({})                    -- teardown

The viewports go onto an offscreen texture of `round(w*scale) x
round(h*scale)` and the engine draws it under the UI, which Urho3D renders to
the backbuffer afterwards and which therefore stays at native resolution. The
viewport stays the game's own, so replacing `renderPath` and HDR are
untouched. At 1.0 the call is `renderer:SetViewport()` and nothing else. A
game that does not call it renders at native resolution and keeps working.

All fourteen call sites are converted: twelve games one line each,
`games/bomber_drone`'s two viewports, and `extensions/luanti_client`'s
disconnect.

The sound half is enforced instead, because it is free: Urho3D multiplies
every sound type's gain by the `"Master"` one, so the client sets the master
and a game's own mixing keeps working underneath. The sandbox therefore stops
letting a game write `"Master"` itself.

Checks: assert-based self-checks of the `-o` parse and of the scaled-size
arithmetic, run at startup beside `check_pick_default_window_size()`.
Visually: `games/voxel_lighting` and `games/bomber_drone` at 0.5 and at 1.0 --
the same scene, one softer, the UI text equally sharp in both -- and
`games/aggregate`'s structures menu, whose `render_scene_to_texture`
thumbnails are outside the mechanism and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)